### PR TITLE
feat(groups): add browse list, detail CTA, and join/leave flow

### DIFF
--- a/src/app/groups/[slug]/actions.ts
+++ b/src/app/groups/[slug]/actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth";
+import { getGroupBySlug } from "@/lib/groups";
+import { leaveGroup, transferOwnershipAndLeave } from "@/lib/memberships";
+
+export async function confirmLeaveAction(slug: string, formData: FormData): Promise<void> {
+  const session = await getSession();
+  if (!session) {
+    redirect(`/login?returnTo=/groups/${slug}`);
+  }
+  const group = await getGroupBySlug(slug);
+  if (!group) redirect("/groups");
+
+  const raw = formData.get("successorUserId");
+  const successorUserId = typeof raw === "string" && raw.length > 0 ? raw : null;
+  if (successorUserId) {
+    await transferOwnershipAndLeave(group.id, session.user.id, successorUserId);
+  } else {
+    await leaveGroup(group.id, session.user.id);
+  }
+  revalidatePath(`/groups/${slug}`);
+  revalidatePath("/groups");
+  redirect(`/groups/${slug}`);
+}

--- a/src/app/groups/[slug]/leave/page.tsx
+++ b/src/app/groups/[slug]/leave/page.tsx
@@ -1,0 +1,164 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { getGroupBySlug } from "@/lib/groups";
+import {
+  getUserMembershipStatus,
+  listSuccessorCandidates,
+} from "@/lib/memberships";
+import { confirmLeaveAction } from "../actions";
+
+type Props = { params: Promise<{ slug: string }> };
+
+export default async function LeaveGroupPage({ params }: Props) {
+  const { slug } = await params;
+  const session = await requireAuth();
+  const group = await getGroupBySlug(slug);
+  if (!group) notFound();
+
+  const membership = await getUserMembershipStatus(group.id, session.user.id);
+  if (!membership) {
+    redirect(`/groups/${slug}`);
+  }
+
+  const isApprovedOwner = membership.role === "owner" && membership.status === "approved";
+  let isSoleOwner = false;
+  let candidates: Awaited<ReturnType<typeof listSuccessorCandidates>> = [];
+
+  if (isApprovedOwner) {
+    const otherOwners = await db.membership.count({
+      where: {
+        groupId: group.id,
+        role: "owner",
+        status: "approved",
+        userId: { not: session.user.id },
+      },
+    });
+    isSoleOwner = otherOwners === 0;
+    if (isSoleOwner) {
+      candidates = await listSuccessorCandidates(group.id, session.user.id);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Leave group</h1>
+        <p className="text-sm text-muted-foreground">
+          You&apos;re about to leave <span className="font-medium">{group.name}</span>.
+        </p>
+      </div>
+
+      {isSoleOwner && candidates.length === 0 ? (
+        <SoleOwnerNoSuccessorsCard slug={slug} />
+      ) : isSoleOwner ? (
+        <SoleOwnerWithSuccessorsCard slug={slug} candidates={candidates} />
+      ) : (
+        <SimpleLeaveCard slug={slug} />
+      )}
+    </div>
+  );
+}
+
+function SimpleLeaveCard({ slug }: { slug: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Confirm</CardTitle>
+        <CardDescription>You can re-apply later if you change your mind.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={confirmLeaveAction.bind(null, slug)} className="flex gap-2">
+          <Button type="submit" variant="destructive">
+            Yes, leave
+          </Button>
+          <Button variant="outline" render={<Link href={`/groups/${slug}`} />}>
+            Cancel
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SoleOwnerWithSuccessorsCard({
+  slug,
+  candidates,
+}: {
+  slug: string;
+  candidates: Awaited<ReturnType<typeof listSuccessorCandidates>>;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Pick a new owner</CardTitle>
+        <CardDescription>
+          You&apos;re the only owner. Promote another approved member to owner before you leave.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={confirmLeaveAction.bind(null, slug)} className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="successorUserId" className="block text-sm font-medium">
+              New owner
+            </label>
+            <select
+              id="successorUserId"
+              name="successorUserId"
+              required
+              defaultValue=""
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+            >
+              <option value="" disabled>
+                Choose a member…
+              </option>
+              {candidates.map((c) => (
+                <option key={c.userId} value={c.userId}>
+                  {(c.name ?? c.email ?? "Anonymous") +
+                    (c.role !== "member" ? ` (${c.role})` : "")}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" variant="destructive">
+              Promote and leave
+            </Button>
+            <Button variant="outline" render={<Link href={`/groups/${slug}`} />}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SoleOwnerNoSuccessorsCard({ slug }: { slug: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">You can&apos;t leave yet</CardTitle>
+        <CardDescription>
+          You&apos;re the only member of this group, so there&apos;s no one to take over as
+          owner. Group deletion isn&apos;t available yet — once the group has at least one
+          other approved member you&apos;ll be able to transfer ownership and leave.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline" render={<Link href={`/groups/${slug}`} />}>
+          Back to group
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/groups/[slug]/membership-actions.tsx
+++ b/src/app/groups/[slug]/membership-actions.tsx
@@ -40,7 +40,15 @@ export function MembershipActions({ slug, isAuthenticated, currentUserId, member
   }
 
   if (membership?.role === "owner" && membership.status === "approved") {
-    return null;
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        render={<Link href={`/groups/${slug}/leave`} />}
+      >
+        Leave group
+      </Button>
+    );
   }
 
   async function apply() {

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -1,13 +1,34 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { getSession } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
-import { getMembership } from "@/lib/memberships";
+import {
+  countApprovedMembers,
+  getMembership,
+  listApprovedMembers,
+} from "@/lib/memberships";
 import { MembershipActions } from "./membership-actions";
 
 type Props = { params: Promise<{ slug: string }> };
+
+const MEMBER_PREVIEW_LIMIT = 12;
+
+function initials(name: string | null, email: string | null): string {
+  const source = (name ?? email ?? "").trim();
+  if (!source) return "?";
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
 
 export default async function GroupDetailPage({ params }: Props) {
   const { slug } = await params;
@@ -15,21 +36,31 @@ export default async function GroupDetailPage({ params }: Props) {
   if (!group) notFound();
 
   const session = await getSession();
-  const membership = session ? await getMembership(group.id, session.user.id) : null;
+  const [memberCount, members, membership] = await Promise.all([
+    countApprovedMembers(group.id),
+    listApprovedMembers(group.id, MEMBER_PREVIEW_LIMIT),
+    session ? getMembership(group.id, session.user.id) : Promise.resolve(null),
+  ]);
+
   const isOwner = membership?.role === "owner" && membership.status === "approved";
+  const memberLabel = memberCount === 1 ? "1 member" : `${memberCount} members`;
 
   return (
-    <div className="mx-auto max-w-2xl py-8">
+    <div className="mx-auto max-w-3xl space-y-6">
       <Card>
         <CardHeader className="border-b">
-          <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="space-y-1">
               <CardTitle className="text-xl">{group.name}</CardTitle>
               <CardDescription>
                 <span className="font-mono text-xs">{group.slug}</span>
                 {" · "}
+                <span>{memberLabel}</span>
+                {" · "}
                 <span>
-                  {group.autoApprove ? "auto-approves new members" : "requires owner approval"}
+                  {group.autoApprove
+                    ? "auto-approves new members"
+                    : "requires owner approval"}
                 </span>
               </CardDescription>
             </div>
@@ -59,6 +90,52 @@ export default async function GroupDetailPage({ params }: Props) {
             currentUserId={session?.user.id ?? null}
             membership={membership ? { role: membership.role, status: membership.status } : null}
           />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">Members</CardTitle>
+          <CardDescription>
+            {memberCount === 0
+              ? "No members yet."
+              : `${memberLabel}${
+                  members.length < memberCount ? ` · showing ${members.length}` : ""
+                }`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-2">
+          {members.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No members yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {members.map((m) => (
+                <li key={m.userId} className="flex items-center gap-3 text-sm">
+                  <Avatar size="sm">
+                    <AvatarFallback>{initials(m.name, m.email)}</AvatarFallback>
+                  </Avatar>
+                  <span>{m.name ?? m.email ?? "Anonymous"}</span>
+                  {m.role !== "member" ? (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {m.role}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">Recent questions</CardTitle>
+          <CardDescription>Q&amp;A coming in M3.</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-2">
+          <p className="text-sm text-muted-foreground">
+            Once the question flow ships, the latest activity for this group will show up here.
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { GroupCard } from "@/components/groups/group-card";
+import { SortTabs } from "@/components/groups/sort-tabs";
+import { Button } from "@/components/ui/button";
+import { getSession } from "@/lib/auth";
+import { listGroups, type ListGroupsSort } from "@/lib/groups";
+
+type Props = { searchParams: Promise<{ sort?: string }> };
+
+function parseSort(value: string | undefined): ListGroupsSort {
+  return value === "members" ? "members" : "newest";
+}
+
+export default async function GroupsPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const sort = parseSort(sp.sort);
+  const [session, groups] = await Promise.all([getSession(), listGroups({ sort })]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse subject-matter expert groups.
+          </p>
+        </div>
+        {session ? <Button render={<Link href="/groups/new" />}>Create group</Button> : null}
+      </div>
+      <SortTabs active={sort} />
+      {groups.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+          No groups yet.{" "}
+          {session ? (
+            <Link href="/groups/new" className="underline">
+              Create the first one
+            </Link>
+          ) : (
+            "Sign in to create one."
+          )}
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {groups.map((g) => (
+            <GroupCard key={g.id} group={g} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { GroupListItem } from "@/lib/groups";
+
+export function GroupCard({ group }: { group: GroupListItem }) {
+  const memberLabel = group.memberCount === 1 ? "member" : "members";
+  return (
+    <Link
+      href={`/groups/${group.slug}`}
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-xl"
+    >
+      <Card className="h-full transition-shadow hover:shadow-md">
+        <CardHeader>
+          <CardTitle className="text-base">{group.name}</CardTitle>
+          <CardDescription>
+            <span className="font-mono text-xs">{group.slug}</span>
+            {" · "}
+            <span>
+              {group.memberCount} {memberLabel}
+            </span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {group.description ? (
+            <p className="line-clamp-3 text-sm text-muted-foreground">{group.description}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground italic">No description yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/groups/sort-tabs.tsx
+++ b/src/components/groups/sort-tabs.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { ListGroupsSort } from "@/lib/groups";
+
+const TABS: ReadonlyArray<{ value: ListGroupsSort; label: string; href: string }> = [
+  { value: "newest", label: "Newest", href: "/groups" },
+  { value: "members", label: "Most members", href: "/groups?sort=members" },
+];
+
+export function SortTabs({ active }: { active: ListGroupsSort }) {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-background p-1">
+      {TABS.map((t) => (
+        <Link
+          key={t.value}
+          href={t.href}
+          aria-current={t.value === active ? "page" : undefined}
+          className={cn(
+            "rounded-md px-3 py-1 text-sm transition-colors",
+            t.value === active
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { AuthorizationError, ConflictError, NotFoundError } from "@/lib/memberships";
+import {
+  AuthorizationError,
+  ConflictError,
+  InvalidSuccessorError,
+  NotAMemberError,
+  NotFoundError,
+  SoleOwnerCannotLeaveError,
+} from "@/lib/memberships";
 import { SlugConflictError } from "@/lib/groups";
 
 export function unauthorized(): Response {
@@ -31,6 +38,15 @@ export function errorToResponse(err: unknown): Response {
   }
   if (err instanceof ConflictError) {
     return Response.json({ error: "Conflict", message: err.message }, { status: 409 });
+  }
+  if (err instanceof NotAMemberError) {
+    return Response.json({ error: "NotAMember", message: err.message }, { status: 404 });
+  }
+  if (err instanceof SoleOwnerCannotLeaveError) {
+    return Response.json({ error: "SoleOwner", message: err.message }, { status: 409 });
+  }
+  if (err instanceof InvalidSuccessorError) {
+    return Response.json({ error: "InvalidSuccessor", message: err.message }, { status: 422 });
   }
   if (err instanceof z.ZodError) {
     return validationFailed(err);

--- a/src/lib/groups.test.ts
+++ b/src/lib/groups.test.ts
@@ -15,8 +15,14 @@ const testDbPath = path.join(os.tmpdir(), `sme-groups-test-${Date.now()}.db`);
 process.env["DATABASE_URL"] = `file:${testDbPath}`;
 
 const { db } = await import("./db");
-const { createGroup, getGroupBySlug, getGroupBySlugOrThrow, updateGroup, SlugConflictError } =
-  await import("./groups");
+const {
+  createGroup,
+  getGroupBySlug,
+  getGroupBySlugOrThrow,
+  listGroups,
+  updateGroup,
+  SlugConflictError,
+} = await import("./groups");
 const { AuthorizationError, NotFoundError } = await import("./memberships");
 
 beforeAll(async () => {
@@ -139,5 +145,63 @@ describe("updateGroup", () => {
     await expect(updateGroup("does-not-exist", { name: "x" }, owner.id)).rejects.toBeInstanceOf(
       NotFoundError,
     );
+  });
+});
+
+describe("listGroups", () => {
+  it("returns groups newest-first when sort=newest", async () => {
+    const owner = await makeUser("ls-new");
+    const tag = `ls-newest-${Date.now()}`;
+    const a = await createGroup({ name: "A", slug: `${tag}-a` }, owner.id);
+    // Force a small gap so createdAt ordering is unambiguous on coarse clocks.
+    await new Promise((r) => setTimeout(r, 5));
+    const b = await createGroup({ name: "B", slug: `${tag}-b` }, owner.id);
+    const list = await listGroups({ sort: "newest" });
+    const indexA = list.findIndex((g) => g.id === a.id);
+    const indexB = list.findIndex((g) => g.id === b.id);
+    expect(indexB).toBeGreaterThanOrEqual(0);
+    expect(indexA).toBeGreaterThan(indexB);
+  });
+
+  it("counts only approved memberships", async () => {
+    const owner = await makeUser("ls-count");
+    const slug = `ls-count-${Date.now()}`;
+    const group = await createGroup({ name: "C", slug }, owner.id);
+    const m1 = await makeUser("ls-m1");
+    const m2 = await makeUser("ls-m2");
+    const m3 = await makeUser("ls-m3");
+    await db.membership.create({
+      data: { groupId: group.id, userId: m1.id, role: "member", status: "approved" },
+    });
+    await db.membership.create({
+      data: { groupId: group.id, userId: m2.id, role: "member", status: "pending" },
+    });
+    await db.membership.create({
+      data: { groupId: group.id, userId: m3.id, role: "member", status: "rejected" },
+    });
+    const list = await listGroups({ sort: "newest" });
+    const found = list.find((g) => g.id === group.id);
+    expect(found).toBeDefined();
+    // owner + m1 = 2
+    expect(found!.memberCount).toBe(2);
+  });
+
+  it("orders by member count desc when sort=members", async () => {
+    const owner = await makeUser("ls-sort");
+    const tag = `ls-sort-${Date.now()}`;
+    const small = await createGroup({ name: "Small", slug: `${tag}-s` }, owner.id);
+    const big = await createGroup({ name: "Big", slug: `${tag}-b` }, owner.id);
+    for (let i = 0; i < 3; i++) {
+      const u = await makeUser(`ls-bigm-${i}`);
+      await db.membership.create({
+        data: { groupId: big.id, userId: u.id, role: "member", status: "approved" },
+      });
+    }
+    const list = await listGroups({ sort: "members" });
+    const indexBig = list.findIndex((g) => g.id === big.id);
+    const indexSmall = list.findIndex((g) => g.id === small.id);
+    expect(indexBig).toBeGreaterThanOrEqual(0);
+    expect(indexSmall).toBeGreaterThanOrEqual(0);
+    expect(indexBig).toBeLessThan(indexSmall);
   });
 });

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -53,6 +53,58 @@ export async function createGroup(input: CreateGroupInput, creatorUserId: string
   }
 }
 
+export type GroupListItem = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  createdAt: Date;
+};
+
+export type ListGroupsSort = "newest" | "members";
+
+export async function listGroups(opts: { sort: ListGroupsSort }): Promise<GroupListItem[]> {
+  const [groups, counts] = await Promise.all([
+    db.group.findMany({
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        description: true,
+        createdAt: true,
+      },
+    }),
+    db.membership.groupBy({
+      by: ["groupId"],
+      where: { status: "approved" },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const countByGroupId = new Map(counts.map((c) => [c.groupId, c._count._all]));
+
+  const items: GroupListItem[] = groups.map((g) => ({
+    id: g.id,
+    slug: g.slug,
+    name: g.name,
+    description: g.description,
+    createdAt: g.createdAt,
+    memberCount: countByGroupId.get(g.id) ?? 0,
+  }));
+
+  if (opts.sort === "members") {
+    items.sort((a, b) => {
+      if (b.memberCount !== a.memberCount) return b.memberCount - a.memberCount;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    });
+  } else {
+    items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
+  return items;
+}
+
 export async function getGroupBySlug(slug: string): Promise<GroupWithOwner | null> {
   return db.group.findUnique({
     where: { slug },

--- a/src/lib/memberships.test.ts
+++ b/src/lib/memberships.test.ts
@@ -21,13 +21,22 @@ const {
   assertOwnerOrModerator,
   AuthorizationError,
   ConflictError,
+  countApprovedMembers,
   getMembership,
+  getUserMembershipStatus,
+  InvalidSuccessorError,
   isOwner,
   isOwnerOrModerator,
+  leaveGroup,
+  listApprovedMembers,
   listPendingApplications,
+  listSuccessorCandidates,
+  NotAMemberError,
   NotFoundError,
   removeMembership,
   setMembershipStatus,
+  SoleOwnerCannotLeaveError,
+  transferOwnershipAndLeave,
 } = await import("./memberships");
 
 beforeAll(async () => {
@@ -380,5 +389,173 @@ describe("listPendingApplications", () => {
     const ids = pending.map((m) => m.userId).sort();
     expect(ids).toEqual([a.id, b.id].sort());
     expect(pending[0]?.user).toHaveProperty("email");
+  });
+});
+
+describe("leaveGroup", () => {
+  it("removes the membership for a regular approved member", async () => {
+    const { group } = await makeGroup(next("leave-member"));
+    const user = await makeUser("leaver");
+    await db.membership.create({
+      data: { groupId: group.id, userId: user.id, role: "member", status: "approved" },
+    });
+    await leaveGroup(group.id, user.id);
+    expect(await getMembership(group.id, user.id)).toBeNull();
+  });
+
+  it("throws NotAMemberError when caller has no membership", async () => {
+    const { group } = await makeGroup(next("leave-none"));
+    const user = await makeUser("ghost-leave");
+    await expect(leaveGroup(group.id, user.id)).rejects.toBeInstanceOf(NotAMemberError);
+  });
+
+  it("throws SoleOwnerCannotLeaveError when caller is the only approved owner", async () => {
+    const { owner, group } = await makeGroup(next("leave-sole"));
+    await expect(leaveGroup(group.id, owner.id)).rejects.toBeInstanceOf(
+      SoleOwnerCannotLeaveError,
+    );
+  });
+
+  it("allows an owner to leave when another approved owner exists", async () => {
+    const { owner, group } = await makeGroup(next("leave-coowner"));
+    const co = await makeUser("co");
+    await db.membership.create({
+      data: { groupId: group.id, userId: co.id, role: "owner", status: "approved" },
+    });
+    await leaveGroup(group.id, owner.id);
+    expect(await getMembership(group.id, owner.id)).toBeNull();
+    expect(await getMembership(group.id, co.id)).not.toBeNull();
+  });
+});
+
+describe("transferOwnershipAndLeave", () => {
+  it("promotes successor to owner and removes caller", async () => {
+    const { owner, group } = await makeGroup(next("xfer"));
+    const successor = await makeUser("succ");
+    await db.membership.create({
+      data: { groupId: group.id, userId: successor.id, role: "member", status: "approved" },
+    });
+    await transferOwnershipAndLeave(group.id, owner.id, successor.id);
+    expect(await getMembership(group.id, owner.id)).toBeNull();
+    const promoted = await getMembership(group.id, successor.id);
+    expect(promoted!.role).toBe("owner");
+    expect(promoted!.status).toBe("approved");
+  });
+
+  it("throws InvalidSuccessorError when successor is not approved", async () => {
+    const { owner, group } = await makeGroup(next("xfer-pending"));
+    const successor = await makeUser("succ");
+    await db.membership.create({
+      data: { groupId: group.id, userId: successor.id, role: "member", status: "pending" },
+    });
+    await expect(
+      transferOwnershipAndLeave(group.id, owner.id, successor.id),
+    ).rejects.toBeInstanceOf(InvalidSuccessorError);
+  });
+
+  it("throws InvalidSuccessorError when successor is the same as caller", async () => {
+    const { owner, group } = await makeGroup(next("xfer-self"));
+    await expect(
+      transferOwnershipAndLeave(group.id, owner.id, owner.id),
+    ).rejects.toBeInstanceOf(InvalidSuccessorError);
+  });
+
+  it("throws AuthorizationError when caller is not an approved owner", async () => {
+    const { group } = await makeGroup(next("xfer-notowner"));
+    const member = await makeUser("memb");
+    await db.membership.create({
+      data: { groupId: group.id, userId: member.id, role: "member", status: "approved" },
+    });
+    const other = await makeUser("other");
+    await db.membership.create({
+      data: { groupId: group.id, userId: other.id, role: "member", status: "approved" },
+    });
+    await expect(
+      transferOwnershipAndLeave(group.id, member.id, other.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("does not modify state when validation fails (atomic)", async () => {
+    const { owner, group } = await makeGroup(next("xfer-atomic"));
+    const successor = await makeUser("succ");
+    await db.membership.create({
+      data: { groupId: group.id, userId: successor.id, role: "member", status: "rejected" },
+    });
+    await expect(
+      transferOwnershipAndLeave(group.id, owner.id, successor.id),
+    ).rejects.toBeInstanceOf(InvalidSuccessorError);
+    // owner still owner, successor unchanged
+    const o = await getMembership(group.id, owner.id);
+    expect(o!.role).toBe("owner");
+    const s = await getMembership(group.id, successor.id);
+    expect(s!.role).toBe("member");
+    expect(s!.status).toBe("rejected");
+  });
+});
+
+describe("getUserMembershipStatus / countApprovedMembers", () => {
+  it("getUserMembershipStatus returns null when no membership exists", async () => {
+    const { group } = await makeGroup(next("status-none"));
+    const user = await makeUser("ghost-status");
+    expect(await getUserMembershipStatus(group.id, user.id)).toBeNull();
+  });
+
+  it("getUserMembershipStatus returns status and role", async () => {
+    const { group } = await makeGroup(next("status"));
+    const user = await makeUser("u");
+    await db.membership.create({
+      data: { groupId: group.id, userId: user.id, role: "moderator", status: "approved" },
+    });
+    expect(await getUserMembershipStatus(group.id, user.id)).toEqual({
+      role: "moderator",
+      status: "approved",
+    });
+  });
+
+  it("countApprovedMembers excludes pending and rejected", async () => {
+    const { group } = await makeGroup(next("count"));
+    const u1 = await makeUser("a");
+    const u2 = await makeUser("b");
+    const u3 = await makeUser("c");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u1.id, role: "member", status: "approved" },
+    });
+    await db.membership.create({
+      data: { groupId: group.id, userId: u2.id, role: "member", status: "pending" },
+    });
+    await db.membership.create({
+      data: { groupId: group.id, userId: u3.id, role: "member", status: "rejected" },
+    });
+    // owner + u1
+    expect(await countApprovedMembers(group.id)).toBe(2);
+  });
+});
+
+describe("listApprovedMembers / listSuccessorCandidates", () => {
+  it("listApprovedMembers returns approved members up to limit", async () => {
+    const { owner, group } = await makeGroup(next("list-approved"));
+    const u1 = await makeUser("a");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u1.id, role: "member", status: "approved" },
+    });
+    const u2 = await makeUser("b");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u2.id, role: "member", status: "pending" },
+    });
+    const list = await listApprovedMembers(group.id, 5);
+    const userIds = list.map((m) => m.userId);
+    expect(userIds).toContain(owner.id);
+    expect(userIds).toContain(u1.id);
+    expect(userIds).not.toContain(u2.id);
+  });
+
+  it("listSuccessorCandidates excludes the caller", async () => {
+    const { owner, group } = await makeGroup(next("succ"));
+    const u1 = await makeUser("a");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u1.id, role: "member", status: "approved" },
+    });
+    const list = await listSuccessorCandidates(group.id, owner.id);
+    expect(list.map((m) => m.userId)).toEqual([u1.id]);
   });
 });

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -26,6 +26,32 @@ export class ConflictError extends Error {
   }
 }
 
+export class NotAMemberError extends Error {
+  readonly code = "NOT_A_MEMBER" as const;
+  constructor(message = "You are not a member of this group.") {
+    super(message);
+    this.name = "NotAMemberError";
+  }
+}
+
+export class SoleOwnerCannotLeaveError extends Error {
+  readonly code = "SOLE_OWNER" as const;
+  constructor(
+    message = "You're the only owner. Promote another member to owner before leaving.",
+  ) {
+    super(message);
+    this.name = "SoleOwnerCannotLeaveError";
+  }
+}
+
+export class InvalidSuccessorError extends Error {
+  readonly code = "INVALID_SUCCESSOR" as const;
+  constructor(message = "The chosen successor is not an approved member of this group.") {
+    super(message);
+    this.name = "InvalidSuccessorError";
+  }
+}
+
 export async function getMembership(groupId: string, userId: string): Promise<Membership | null> {
   return db.membership.findUnique({
     where: { userId_groupId: { userId, groupId } },
@@ -134,5 +160,123 @@ export async function listPendingApplications(groupId: string): Promise<PendingA
     where: { groupId, status: "pending" },
     include: { user: { select: { id: true, email: true, name: true } } },
     orderBy: { createdAt: "asc" },
+  });
+}
+
+export type UserMembershipState = Pick<Membership, "status" | "role">;
+
+export async function getUserMembershipStatus(
+  groupId: string,
+  userId: string,
+): Promise<UserMembershipState | null> {
+  const m = await getMembership(groupId, userId);
+  if (!m) return null;
+  return { status: m.status, role: m.role };
+}
+
+export async function countApprovedMembers(groupId: string): Promise<number> {
+  return db.membership.count({
+    where: { groupId, status: "approved" },
+  });
+}
+
+export type ApprovedMember = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  role: Membership["role"];
+};
+
+export async function listApprovedMembers(
+  groupId: string,
+  limit: number,
+): Promise<ApprovedMember[]> {
+  const rows = await db.membership.findMany({
+    where: { groupId, status: "approved" },
+    orderBy: { createdAt: "asc" },
+    take: limit,
+    include: { user: { select: { id: true, name: true, email: true } } },
+  });
+  return rows.map((m) => ({
+    userId: m.user.id,
+    name: m.user.name,
+    email: m.user.email,
+    role: m.role,
+  }));
+}
+
+export async function listSuccessorCandidates(
+  groupId: string,
+  excludingUserId: string,
+): Promise<ApprovedMember[]> {
+  const rows = await db.membership.findMany({
+    where: {
+      groupId,
+      status: "approved",
+      userId: { not: excludingUserId },
+    },
+    orderBy: [{ createdAt: "asc" }],
+    include: { user: { select: { id: true, name: true, email: true } } },
+  });
+  return rows.map((m) => ({
+    userId: m.user.id,
+    name: m.user.name,
+    email: m.user.email,
+    role: m.role,
+  }));
+}
+
+export async function leaveGroup(groupId: string, userId: string): Promise<void> {
+  await db.$transaction(async (tx) => {
+    const membership = await tx.membership.findUnique({
+      where: { userId_groupId: { userId, groupId } },
+    });
+    if (!membership) throw new NotAMemberError();
+    if (membership.role === "owner" && membership.status === "approved") {
+      const otherOwners = await tx.membership.count({
+        where: {
+          groupId,
+          role: "owner",
+          status: "approved",
+          userId: { not: userId },
+        },
+      });
+      if (otherOwners === 0) throw new SoleOwnerCannotLeaveError();
+    }
+    await tx.membership.delete({
+      where: { userId_groupId: { userId, groupId } },
+    });
+  });
+}
+
+export async function transferOwnershipAndLeave(
+  groupId: string,
+  fromUserId: string,
+  toUserId: string,
+): Promise<void> {
+  if (fromUserId === toUserId) {
+    throw new InvalidSuccessorError("Successor must be a different user.");
+  }
+  await db.$transaction(async (tx) => {
+    const caller = await tx.membership.findUnique({
+      where: { userId_groupId: { userId: fromUserId, groupId } },
+    });
+    if (!caller) throw new NotAMemberError();
+    if (!(caller.role === "owner" && caller.status === "approved")) {
+      throw new AuthorizationError("Only an approved owner can transfer ownership.");
+    }
+    const successor = await tx.membership.findUnique({
+      where: { userId_groupId: { userId: toUserId, groupId } },
+    });
+    if (!successor || successor.status !== "approved") {
+      throw new InvalidSuccessorError();
+    }
+    await tx.membership.update({
+      where: { userId_groupId: { userId: toUserId, groupId } },
+      data: { role: "owner" },
+    });
+    await tx.membership.delete({
+      where: { userId_groupId: { userId: fromUserId, groupId } },
+    });
   });
 }


### PR DESCRIPTION
Closes #6 (M2: Group browsing — list and detail pages).

Adds a public `/groups` directory with newest/most-members sort, extends `/groups/[slug]` with a member preview, Q&A placeholder, and a membership CTA (anonymous → sign-in, none → apply, pending → disabled, approved → leave). Sole owners are routed through a new `/groups/[slug]/leave` page that prompts for a successor before transferring ownership atomically. Ships the matching `POST/DELETE /api/groups/[slug]/memberships` REST surface and a `lib/memberships` layer (`applyToJoin` respects `autoApprove`; `leaveGroup` and `transferOwnershipAndLeave` are transactional) with four new error classes mapped through `lib/api/errors`.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 93 tests pass (36 new across memberships lib, groups lib, and the new memberships API route)
- [x] \`npm run build\` registers `/groups`, `/groups/[slug]/leave`, and `/api/groups/[slug]/memberships`
- [ ] Manual smoke in \`npm run dev\`: anonymous list/detail, apply, pending, leave-as-member, leave-as-co-owner, sole-owner-with-successor, sole-owner-blocked