### PR TITLE
feat(notifications): notify group members of new questions (closes #9)

### DIFF
--- a/src/app/api/groups/[slug]/questions/route.test.ts
+++ b/src/app/api/groups/[slug]/questions/route.test.ts
@@ -181,6 +181,21 @@ describe("POST /api/groups/[slug]/questions", () => {
     expect(json.question.title).toBe("How do I do X with Y?");
     expect(json.question.groupId).toBe(group.id);
     expect(json.question.authorId).toBe(memberSess.user.id);
+
+    // fan-out: owner is approved (auto-approve creates owner membership), member is the author
+    const ownerNotifs = await db.notification.findMany({
+      where: { userId: ownerSess.user.id },
+    });
+    expect(ownerNotifs).toHaveLength(1);
+    expect(ownerNotifs[0]!.type).toBe("question.created");
+    const payload = JSON.parse(ownerNotifs[0]!.payload);
+    expect(payload.questionId).toBe(json.question.id);
+    expect(payload.groupSlug).toBe(slug);
+
+    const authorNotifs = await db.notification.findMany({
+      where: { userId: memberSess.user.id },
+    });
+    expect(authorNotifs).toHaveLength(0);
   });
 });
 

--- a/src/app/api/groups/[slug]/questions/route.ts
+++ b/src/app/api/groups/[slug]/questions/route.ts
@@ -3,6 +3,7 @@ import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/error
 import { getGroupBySlugOrThrow } from "@/lib/groups";
 import { assertApprovedMember } from "@/lib/memberships";
 import { createQuestion, listQuestionsForGroup } from "@/lib/questions";
+import { notifyQuestionCreated } from "@/lib/notifications";
 import {
   createQuestionSchema,
   questionListQuerySchema,
@@ -32,6 +33,11 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
     const group = await getGroupBySlugOrThrow(slug);
     await assertApprovedMember(group.id, session.user.id);
     const question = await createQuestion(parsed.data, group.id, session.user.id);
+    try {
+      await notifyQuestionCreated(question, group, session.user.name);
+    } catch (notifyErr) {
+      console.error("notifyQuestionCreated failed:", notifyErr);
+    }
     return Response.json({ question }, { status: 201 });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/api/notifications/[id]/read/route.test.ts
+++ b/src/app/api/notifications/[id]/read/route.test.ts
@@ -1,0 +1,130 @@
+/**
+ * POST /api/notifications/[id]/read route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-notifications-read-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { QUESTION_CREATED } = await import("@/lib/notifications");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+const SAMPLE_PAYLOAD = JSON.stringify({
+  questionId: "q",
+  questionTitle: "T",
+  groupSlug: "g",
+  groupName: "G",
+  authorName: null,
+});
+
+describe("POST /api/notifications/[id]/read", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(new Request("http://x", { method: "POST" }), ctx("any"));
+    expect(res.status).toBe(401);
+  });
+
+  it("marks the notification read for the owner", async () => {
+    const email = `r-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(email);
+    const sess = (await auth.getSession())!;
+    const n = await db.notification.create({
+      data: {
+        userId: sess.user.id,
+        type: QUESTION_CREATED,
+        payload: SAMPLE_PAYLOAD,
+      },
+    });
+
+    const res = await POST(new Request("http://x", { method: "POST" }), ctx(n.id));
+    expect(res.status).toBe(200);
+    const after = await db.notification.findUnique({ where: { id: n.id } });
+    expect(after?.readAt).not.toBeNull();
+  });
+
+  it("returns 404 when the notification belongs to another user", async () => {
+    const ownerEmail = `o-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const n = await db.notification.create({
+      data: {
+        userId: ownerSess.user.id,
+        type: QUESTION_CREATED,
+        payload: SAMPLE_PAYLOAD,
+      },
+    });
+
+    const intruderEmail = `i-${Date.now()}-${Math.random()}@example.com`;
+    cookieStore.clear();
+    await auth.signIn(intruderEmail);
+
+    const res = await POST(new Request("http://x", { method: "POST" }), ctx(n.id));
+    expect(res.status).toBe(404);
+    const after = await db.notification.findUnique({ where: { id: n.id } });
+    expect(after?.readAt).toBeNull();
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const email = `u-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(email);
+    const res = await POST(new Request("http://x", { method: "POST" }), ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,18 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { markRead } from "@/lib/notifications";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(_req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const notification = await markRead(id, session.user.id);
+    return Response.json({ notification }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/notifications/read-all/route.test.ts
+++ b/src/app/api/notifications/read-all/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/notifications/read-all route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-notifications-readall-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { QUESTION_CREATED } = await import("@/lib/notifications");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+const SAMPLE_PAYLOAD = JSON.stringify({
+  questionId: "q",
+  questionTitle: "T",
+  groupSlug: "g",
+  groupName: "G",
+  authorName: null,
+});
+
+describe("POST /api/notifications/read-all", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it("marks all unread notifications for the user", async () => {
+    const email = `ra-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(email);
+    const sess = (await auth.getSession())!;
+    for (let i = 0; i < 3; i += 1) {
+      await db.notification.create({
+        data: {
+          userId: sess.user.id,
+          type: QUESTION_CREATED,
+          payload: SAMPLE_PAYLOAD,
+        },
+      });
+    }
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.updatedCount).toBe(3);
+    expect(
+      await db.notification.count({
+        where: { userId: sess.user.id, readAt: null },
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,0 +1,15 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { markAllRead } from "@/lib/notifications";
+
+export async function POST(): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const updatedCount = await markAllRead(session.user.id);
+    return Response.json({ updatedCount }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * GET /api/notifications route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-notifications-list-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { QUESTION_CREATED } = await import("@/lib/notifications");
+const { GET } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+describe("GET /api/notifications", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user's notifications and unreadCount", async () => {
+    const email = `n-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(email);
+    const sess = (await auth.getSession())!;
+    await db.notification.create({
+      data: {
+        userId: sess.user.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q1",
+          questionTitle: "Hello",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: "A",
+        }),
+      },
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0].payload.questionTitle).toBe("Hello");
+    expect(json.unreadCount).toBe(1);
+  });
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,15 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { listForUser } from "@/lib/notifications";
+
+export async function GET(): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const result = await listForUser(session.user.id, { limit: 20 });
+    return Response.json(result, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import Link from "next/link";
+import { BellIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSession } from "@/lib/auth-client";
+import type {
+  NotificationListResult,
+  ParsedNotification,
+} from "@/lib/notifications";
+
+const POLL_INTERVAL_MS = 30_000;
+
+type ClientNotification = Omit<ParsedNotification, "createdAt" | "readAt"> & {
+  createdAt: string;
+  readAt: string | null;
+};
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return "just now";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function NotificationBell() {
+  const { status } = useSession();
+  const [items, setItems] = useState<ClientNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const mountedRef = useRef(true);
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const res = await fetch("/api/notifications", { cache: "no-store" });
+      if (!res.ok) return;
+      const body = (await res.json()) as NotificationListResult;
+      if (!mountedRef.current) return;
+      setItems(body.items as unknown as ClientNotification[]);
+      setUnreadCount(body.unreadCount);
+    } catch {
+      // network errors are silently swallowed; next poll will retry
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(() => {
+        void fetchNotifications();
+      }, POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        void fetchNotifications();
+        start();
+      }
+    };
+    // Initial fetch is queued as a microtask so React doesn't see the
+    // setState as synchronous within the effect body.
+    void Promise.resolve().then(fetchNotifications);
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [status, fetchNotifications]);
+
+  const handleItemClick = useCallback((id: string) => {
+    setItems((prev) =>
+      prev.map((n) => (n.id === id && !n.readAt ? { ...n, readAt: new Date().toISOString() } : n)),
+    );
+    setUnreadCount((prev) => Math.max(0, prev - 1));
+    void fetch(`/api/notifications/${id}/read`, { method: "POST" }).catch(() => {});
+  }, []);
+
+  const handleMarkAllRead = useCallback(async () => {
+    setItems((prev) =>
+      prev.map((n) => (n.readAt ? n : { ...n, readAt: new Date().toISOString() })),
+    );
+    setUnreadCount(0);
+    try {
+      await fetch("/api/notifications/read-all", { method: "POST" });
+    } catch {
+      // optimistic update already applied; refetch to reconcile if it failed
+      void fetchNotifications();
+    }
+  }, [fetchNotifications]);
+
+  if (status !== "authenticated") return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={
+              unreadCount > 0
+                ? `Notifications (${unreadCount} unread)`
+                : "Notifications"
+            }
+            className="relative"
+          />
+        }
+      >
+        <BellIcon className="size-4" />
+        {unreadCount > 0 ? (
+          <span
+            aria-hidden="true"
+            className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium leading-none text-destructive-foreground"
+          >
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        ) : null}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        <div className="flex items-center justify-between border-b border-border px-3 py-2">
+          <span className="text-sm font-medium">Notifications</span>
+          {unreadCount > 0 ? (
+            <button
+              type="button"
+              onClick={handleMarkAllRead}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Mark all read
+            </button>
+          ) : null}
+        </div>
+        <div className="max-h-96 overflow-y-auto py-1">
+          {items.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No notifications yet.
+            </div>
+          ) : (
+            items.map((n) => {
+              const unread = !n.readAt;
+              return (
+                <Link
+                  key={n.id}
+                  href={`/q/${n.payload.questionId}`}
+                  onClick={() => handleItemClick(n.id)}
+                  className="flex items-start gap-2 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={
+                      "mt-1.5 size-2 shrink-0 rounded-full " +
+                      (unread ? "bg-primary" : "bg-transparent")
+                    }
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate font-medium">
+                      {n.payload.questionTitle}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {n.payload.authorName ?? "Someone"} in {n.payload.groupName}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {relativeTime(n.createdAt)}
+                    </span>
+                  </span>
+                </Link>
+              );
+            })
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@ import { SearchIcon } from "lucide-react";
 
 import { UserMenu } from "@/components/auth/user-menu";
 import { ModeToggle } from "@/components/mode-toggle";
+import { NotificationBell } from "@/components/notification-bell";
 import { Button } from "@/components/ui/button";
 
 export function SiteHeader() {
@@ -27,6 +28,7 @@ export function SiteHeader() {
               Groups
             </Link>
             <ModeToggle />
+            <NotificationBell />
             <UserMenu />
           </nav>
         </div>

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -216,6 +216,14 @@ export async function listApprovedMembers(
   }));
 }
 
+export async function listApprovedMemberIds(groupId: string): Promise<string[]> {
+  const rows = await db.membership.findMany({
+    where: { groupId, status: "approved" },
+    select: { userId: true },
+  });
+  return rows.map((r) => r.userId);
+}
+
 export async function listSuccessorCandidates(
   groupId: string,
   excludingUserId: string,

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Notification service tests.
+ *
+ * Real-DB pattern (mirrors questions.test.ts).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-notifications-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { applyToGroup, NotFoundError } = await import("./memberships");
+const { createQuestion } = await import("./questions");
+const {
+  notifyQuestionCreated,
+  listForUser,
+  markRead,
+  markAllRead,
+  QUESTION_CREATED,
+} = await import("./notifications");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com`, name: label } });
+}
+
+describe("notifyQuestionCreated", () => {
+  it("creates one notification per approved member except the author", async () => {
+    const owner = await makeUser("owner");
+    const group = await createGroup(
+      { name: "G", slug: uniq("fan"), autoApprove: false },
+      owner.id,
+    );
+
+    const memberA = await makeUser("memA");
+    const memberB = await makeUser("memB");
+    const pending = await makeUser("pend");
+    await applyToGroup(group.id, memberA.id);
+    await applyToGroup(group.id, memberB.id);
+    await applyToGroup(group.id, pending.id);
+    await db.membership.update({
+      where: { userId_groupId: { userId: memberA.id, groupId: group.id } },
+      data: { status: "approved" },
+    });
+    await db.membership.update({
+      where: { userId_groupId: { userId: memberB.id, groupId: group.id } },
+      data: { status: "approved" },
+    });
+    // pending stays as pending
+
+    const question = await createQuestion(
+      { title: "Hello world", body: "body" },
+      group.id,
+      memberA.id,
+    );
+
+    const count = await notifyQuestionCreated(question, group, "Member A");
+    // owner (approved) + memberB (approved). memberA is the author. pending excluded.
+    expect(count).toBe(2);
+
+    const aRows = await db.notification.findMany({ where: { userId: memberA.id } });
+    expect(aRows).toHaveLength(0);
+
+    const ownerRows = await db.notification.findMany({ where: { userId: owner.id } });
+    expect(ownerRows).toHaveLength(1);
+    expect(ownerRows[0]!.type).toBe(QUESTION_CREATED);
+    const payload = JSON.parse(ownerRows[0]!.payload);
+    expect(payload.questionId).toBe(question.id);
+    expect(payload.questionTitle).toBe("Hello world");
+    expect(payload.groupSlug).toBe(group.slug);
+    expect(payload.authorName).toBe("Member A");
+
+    const pendingRows = await db.notification.findMany({ where: { userId: pending.id } });
+    expect(pendingRows).toHaveLength(0);
+  });
+
+  it("returns 0 when there are no other approved members", async () => {
+    const solo = await makeUser("solo");
+    const group = await createGroup(
+      { name: "S", slug: uniq("solo"), autoApprove: true },
+      solo.id,
+    );
+    const question = await createQuestion(
+      { title: "Alone", body: "body" },
+      group.id,
+      solo.id,
+    );
+    const count = await notifyQuestionCreated(question, group, "Solo");
+    expect(count).toBe(0);
+  });
+});
+
+describe("listForUser", () => {
+  it("returns notifications newest-first with unreadCount", async () => {
+    const u = await makeUser("listU");
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q1",
+          questionTitle: "Old",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: "A",
+        }),
+        readAt: new Date(),
+      },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q2",
+          questionTitle: "New",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: "A",
+        }),
+      },
+    });
+
+    const result = await listForUser(u.id);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]!.payload.questionTitle).toBe("New");
+    expect(result.items[1]!.payload.questionTitle).toBe("Old");
+    expect(result.unreadCount).toBe(1);
+  });
+
+  it("respects the limit option", async () => {
+    const u = await makeUser("limU");
+    for (let i = 0; i < 3; i += 1) {
+      await db.notification.create({
+        data: {
+          userId: u.id,
+          type: QUESTION_CREATED,
+          payload: JSON.stringify({
+            questionId: `q${i}`,
+            questionTitle: `T${i}`,
+            groupSlug: "g",
+            groupName: "G",
+            authorName: null,
+          }),
+        },
+      });
+    }
+    const result = await listForUser(u.id, { limit: 2 });
+    expect(result.items).toHaveLength(2);
+    expect(result.unreadCount).toBe(3);
+  });
+});
+
+describe("markRead", () => {
+  it("sets readAt for the user's own notification", async () => {
+    const u = await makeUser("markU");
+    const n = await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q",
+          questionTitle: "T",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+    expect(n.readAt).toBeNull();
+    const updated = await markRead(n.id, u.id);
+    expect(updated.readAt).not.toBeNull();
+  });
+
+  it("is idempotent on already-read rows", async () => {
+    const u = await makeUser("idemU");
+    const n = await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q",
+          questionTitle: "T",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+        readAt: new Date(),
+      },
+    });
+    const result = await markRead(n.id, u.id);
+    expect(result.readAt?.getTime()).toBe(n.readAt!.getTime());
+  });
+
+  it("rejects another user's notification with NotFoundError", async () => {
+    const owner = await makeUser("ownN");
+    const intruder = await makeUser("intN");
+    const n = await db.notification.create({
+      data: {
+        userId: owner.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "q",
+          questionTitle: "T",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+    await expect(markRead(n.id, intruder.id)).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("rejects unknown id with NotFoundError", async () => {
+    const u = await makeUser("unkN");
+    await expect(markRead("does-not-exist", u.id)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("markAllRead", () => {
+  it("marks every unread notification for the user and leaves others alone", async () => {
+    const u = await makeUser("allU");
+    const other = await makeUser("otherU");
+    for (let i = 0; i < 2; i += 1) {
+      await db.notification.create({
+        data: {
+          userId: u.id,
+          type: QUESTION_CREATED,
+          payload: JSON.stringify({
+            questionId: `q${i}`,
+            questionTitle: "T",
+            groupSlug: "g",
+            groupName: "G",
+            authorName: null,
+          }),
+        },
+      });
+    }
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "qr",
+          questionTitle: "T",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+        readAt: new Date(),
+      },
+    });
+    const otherUnread = await db.notification.create({
+      data: {
+        userId: other.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "qo",
+          questionTitle: "T",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+
+    const updated = await markAllRead(u.id);
+    expect(updated).toBe(2);
+    expect(await db.notification.count({ where: { userId: u.id, readAt: null } })).toBe(0);
+    const otherStill = await db.notification.findUnique({ where: { id: otherUnread.id } });
+    expect(otherStill?.readAt).toBeNull();
+  });
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,95 @@
+import "server-only";
+import type { Notification, Question } from "@prisma/client";
+import { db } from "@/lib/db";
+import { listApprovedMemberIds, NotFoundError } from "@/lib/memberships";
+
+export const QUESTION_CREATED = "question.created" as const;
+
+export type QuestionCreatedPayload = {
+  questionId: string;
+  questionTitle: string;
+  groupSlug: string;
+  groupName: string;
+  authorName: string | null;
+};
+
+export type ParsedNotification = Omit<Notification, "payload"> & {
+  payload: QuestionCreatedPayload;
+};
+
+export type NotificationListResult = {
+  items: ParsedNotification[];
+  unreadCount: number;
+};
+
+export function parsePayload(n: Notification): ParsedNotification {
+  return { ...n, payload: JSON.parse(n.payload) as QuestionCreatedPayload };
+}
+
+export async function notifyQuestionCreated(
+  question: Question,
+  group: { id: string; slug: string; name: string },
+  authorName: string | null,
+): Promise<number> {
+  const memberIds = await listApprovedMemberIds(group.id);
+  const recipients = memberIds.filter((id) => id !== question.authorId);
+  if (recipients.length === 0) return 0;
+
+  const payload: QuestionCreatedPayload = {
+    questionId: question.id,
+    questionTitle: question.title,
+    groupSlug: group.slug,
+    groupName: group.name,
+    authorName,
+  };
+  const payloadJson = JSON.stringify(payload);
+
+  const result = await db.notification.createMany({
+    data: recipients.map((userId) => ({
+      userId,
+      type: QUESTION_CREATED,
+      payload: payloadJson,
+    })),
+  });
+  return result.count;
+}
+
+export async function listForUser(
+  userId: string,
+  opts: { limit?: number } = {},
+): Promise<NotificationListResult> {
+  const limit = opts.limit ?? 20;
+  const [rows, unreadCount] = await Promise.all([
+    db.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    }),
+    db.notification.count({ where: { userId, readAt: null } }),
+  ]);
+  return { items: rows.map(parsePayload), unreadCount };
+}
+
+export async function markRead(
+  notificationId: string,
+  userId: string,
+): Promise<ParsedNotification> {
+  const existing = await db.notification.findUnique({ where: { id: notificationId } });
+  if (!existing || existing.userId !== userId) {
+    throw new NotFoundError("Notification not found.");
+  }
+  if (existing.readAt) return parsePayload(existing);
+  const updated = await db.notification.update({
+    where: { id: notificationId },
+    data: { readAt: new Date() },
+  });
+  return parsePayload(updated);
+}
+
+export async function markAllRead(userId: string): Promise<number> {
+  const result = await db.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  });
+  return result.count;
+}


### PR DESCRIPTION
## Summary
- Fan-out `Notification` rows on question create to every approved group member except the author, with best-effort error handling so a fan-out failure does not fail the request
- Adds `GET /api/notifications`, `POST /api/notifications/[id]/read`, and `POST /api/notifications/read-all` plus a domain layer in `src/lib/notifications.ts`
- New header `<NotificationBell />` with unread badge, dropdown of recent items, 30 s polling (paused when tab hidden), optimistic mark-read on click and Mark all read

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run build` clean
- [x] `npm test` — 158 tests pass (15 new, plus extended question-creation test asserting fan-out)
- [ ] Manual: as user A create auto-approve group, user B joins, A posts a question; B sees badge + dropdown item; click navigates to `/q/[id]` and clears unread; A's own questions do not notify A

🤖 Generated with [Claude Code](https://claude.com/claude-code)