### PR TITLE
feat(qa): post, edit, and delete answers (closes #10)

### DIFF
--- a/src/app/api/answers/[id]/route.test.ts
+++ b/src/app/api/answers/[id]/route.test.ts
@@ -1,0 +1,273 @@
+/**
+ * PATCH + DELETE /api/answers/[id] route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-answer-edit-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { PATCH, DELETE } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function jsonReq(url: string, method: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+type Setup = {
+  groupId: string;
+  questionId: string;
+  ownerId: string;
+  authorId: string;
+  answerId: string;
+};
+
+async function setupAnswer(slug: string): Promise<Setup> {
+  const ownerEmail = `o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: ownerSess.user.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+
+  cookieStore.clear();
+  const authorEmail = `a-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(authorEmail);
+  const authorSess = (await auth.getSession())!;
+  await applyToGroup(group.id, authorSess.user.id);
+  const answer = await db.answer.create({
+    data: {
+      questionId: question.id,
+      authorId: authorSess.user.id,
+      body: "Initial answer body.",
+    },
+  });
+
+  return {
+    groupId: group.id,
+    questionId: question.id,
+    ownerId: ownerSess.user.id,
+    authorId: authorSess.user.id,
+    answerId: answer.id,
+  };
+}
+
+describe("PATCH /api/answers/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await PATCH(
+      jsonReq("http://x/api/answers/abc", "PATCH", { body: "new" }),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when answer is unknown", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await PATCH(
+      jsonReq("http://x/api/answers/missing", "PATCH", { body: "new" }),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when body is invalid (empty)", async () => {
+    const setup = await setupAnswer(`e1-${Date.now()}`);
+    // session is the author at this point
+    const res = await PATCH(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "PATCH", { body: "" }),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller is not the author", async () => {
+    const setup = await setupAnswer(`e2-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`other-${Date.now()}-${Math.random()}@example.com`);
+    const res = await PATCH(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "PATCH", {
+        body: "stranger edit",
+      }),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with the updated answer for the author", async () => {
+    const setup = await setupAnswer(`e3-${Date.now()}`);
+    const before = await db.answer.findUnique({ where: { id: setup.answerId } });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const res = await PATCH(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "PATCH", {
+        body: "Updated answer body.",
+      }),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.answer.body).toBe("Updated answer body.");
+
+    const after = await db.answer.findUnique({ where: { id: setup.answerId } });
+    expect(after!.body).toBe("Updated answer body.");
+    expect(after!.updatedAt.getTime()).toBeGreaterThan(before!.updatedAt.getTime());
+  });
+});
+
+describe("DELETE /api/answers/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await DELETE(
+      jsonReq("http://x/api/answers/abc", "DELETE"),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when answer is unknown", async () => {
+    await auth.signIn(`d-${Date.now()}@example.com`);
+    const res = await DELETE(
+      jsonReq("http://x/api/answers/missing", "DELETE"),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is the answer author (not mod/owner)", async () => {
+    // setupAnswer leaves session as the (plain-member) author
+    const setup = await setupAnswer(`d1-${Date.now()}`);
+    const res = await DELETE(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "DELETE"),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(403);
+
+    const stillThere = await db.answer.findUnique({ where: { id: setup.answerId } });
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("returns 403 when caller is a plain approved member", async () => {
+    const setup = await setupAnswer(`d2-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`pm-${Date.now()}-${Math.random()}@example.com`);
+    const session = (await auth.getSession())!;
+    await applyToGroup(setup.groupId, session.user.id);
+
+    const res = await DELETE(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "DELETE"),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 204 when caller is the group owner", async () => {
+    const setup = await setupAnswer(`d3-${Date.now()}`);
+    cookieStore.clear();
+    // sign in as the owner — owner email used during setup
+    const ownerUser = await db.user.findUnique({ where: { id: setup.ownerId } });
+    await auth.signIn(ownerUser!.email!);
+
+    const res = await DELETE(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "DELETE"),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(204);
+
+    const gone = await db.answer.findUnique({ where: { id: setup.answerId } });
+    expect(gone).toBeNull();
+  });
+
+  it("returns 204 when caller is a moderator", async () => {
+    const setup = await setupAnswer(`d4-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`mod-${Date.now()}-${Math.random()}@example.com`);
+    const modSess = (await auth.getSession())!;
+    await db.membership.create({
+      data: {
+        groupId: setup.groupId,
+        userId: modSess.user.id,
+        role: "moderator",
+        status: "approved",
+      },
+    });
+
+    const res = await DELETE(
+      jsonReq(`http://x/api/answers/${setup.answerId}`, "DELETE"),
+      ctx(setup.answerId),
+    );
+    expect(res.status).toBe(204);
+
+    const gone = await db.answer.findUnique({ where: { id: setup.answerId } });
+    expect(gone).toBeNull();
+  });
+});

--- a/src/app/api/answers/[id]/route.ts
+++ b/src/app/api/answers/[id]/route.ts
@@ -1,0 +1,45 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { deleteAnswer, updateAnswer } from "@/lib/answers";
+import { updateAnswerSchema } from "@/lib/validation/answers";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateAnswerSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const answer = await updateAnswer(id, parsed.data, session.user.id);
+    return Response.json({ answer }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}
+
+export async function DELETE(_req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    await deleteAnswer(id, session.user.id);
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/questions/[id]/answers/route.test.ts
+++ b/src/app/api/questions/[id]/answers/route.test.ts
@@ -1,0 +1,210 @@
+/**
+ * POST /api/questions/[id]/answers route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-answers-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function jsonReq(url: string, method: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function createGroupWithApprovedAuthor(slug: string) {
+  const ownerEmail = `o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: ownerSess.user.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+  return { group, question, ownerSess };
+}
+
+describe("POST /api/questions/[id]/answers", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(
+      jsonReq("http://x/api/questions/abc/answers", "POST", { body: "hi" }),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is invalid (empty)", async () => {
+    await auth.signIn(`v-${Date.now()}@example.com`);
+    const res = await POST(
+      jsonReq("http://x/api/questions/abc/answers", "POST", { body: "" }),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is too long", async () => {
+    await auth.signIn(`vlong-${Date.now()}@example.com`);
+    const res = await POST(
+      jsonReq("http://x/api/questions/abc/answers", "POST", {
+        body: "a".repeat(20_001),
+      }),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the question id is unknown", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await POST(
+      jsonReq("http://x/api/questions/missing/answers", "POST", { body: "ok" }),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is not a group member", async () => {
+    const slug = `nope-${Date.now()}`;
+    const { question } = await createGroupWithApprovedAuthor(slug);
+
+    cookieStore.clear();
+    await auth.signIn(`s-${Date.now()}-${Math.random()}@example.com`);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${question.id}/answers`, "POST", {
+        body: "i am a stranger",
+      }),
+      ctx(question.id),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when caller is a pending applicant", async () => {
+    const ownerEmail = `own2-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `pending-${Date.now()}`;
+    const group = await createGroup(
+      { name: "P", slug, autoApprove: false },
+      ownerSess.user.id,
+    );
+    const question = await db.question.create({
+      data: {
+        groupId: group.id,
+        authorId: ownerSess.user.id,
+        title: "Seeded title here",
+        body: "Seed",
+      },
+    });
+
+    cookieStore.clear();
+    await auth.signIn(`app-${Date.now()}-${Math.random()}@example.com`);
+    const applicantSess = (await auth.getSession())!;
+    await applyToGroup(group.id, applicantSess.user.id);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${question.id}/answers`, "POST", {
+        body: "pending answer",
+      }),
+      ctx(question.id),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 201 with the created answer for an approved member", async () => {
+    const slug = `ok-${Date.now()}`;
+    const { group, question } = await createGroupWithApprovedAuthor(slug);
+
+    cookieStore.clear();
+    const memberEmail = `m-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(memberEmail);
+    const memberSess = (await auth.getSession())!;
+    await applyToGroup(group.id, memberSess.user.id);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${question.id}/answers`, "POST", {
+        body: "Here is my **answer** with markdown.",
+      }),
+      ctx(question.id),
+    );
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.answer.body).toBe("Here is my **answer** with markdown.");
+    expect(json.answer.questionId).toBe(question.id);
+    expect(json.answer.authorId).toBe(memberSess.user.id);
+
+    const stored = await db.answer.findUnique({ where: { id: json.answer.id } });
+    expect(stored).not.toBeNull();
+    expect(stored!.body).toBe("Here is my **answer** with markdown.");
+  });
+});

--- a/src/app/api/questions/[id]/answers/route.ts
+++ b/src/app/api/questions/[id]/answers/route.ts
@@ -1,0 +1,40 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { NotFoundError, assertApprovedMember } from "@/lib/memberships";
+import { createAnswer } from "@/lib/answers";
+import { createAnswerSchema } from "@/lib/validation/answers";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createAnswerSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const question = await db.question.findUnique({
+      where: { id },
+      select: { id: true, groupId: true },
+    });
+    if (!question) throw new NotFoundError("Question not found.");
+    await assertApprovedMember(question.groupId, session.user.id);
+    const answer = await createAnswer(parsed.data, question.id, session.user.id);
+    return Response.json({ answer }, { status: 201 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import {
+  AuthorizationError,
+  NotFoundError,
+  assertApprovedMember,
+} from "@/lib/memberships";
+import {
+  createAnswer,
+  deleteAnswer,
+  updateAnswer,
+} from "@/lib/answers";
+import { db } from "@/lib/db";
+import {
+  createAnswerSchema,
+  updateAnswerSchema,
+} from "@/lib/validation/answers";
+
+export type FieldError = { path: string; message: string };
+
+export type AnswerFormState = {
+  ok?: boolean;
+  error?: string;
+  fieldErrors?: FieldError[];
+  values?: { body?: string };
+};
+
+export async function createAnswerAction(
+  questionId: string,
+  _prev: AnswerFormState,
+  formData: FormData,
+): Promise<AnswerFormState> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to post an answer." };
+  }
+
+  const raw = { body: String(formData.get("body") ?? "") };
+  const parsed = createAnswerSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+      values: raw,
+    };
+  }
+
+  try {
+    const question = await db.question.findUnique({
+      where: { id: questionId },
+      select: { id: true, groupId: true },
+    });
+    if (!question) {
+      return { error: "Question not found.", values: raw };
+    }
+    await assertApprovedMember(question.groupId, session.user.id);
+    await createAnswer(parsed.data, question.id, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return {
+        error: "You must be an approved member of this group to post an answer.",
+        values: raw,
+      };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message, values: raw };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not post answer.",
+      values: raw,
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export async function updateAnswerAction(
+  answerId: string,
+  questionId: string,
+  _prev: AnswerFormState,
+  formData: FormData,
+): Promise<AnswerFormState> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to edit an answer." };
+  }
+
+  const raw = { body: String(formData.get("body") ?? "") };
+  const parsed = updateAnswerSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+      values: raw,
+    };
+  }
+
+  try {
+    await updateAnswer(answerId, parsed.data, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only the answer's author can edit it.", values: raw };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message, values: raw };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not update answer.",
+      values: raw,
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export type DeleteAnswerResult = { error?: string; ok?: boolean };
+
+export async function deleteAnswerAction(
+  answerId: string,
+  questionId: string,
+): Promise<DeleteAnswerResult> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to delete an answer." };
+  }
+
+  try {
+    await deleteAnswer(answerId, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only moderators or owners can delete answers." };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not delete answer.",
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}

--- a/src/app/q/[id]/answer-actions.tsx
+++ b/src/app/q/[id]/answer-actions.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useActionState, useEffect, useState, useTransition } from "react";
+import { MarkdownBody } from "@/components/markdown-body";
+import {
+  deleteAnswerAction,
+  updateAnswerAction,
+  type AnswerFormState,
+} from "./actions";
+
+const initialEditState: AnswerFormState = {};
+
+function fieldError(state: AnswerFormState, path: string): string | undefined {
+  return state.fieldErrors?.find((e) => e.path === path)?.message;
+}
+
+type Props = {
+  answerId: string;
+  questionId: string;
+  body: string;
+  canEdit: boolean;
+  canDelete: boolean;
+};
+
+export function AnswerActions({
+  answerId,
+  questionId,
+  body,
+  canEdit,
+  canDelete,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+
+  const editAction = updateAnswerAction.bind(null, answerId, questionId);
+  const [editState, editFormAction, editPending] = useActionState(
+    editAction,
+    initialEditState,
+  );
+
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletePending, startDelete] = useTransition();
+
+  useEffect(() => {
+    if (editState.ok) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEditing(false);
+    }
+  }, [editState.ok]);
+
+  const onDeleteClick = () => {
+    if (!confirm("Delete this answer? This cannot be undone.")) return;
+    setDeleteError(null);
+    startDelete(async () => {
+      const result = await deleteAnswerAction(answerId, questionId);
+      if (result.error) setDeleteError(result.error);
+    });
+  };
+
+  if (editing) {
+    return (
+      <form action={editFormAction} className="space-y-2">
+        <textarea
+          name="body"
+          rows={6}
+          required
+          minLength={1}
+          maxLength={20000}
+          defaultValue={editState.values?.body ?? body}
+          className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+        />
+        {fieldError(editState, "body") ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {fieldError(editState, "body")}
+          </p>
+        ) : null}
+        {editState.error ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {editState.error}
+          </p>
+        ) : null}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={editPending}
+            className="rounded bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {editPending ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="rounded border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <>
+      <MarkdownBody source={body} />
+      {canEdit || canDelete ? (
+        <div className="flex items-center gap-3 pt-1">
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="text-xs text-zinc-600 underline hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+            >
+              Edit
+            </button>
+          ) : null}
+          {canDelete ? (
+            <button
+              type="button"
+              onClick={onDeleteClick}
+              disabled={deletePending}
+              className="text-xs text-red-600 underline hover:text-red-700 disabled:opacity-60 dark:text-red-400 dark:hover:text-red-300"
+            >
+              {deletePending ? "Deleting…" : "Delete"}
+            </button>
+          ) : null}
+          {deleteError ? (
+            <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+              {deleteError}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/q/[id]/answer-form.tsx
+++ b/src/app/q/[id]/answer-form.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useActionState, useEffect, useRef } from "react";
+import { createAnswerAction, type AnswerFormState } from "./actions";
+
+const initialState: AnswerFormState = {};
+
+function fieldError(state: AnswerFormState, path: string): string | undefined {
+  return state.fieldErrors?.find((e) => e.path === path)?.message;
+}
+
+type Props = { questionId: string };
+
+export function AnswerForm({ questionId }: Props) {
+  const action = createAnswerAction.bind(null, questionId);
+  const [state, formAction, isPending] = useActionState(action, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state.ok && formRef.current) {
+      formRef.current.reset();
+    }
+  }, [state.ok]);
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-3">
+      <div className="space-y-1">
+        <label htmlFor="answer-body" className="block text-sm font-medium">
+          Your answer <span className="text-zinc-500">(Markdown supported)</span>
+        </label>
+        <textarea
+          id="answer-body"
+          name="body"
+          rows={6}
+          required
+          minLength={1}
+          maxLength={20000}
+          defaultValue={state.values?.body ?? ""}
+          placeholder="Share what you know. Be concrete and link to sources where helpful."
+          className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+        />
+        {fieldError(state, "body") ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {fieldError(state, "body")}
+          </p>
+        ) : null}
+      </div>
+
+      {state.error ? (
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+          {state.error}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded bg-zinc-900 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {isPending ? "Posting…" : "Post answer"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -2,8 +2,11 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MarkdownBody } from "@/components/markdown-body";
-import { NotFoundError } from "@/lib/memberships";
+import { getSession } from "@/lib/auth";
+import { NotFoundError, getMembership } from "@/lib/memberships";
 import { getQuestionById } from "@/lib/questions";
+import { AnswerForm } from "./answer-form";
+import { AnswerActions } from "./answer-actions";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -21,6 +24,16 @@ export default async function QuestionDetailPage({ params }: Props) {
     if (err instanceof NotFoundError) notFound();
     throw err;
   }
+
+  const session = await getSession();
+  const currentUserId = session?.user.id ?? null;
+  const viewerMembership = currentUserId
+    ? await getMembership(question.group.id, currentUserId)
+    : null;
+  const isApprovedViewer = viewerMembership?.status === "approved";
+  const canDeleteAny =
+    isApprovedViewer &&
+    (viewerMembership?.role === "owner" || viewerMembership?.role === "moderator");
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 py-8">
@@ -49,23 +62,54 @@ export default async function QuestionDetailPage({ params }: Props) {
         </h2>
         {question.answers.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            Answers ship in a follow-up — check back soon.
+            Be the first to answer.
           </p>
         ) : (
           <ul className="space-y-3">
-            {question.answers.map((a) => (
-              <li key={a.id}>
-                <Card>
-                  <CardContent className="space-y-2 pt-4">
-                    <p className="text-xs text-muted-foreground">
-                      {authorLabel(a.author)} · Score {a.voteScore}
-                    </p>
-                    <MarkdownBody source={a.body} />
-                  </CardContent>
-                </Card>
-              </li>
-            ))}
+            {question.answers.map((a) => {
+              const canEdit = currentUserId !== null && a.author.id === currentUserId;
+              return (
+                <li key={a.id}>
+                  <Card>
+                    <CardContent className="space-y-2 pt-4">
+                      <p className="text-xs text-muted-foreground">
+                        {authorLabel(a.author)} · Score {a.voteScore}
+                      </p>
+                      <AnswerActions
+                        answerId={a.id}
+                        questionId={question.id}
+                        body={a.body}
+                        canEdit={canEdit}
+                        canDelete={canDeleteAny}
+                      />
+                    </CardContent>
+                  </Card>
+                </li>
+              );
+            })}
           </ul>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-base font-medium">Post an answer</h3>
+        {!currentUserId ? (
+          <p className="text-sm text-muted-foreground">
+            <Link href="/login" className="underline">
+              Sign in
+            </Link>{" "}
+            to post an answer.
+          </p>
+        ) : isApprovedViewer ? (
+          <AnswerForm questionId={question.id} />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            You must be an approved member of{" "}
+            <Link href={`/groups/${question.group.slug}`} className="underline">
+              {question.group.name}
+            </Link>{" "}
+            to answer this question.
+          </p>
         )}
       </section>
     </div>

--- a/src/lib/answers.ts
+++ b/src/lib/answers.ts
@@ -1,0 +1,67 @@
+import "server-only";
+import type { Answer } from "@prisma/client";
+import { db } from "@/lib/db";
+import {
+  AuthorizationError,
+  NotFoundError,
+  assertOwnerOrModerator,
+} from "@/lib/memberships";
+import type {
+  CreateAnswerInput,
+  UpdateAnswerInput,
+} from "@/lib/validation/answers";
+
+export type AnswerWithQuestion = Answer & {
+  question: { id: string; groupId: string; authorId: string };
+};
+
+export async function createAnswer(
+  input: CreateAnswerInput,
+  questionId: string,
+  authorId: string,
+): Promise<Answer> {
+  return db.answer.create({
+    data: {
+      questionId,
+      authorId,
+      body: input.body,
+    },
+  });
+}
+
+export async function getAnswerWithQuestion(
+  answerId: string,
+): Promise<AnswerWithQuestion> {
+  const answer = await db.answer.findUnique({
+    where: { id: answerId },
+    include: {
+      question: { select: { id: true, groupId: true, authorId: true } },
+    },
+  });
+  if (!answer) throw new NotFoundError("Answer not found.");
+  return answer;
+}
+
+export async function updateAnswer(
+  answerId: string,
+  input: UpdateAnswerInput,
+  userId: string,
+): Promise<Answer> {
+  const existing = await getAnswerWithQuestion(answerId);
+  if (existing.authorId !== userId) {
+    throw new AuthorizationError("Only the answer's author can edit it.");
+  }
+  return db.answer.update({
+    where: { id: answerId },
+    data: { body: input.body },
+  });
+}
+
+export async function deleteAnswer(
+  answerId: string,
+  userId: string,
+): Promise<void> {
+  const existing = await getAnswerWithQuestion(answerId);
+  await assertOwnerOrModerator(existing.question.groupId, userId);
+  await db.answer.delete({ where: { id: answerId } });
+}

--- a/src/lib/validation/answers.ts
+++ b/src/lib/validation/answers.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { questionBodySchema } from "./questions";
+
+export const answerBodySchema = questionBodySchema;
+
+export const createAnswerSchema = z.object({
+  body: answerBodySchema,
+});
+
+export type CreateAnswerInput = z.input<typeof createAnswerSchema>;
+
+export const updateAnswerSchema = z.object({
+  body: answerBodySchema,
+});
+
+export type UpdateAnswerInput = z.input<typeof updateAnswerSchema>;


### PR DESCRIPTION
## Summary
- Adds `POST /api/questions/[id]/answers` (Markdown body, gated to approved group members), `PATCH /api/answers/[id]` (author-only edit), and `DELETE /api/answers/[id]` (mod/owner-only) — all backed by a thin `src/lib/answers.ts` data layer that reuses the existing membership helpers and error mapping.
- Replaces the "Answers ship in a follow-up" placeholder on `/q/[id]` with a real answer form, an oldest-first list with inline edit/delete affordances, and clear gating for signed-out and non-member viewers; viewer permissions are computed from a single `getMembership` lookup.
- Adds 18 new vitest route tests (auth, validation, membership, ownership/role) and leaves the existing 158 green; lint, typecheck, and `next build` all pass.

## Test plan
- [ ] `npm run lint && npm run typecheck && npm run test && npm run build` — all green locally.
- [ ] `npm run dev`, sign in as user A, create an auto-approve group, ask a question; sign in as user B, join the group, post an answer at `/q/<id>` and confirm it appears oldest-first.
- [ ] As B, edit your own answer; confirm the Edit button is hidden on A's prior answers and a direct API `PATCH` returns 403.
- [ ] As A (owner), delete B's answer and confirm the row is gone; confirm a plain member sees no Delete button and a direct `DELETE` returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)