### PR TITLE
feat(qa): add upvoting on questions and answers (closes #11)

### DIFF
--- a/src/app/api/votes/route.test.ts
+++ b/src/app/api/votes/route.test.ts
@@ -1,0 +1,219 @@
+/**
+ * POST /api/votes route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-votes-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function jsonReq(method: string, body?: unknown, raw?: string): Request {
+  return new Request("http://x/api/votes", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: raw !== undefined ? raw : body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function setupGroupWithQuestion(autoApprove = true) {
+  const ownerEmail = `${uniq("o")}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: uniq("G"), slug: uniq("g"), autoApprove },
+    ownerSess.user.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: ownerSess.user.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+  return { group, question, ownerSess };
+}
+
+describe("POST /api/votes", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: "any", value: 1 }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is malformed JSON", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(jsonReq("POST", undefined, "{not json"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when value is not 1", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: "x", value: 2 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetType is missing", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(jsonReq("POST", { targetId: "x", value: 1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when target id is unknown", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", {
+        targetType: "question",
+        targetId: "does-not-exist",
+        value: 1,
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is the author (self-vote)", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when caller is not an approved member", async () => {
+    const { question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("stranger")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with voted=true for an approved member voting on a question", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("voter")}@example.com`);
+    const sess = (await auth.getSession())!;
+    await applyToGroup(group.id, sess.user.id);
+
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.voted).toBe(true);
+    expect(json.voteScore).toBe(1);
+    expect(json.targetType).toBe("question");
+    expect(json.targetId).toBe(question.id);
+  });
+
+  it("returns 200 with voted=true for an answer vote", async () => {
+    const { group, question, ownerSess } = await setupGroupWithQuestion();
+    const answer = await db.answer.create({
+      data: {
+        questionId: question.id,
+        authorId: ownerSess.user.id,
+        body: "an answer",
+      },
+    });
+
+    cookieStore.clear();
+    await auth.signIn(`${uniq("av")}@example.com`);
+    const sess = (await auth.getSession())!;
+    await applyToGroup(group.id, sess.user.id);
+
+    const res = await POST(
+      jsonReq("POST", { targetType: "answer", targetId: answer.id, value: 1 }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.voted).toBe(true);
+    expect(json.voteScore).toBe(1);
+    expect(json.targetType).toBe("answer");
+  });
+
+  it("toggles off on second call and returns voted=false", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("tog")}@example.com`);
+    const sess = (await auth.getSession())!;
+    await applyToGroup(group.id, sess.user.id);
+
+    await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.voted).toBe(false);
+    expect(json.voteScore).toBe(0);
+  });
+});

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,0 +1,32 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { castVote } from "@/lib/votes";
+import { voteInputSchema } from "@/lib/validation/votes";
+
+export async function POST(req: Request): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = voteInputSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const result = await castVote(
+      { targetType: parsed.data.targetType, targetId: parsed.data.targetId },
+      session.user.id,
+    );
+    return Response.json(result, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -7,6 +7,7 @@ import { NotFoundError, getMembership } from "@/lib/memberships";
 import { getQuestionById } from "@/lib/questions";
 import { AnswerForm } from "./answer-form";
 import { AnswerActions } from "./answer-actions";
+import { VoteButton } from "./vote-button";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -17,16 +18,17 @@ function authorLabel(a: { name: string | null; email: string | null }): string {
 export default async function QuestionDetailPage({ params }: Props) {
   const { id } = await params;
 
+  const session = await getSession();
+  const currentUserId = session?.user.id ?? null;
+
   let question;
   try {
-    question = await getQuestionById(id);
+    question = await getQuestionById(id, currentUserId ?? undefined);
   } catch (err) {
     if (err instanceof NotFoundError) notFound();
     throw err;
   }
 
-  const session = await getSession();
-  const currentUserId = session?.user.id ?? null;
   const viewerMembership = currentUserId
     ? await getMembership(question.group.id, currentUserId)
     : null;
@@ -34,6 +36,18 @@ export default async function QuestionDetailPage({ params }: Props) {
   const canDeleteAny =
     isApprovedViewer &&
     (viewerMembership?.role === "owner" || viewerMembership?.role === "moderator");
+
+  const voteDisabledReason = !currentUserId
+    ? "Sign in to vote."
+    : !isApprovedViewer
+      ? "You must be an approved member of this group to vote."
+      : undefined;
+  const questionVoteDisabled =
+    !currentUserId || !isApprovedViewer || question.author.id === currentUserId;
+  const questionVoteDisabledReason =
+    currentUserId && question.author.id === currentUserId
+      ? "You cannot vote on your own question."
+      : voteDisabledReason;
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 py-8">
@@ -45,11 +59,18 @@ export default async function QuestionDetailPage({ params }: Props) {
             <Link href={`/groups/${question.group.slug}`} className="underline">
               {question.group.name}
             </Link>
-            {" · "}
-            <span>Score {question.voteScore}</span>
           </p>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-3 pt-4">
+          <VoteButton
+            targetType="question"
+            targetId={question.id}
+            questionId={question.id}
+            initialScore={question.voteScore}
+            initialVoted={question.viewerVote === 1}
+            disabled={questionVoteDisabled}
+            disabledReason={questionVoteDisabledReason}
+          />
           <MarkdownBody source={question.body} />
         </CardContent>
       </Card>
@@ -67,14 +88,32 @@ export default async function QuestionDetailPage({ params }: Props) {
         ) : (
           <ul className="space-y-3">
             {question.answers.map((a) => {
-              const canEdit = currentUserId !== null && a.author.id === currentUserId;
+              const isOwnAnswer =
+                currentUserId !== null && a.author.id === currentUserId;
+              const canEdit = isOwnAnswer;
+              const answerVoteDisabled =
+                !currentUserId || !isApprovedViewer || isOwnAnswer;
+              const answerVoteDisabledReason = isOwnAnswer
+                ? "You cannot vote on your own answer."
+                : voteDisabledReason;
               return (
                 <li key={a.id}>
                   <Card>
                     <CardContent className="space-y-2 pt-4">
-                      <p className="text-xs text-muted-foreground">
-                        {authorLabel(a.author)} · Score {a.voteScore}
-                      </p>
+                      <div className="flex items-center gap-3">
+                        <VoteButton
+                          targetType="answer"
+                          targetId={a.id}
+                          questionId={question.id}
+                          initialScore={a.voteScore}
+                          initialVoted={a.viewerVote === 1}
+                          disabled={answerVoteDisabled}
+                          disabledReason={answerVoteDisabledReason}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          {authorLabel(a.author)}
+                        </p>
+                      </div>
                       <AnswerActions
                         answerId={a.id}
                         questionId={question.id}

--- a/src/app/q/[id]/vote-actions.ts
+++ b/src/app/q/[id]/vote-actions.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import { AuthorizationError, NotFoundError } from "@/lib/memberships";
+import { castVote, type VoteTargetType } from "@/lib/votes";
+
+export type VoteActionResult =
+  | { ok: true; voted: boolean; voteScore: number }
+  | { ok: false; error: string };
+
+export async function voteAction(
+  targetType: VoteTargetType,
+  targetId: string,
+  questionId: string,
+): Promise<VoteActionResult> {
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: "You must be signed in to vote." };
+  }
+
+  try {
+    const result = await castVote({ targetType, targetId }, session.user.id);
+    revalidatePath(`/q/${questionId}`);
+    return { ok: true, voted: result.voted, voteScore: result.voteScore };
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { ok: false, error: err.message };
+    }
+    if (err instanceof NotFoundError) {
+      return { ok: false, error: err.message };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not register vote.",
+    };
+  }
+}

--- a/src/app/q/[id]/vote-button.tsx
+++ b/src/app/q/[id]/vote-button.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ChevronUpIcon } from "lucide-react";
+import { useState, useTransition } from "react";
+import { voteAction } from "./vote-actions";
+import type { VoteTargetType } from "@/lib/votes";
+
+type Props = {
+  targetType: VoteTargetType;
+  targetId: string;
+  questionId: string;
+  initialScore: number;
+  initialVoted: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+};
+
+export function VoteButton({
+  targetType,
+  targetId,
+  questionId,
+  initialScore,
+  initialVoted,
+  disabled = false,
+  disabledReason,
+}: Props) {
+  const [score, setScore] = useState(initialScore);
+  const [voted, setVoted] = useState(initialVoted);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (disabled || pending) return;
+    setError(null);
+    const prevScore = score;
+    const prevVoted = voted;
+    const optimisticScore = prevVoted ? prevScore - 1 : prevScore + 1;
+    setScore(optimisticScore);
+    setVoted(!prevVoted);
+
+    startTransition(async () => {
+      const result = await voteAction(targetType, targetId, questionId);
+      if (result.ok) {
+        setScore(result.voteScore);
+        setVoted(result.voted);
+      } else {
+        setScore(prevScore);
+        setVoted(prevVoted);
+        setError(result.error);
+      }
+    });
+  };
+
+  const label = voted ? "Remove vote" : "Upvote";
+  const title = disabled ? disabledReason ?? label : label;
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || pending}
+        aria-pressed={voted}
+        aria-label={label}
+        title={title}
+        className={
+          "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs transition-colors " +
+          (voted
+            ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+            : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800") +
+          " disabled:cursor-not-allowed disabled:opacity-60"
+        }
+      >
+        <ChevronUpIcon className="h-3.5 w-3.5" />
+        <span className="tabular-nums">{score}</span>
+      </button>
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/questions.test.ts
+++ b/src/lib/questions.test.ts
@@ -172,4 +172,74 @@ describe("getQuestionById", () => {
   it("throws NotFoundError for unknown id", async () => {
     await expect(getQuestionById("does-not-exist")).rejects.toBeInstanceOf(NotFoundError);
   });
+
+  it("returns viewerVote=null when no viewerUserId is supplied", async () => {
+    const author = await makeUser("authV0");
+    const group = await createGroup(
+      { name: "V0", slug: uniq("v0"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Title", body: "Body" },
+      group.id,
+      author.id,
+    );
+    const detail = await getQuestionById(q.id);
+    expect(detail.viewerVote).toBeNull();
+  });
+
+  it("returns viewerVote=1 on question and answers the viewer has voted on", async () => {
+    const author = await makeUser("authV1");
+    const group = await createGroup(
+      { name: "V1", slug: uniq("v1"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Title", body: "Body" },
+      group.id,
+      author.id,
+    );
+    const a1 = await db.answer.create({
+      data: { questionId: q.id, authorId: author.id, body: "answer one" },
+    });
+    const a2 = await db.answer.create({
+      data: { questionId: q.id, authorId: author.id, body: "answer two" },
+    });
+    const viewer = await makeUser("viewerV1");
+    await db.vote.create({
+      data: { userId: viewer.id, targetType: "question", targetId: q.id, value: 1 },
+    });
+    await db.vote.create({
+      data: { userId: viewer.id, targetType: "answer", targetId: a1.id, value: 1 },
+    });
+
+    const detail = await getQuestionById(q.id, viewer.id);
+    expect(detail.viewerVote).toBe(1);
+    const answer1 = detail.answers.find((a) => a.id === a1.id)!;
+    const answer2 = detail.answers.find((a) => a.id === a2.id)!;
+    expect(answer1.viewerVote).toBe(1);
+    expect(answer2.viewerVote).toBeNull();
+  });
+
+  it("does not leak another user's vote into viewerVote", async () => {
+    const author = await makeUser("authV2");
+    const group = await createGroup(
+      { name: "V2", slug: uniq("v2"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Title", body: "Body" },
+      group.id,
+      author.id,
+    );
+    const otherVoter = await makeUser("otherV2");
+    await db.vote.create({
+      data: { userId: otherVoter.id, targetType: "question", targetId: q.id, value: 1 },
+    });
+    const viewer = await makeUser("meV2");
+
+    const detail = await getQuestionById(q.id, viewer.id);
+    expect(detail.voteScore).toBe(1);
+    expect(detail.viewerVote).toBeNull();
+  });
 });

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { Answer, Question, User } from "@prisma/client";
 import { db } from "@/lib/db";
 import { NotFoundError } from "@/lib/memberships";
+import { viewerVotesFor, voteScoresFor } from "@/lib/votes";
 import type { CreateQuestionInput } from "@/lib/validation/questions";
 
 export type QuestionAuthor = Pick<User, "id" | "email" | "name">;
@@ -29,9 +30,11 @@ export type QuestionDetail = Question & {
     Pick<Answer, "id" | "body" | "createdAt" | "updatedAt"> & {
       author: QuestionAuthor;
       voteScore: number;
+      viewerVote: 1 | null;
     }
   >;
   voteScore: number;
+  viewerVote: 1 | null;
 };
 
 export async function createQuestion(
@@ -47,16 +50,6 @@ export async function createQuestion(
       body: input.body,
     },
   });
-}
-
-async function voteScoresFor(targetType: "question" | "answer", ids: string[]) {
-  if (ids.length === 0) return new Map<string, number>();
-  const rows = await db.vote.groupBy({
-    by: ["targetId"],
-    where: { targetType, targetId: { in: ids } },
-    _sum: { value: true },
-  });
-  return new Map(rows.map((r) => [r.targetId, r._sum.value ?? 0]));
 }
 
 export async function listQuestionsForGroup(
@@ -97,7 +90,10 @@ export async function listQuestionsForGroup(
   return { items, total, page: opts.page, per: opts.per };
 }
 
-export async function getQuestionById(id: string): Promise<QuestionDetail> {
+export async function getQuestionById(
+  id: string,
+  viewerUserId?: string,
+): Promise<QuestionDetail> {
   const q = await db.question.findUnique({
     where: { id },
     include: {
@@ -113,17 +109,24 @@ export async function getQuestionById(id: string): Promise<QuestionDetail> {
   });
   if (!q) throw new NotFoundError("Question not found.");
 
-  const [questionScores, answerScores] = await Promise.all([
-    voteScoresFor("question", [q.id]),
-    voteScoresFor(
-      "answer",
-      q.answers.map((a) => a.id),
-    ),
-  ]);
+  const answerIds = q.answers.map((a) => a.id);
+
+  const [questionScores, answerScores, viewerQuestionVotes, viewerAnswerVotes] =
+    await Promise.all([
+      voteScoresFor("question", [q.id]),
+      voteScoresFor("answer", answerIds),
+      viewerUserId
+        ? viewerVotesFor("question", [q.id], viewerUserId)
+        : Promise.resolve(new Map<string, 1>()),
+      viewerUserId
+        ? viewerVotesFor("answer", answerIds, viewerUserId)
+        : Promise.resolve(new Map<string, 1>()),
+    ]);
 
   return {
     ...q,
     voteScore: questionScores.get(q.id) ?? 0,
+    viewerVote: viewerQuestionVotes.get(q.id) ?? null,
     answers: q.answers.map((a) => ({
       id: a.id,
       body: a.body,
@@ -131,6 +134,7 @@ export async function getQuestionById(id: string): Promise<QuestionDetail> {
       updatedAt: a.updatedAt,
       author: a.author,
       voteScore: answerScores.get(a.id) ?? 0,
+      viewerVote: viewerAnswerVotes.get(a.id) ?? null,
     })),
   };
 }

--- a/src/lib/validation/votes.ts
+++ b/src/lib/validation/votes.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const voteTargetTypeSchema = z.enum(["question", "answer"]);
+
+export const voteInputSchema = z.object({
+  targetType: voteTargetTypeSchema,
+  targetId: z.string().min(1, "targetId is required."),
+  value: z.literal(1),
+});
+
+export type VoteInput = z.input<typeof voteInputSchema>;

--- a/src/lib/votes.test.ts
+++ b/src/lib/votes.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Vote service tests.
+ *
+ * Real-DB pattern: a throw-away SQLite file initialised by `prisma migrate deploy`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-votes-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { applyToGroup, AuthorizationError, NotFoundError } = await import(
+  "./memberships"
+);
+const { castVote, viewerVotesFor, voteScoresFor } = await import("./votes");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com` } });
+}
+
+async function setupGroupWithQuestion(autoApprove = true) {
+  const author = await makeUser("author");
+  const group = await createGroup(
+    { name: "G", slug: uniq("g"), autoApprove },
+    author.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: author.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+  return { author, group, question };
+}
+
+describe("castVote on questions", () => {
+  it("creates a vote and returns voted=true with incremented score", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const voter = await makeUser("voter");
+    await applyToGroup(group.id, voter.id);
+
+    const result = await castVote(
+      { targetType: "question", targetId: question.id },
+      voter.id,
+    );
+
+    expect(result.voted).toBe(true);
+    expect(result.voteScore).toBe(1);
+    expect(result.targetType).toBe("question");
+    expect(result.targetId).toBe(question.id);
+
+    const stored = await db.vote.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: voter.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+    });
+    expect(stored).not.toBeNull();
+    expect(stored!.value).toBe(1);
+  });
+
+  it("toggles off on second call and returns voted=false", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const voter = await makeUser("toggler");
+    await applyToGroup(group.id, voter.id);
+
+    await castVote({ targetType: "question", targetId: question.id }, voter.id);
+    const second = await castVote(
+      { targetType: "question", targetId: question.id },
+      voter.id,
+    );
+
+    expect(second.voted).toBe(false);
+    expect(second.voteScore).toBe(0);
+
+    const stored = await db.vote.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: voter.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+    });
+    expect(stored).toBeNull();
+  });
+
+  it("rejects self-vote on own question", async () => {
+    const { author, question } = await setupGroupWithQuestion();
+    await expect(
+      castVote({ targetType: "question", targetId: question.id }, author.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("rejects votes from non-members", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const stranger = await makeUser("stranger");
+    await expect(
+      castVote({ targetType: "question", targetId: question.id }, stranger.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("rejects votes from pending applicants", async () => {
+    const { group, question } = await setupGroupWithQuestion(false);
+    const pending = await makeUser("pending");
+    await applyToGroup(group.id, pending.id);
+    await expect(
+      castVote({ targetType: "question", targetId: question.id }, pending.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws NotFoundError for unknown question id", async () => {
+    const voter = await makeUser("v404");
+    await expect(
+      castVote(
+        { targetType: "question", targetId: "does-not-exist" },
+        voter.id,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("castVote on answers", () => {
+  it("resolves the answer's group via question and records the vote", async () => {
+    const { author, group, question } = await setupGroupWithQuestion();
+    const answerer = await makeUser("answerer");
+    await applyToGroup(group.id, answerer.id);
+    const answer = await db.answer.create({
+      data: { questionId: question.id, authorId: answerer.id, body: "ans" },
+    });
+
+    // Author of the question (not the answer) votes on the answer.
+    const result = await castVote(
+      { targetType: "answer", targetId: answer.id },
+      author.id,
+    );
+
+    expect(result.voted).toBe(true);
+    expect(result.voteScore).toBe(1);
+  });
+
+  it("rejects self-vote on own answer", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const answerer = await makeUser("self-ans");
+    await applyToGroup(group.id, answerer.id);
+    const answer = await db.answer.create({
+      data: { questionId: question.id, authorId: answerer.id, body: "mine" },
+    });
+    await expect(
+      castVote({ targetType: "answer", targetId: answer.id }, answerer.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws NotFoundError for unknown answer id", async () => {
+    const voter = await makeUser("va404");
+    await expect(
+      castVote(
+        { targetType: "answer", targetId: "does-not-exist" },
+        voter.id,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("voteScoresFor", () => {
+  it("returns an empty map when no ids are supplied", async () => {
+    const map = await voteScoresFor("question", []);
+    expect(map.size).toBe(0);
+  });
+
+  it("sums values per target", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const v1 = await makeUser("vs1");
+    const v2 = await makeUser("vs2");
+    await applyToGroup(group.id, v1.id);
+    await applyToGroup(group.id, v2.id);
+    await castVote({ targetType: "question", targetId: question.id }, v1.id);
+    await castVote({ targetType: "question", targetId: question.id }, v2.id);
+
+    const map = await voteScoresFor("question", [question.id]);
+    expect(map.get(question.id)).toBe(2);
+  });
+});
+
+describe("viewerVotesFor", () => {
+  it("returns only the supplied user's votes", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const me = await makeUser("me");
+    const other = await makeUser("other");
+    await applyToGroup(group.id, me.id);
+    await applyToGroup(group.id, other.id);
+    await castVote({ targetType: "question", targetId: question.id }, other.id);
+
+    const beforeMe = await viewerVotesFor("question", [question.id], me.id);
+    expect(beforeMe.size).toBe(0);
+
+    await castVote({ targetType: "question", targetId: question.id }, me.id);
+    const afterMe = await viewerVotesFor("question", [question.id], me.id);
+    expect(afterMe.get(question.id)).toBe(1);
+
+    const otherMap = await viewerVotesFor("question", [question.id], other.id);
+    expect(otherMap.get(question.id)).toBe(1);
+  });
+});

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -1,0 +1,134 @@
+import "server-only";
+import { Prisma, type TargetType } from "@prisma/client";
+import { db } from "@/lib/db";
+import {
+  AuthorizationError,
+  NotFoundError,
+  assertApprovedMember,
+} from "@/lib/memberships";
+
+export type VoteTargetType = TargetType;
+
+export type CastVoteResult = {
+  voted: boolean;
+  voteScore: number;
+  targetType: VoteTargetType;
+  targetId: string;
+};
+
+export async function voteScoresFor(
+  targetType: VoteTargetType,
+  ids: string[],
+): Promise<Map<string, number>> {
+  if (ids.length === 0) return new Map<string, number>();
+  const rows = await db.vote.groupBy({
+    by: ["targetId"],
+    where: { targetType, targetId: { in: ids } },
+    _sum: { value: true },
+  });
+  return new Map(rows.map((r) => [r.targetId, r._sum.value ?? 0]));
+}
+
+export async function viewerVotesFor(
+  targetType: VoteTargetType,
+  ids: string[],
+  userId: string,
+): Promise<Map<string, 1>> {
+  if (ids.length === 0) return new Map<string, 1>();
+  const rows = await db.vote.findMany({
+    where: { userId, targetType, targetId: { in: ids } },
+    select: { targetId: true, value: true },
+  });
+  const out = new Map<string, 1>();
+  for (const r of rows) {
+    if (r.value === 1) out.set(r.targetId, 1);
+  }
+  return out;
+}
+
+async function resolveTarget(
+  targetType: VoteTargetType,
+  targetId: string,
+): Promise<{ groupId: string; authorId: string }> {
+  if (targetType === "question") {
+    const q = await db.question.findUnique({
+      where: { id: targetId },
+      select: { groupId: true, authorId: true },
+    });
+    if (!q) throw new NotFoundError("Question not found.");
+    return q;
+  }
+  const a = await db.answer.findUnique({
+    where: { id: targetId },
+    select: {
+      authorId: true,
+      question: { select: { groupId: true } },
+    },
+  });
+  if (!a) throw new NotFoundError("Answer not found.");
+  return { groupId: a.question.groupId, authorId: a.authorId };
+}
+
+export async function castVote(
+  input: { targetType: VoteTargetType; targetId: string },
+  userId: string,
+): Promise<CastVoteResult> {
+  const { groupId, authorId } = await resolveTarget(input.targetType, input.targetId);
+  if (authorId === userId) {
+    throw new AuthorizationError("You cannot vote on your own content.");
+  }
+  await assertApprovedMember(groupId, userId);
+
+  const existing = await db.vote.findUnique({
+    where: {
+      userId_targetType_targetId: {
+        userId,
+        targetType: input.targetType,
+        targetId: input.targetId,
+      },
+    },
+    select: { id: true },
+  });
+
+  let voted: boolean;
+  if (existing) {
+    try {
+      await db.vote.delete({ where: { id: existing.id } });
+    } catch (err) {
+      // P2025: row already removed by a concurrent request — same outcome.
+      if (
+        !(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025")
+      ) {
+        throw err;
+      }
+    }
+    voted = false;
+  } else {
+    try {
+      await db.vote.create({
+        data: {
+          userId,
+          targetType: input.targetType,
+          targetId: input.targetId,
+          value: 1,
+        },
+      });
+    } catch (err) {
+      // P2002: a concurrent request inserted the same vote — same outcome.
+      if (
+        !(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")
+      ) {
+        throw err;
+      }
+    }
+    voted = true;
+  }
+
+  const scores = await voteScoresFor(input.targetType, [input.targetId]);
+  return {
+    voted,
+    voteScore: scores.get(input.targetId) ?? 0,
+    targetType: input.targetType,
+    targetId: input.targetId,
+  };
+}


### PR DESCRIPTION
## Summary
- New `POST /api/votes` toggles a `Vote` row (positive-only, `value=1`) and returns the recomputed score; rejects self-votes and non-approved-member callers.
- `getQuestionById` now accepts a viewer id and returns `viewerVote: 1 | null` on the question and each answer, so the detail page renders interactive up-arrow buttons reflecting current vote state.
- New `VoteButton` client component (optimistic update with rollback) calls a `voteAction` server action that wraps the same `castVote` lib as the API route — single source of truth for the write path.
- Closes #11. Downvotes remain out of scope per the issue.

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (201/201 passing — 12 new lib tests, 10 new route tests, 3 new viewerVote cases)
- [ ] Manual: sign in as User A, click up-arrow on a question authored by User B → score increments and button shows pressed; click again → toggles off; verify button is disabled with tooltip on own content and when signed-out / not an approved member

🤖 Generated with [Claude Code](https://claude.com/claude-code)