### PR TITLE
feat(qa): mark a question as answered (closes #12)

### DIFF
--- a/src/app/api/questions/[id]/accept/route.test.ts
+++ b/src/app/api/questions/[id]/accept/route.test.ts
@@ -1,0 +1,267 @@
+/**
+ * POST /api/questions/[id]/accept route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-accept-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function jsonReq(url: string, body?: unknown): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+type Setup = {
+  groupId: string;
+  questionId: string;
+  ownerId: string;
+  authorId: string;
+  answerId: string;
+  answerAuthorId: string;
+};
+
+async function setupQuestion(slug: string): Promise<Setup> {
+  const ownerEmail = `o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+
+  cookieStore.clear();
+  const authorEmail = `a-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(authorEmail);
+  const authorSess = (await auth.getSession())!;
+  await applyToGroup(group.id, authorSess.user.id);
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: authorSess.user.id,
+      title: "Seed question for accept tests",
+      body: "Seed body",
+    },
+  });
+
+  cookieStore.clear();
+  const ansAuthorEmail = `aa-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(ansAuthorEmail);
+  const ansSess = (await auth.getSession())!;
+  await applyToGroup(group.id, ansSess.user.id);
+  const answer = await db.answer.create({
+    data: {
+      questionId: question.id,
+      authorId: ansSess.user.id,
+      body: "Seed answer body.",
+    },
+  });
+
+  cookieStore.clear();
+  return {
+    groupId: group.id,
+    questionId: question.id,
+    ownerId: ownerSess.user.id,
+    authorId: authorSess.user.id,
+    answerId: answer.id,
+    answerAuthorId: ansSess.user.id,
+  };
+}
+
+async function signInAs(userId: string): Promise<void> {
+  cookieStore.clear();
+  const u = await db.user.findUnique({ where: { id: userId } });
+  await auth.signIn(u!.email!);
+}
+
+describe("POST /api/questions/[id]/accept", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(jsonReq("http://x/api/questions/abc/accept"), ctx("abc"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when question is unknown", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await POST(
+      jsonReq("http://x/api/questions/missing/accept"),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is a plain approved member", async () => {
+    const setup = await setupQuestion(`acc1-${Date.now()}`);
+    await auth.signIn(`pm-${Date.now()}-${Math.random()}@example.com`);
+    const session = (await auth.getSession())!;
+    await applyToGroup(setup.groupId, session.user.id);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when caller is not a member of the group", async () => {
+    const setup = await setupQuestion(`acc2-${Date.now()}`);
+    await auth.signIn(`stranger-${Date.now()}-${Math.random()}@example.com`);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 and flips status when caller is the question author (no answerId)", async () => {
+    const setup = await setupQuestion(`acc3-${Date.now()}`);
+    await signInAs(setup.authorId);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.question.status).toBe("answered");
+    expect(json.question.acceptedAnswerId).toBeNull();
+
+    const after = await db.question.findUnique({ where: { id: setup.questionId } });
+    expect(after!.status).toBe("answered");
+    expect(after!.acceptedAnswerId).toBeNull();
+  });
+
+  it("returns 200 and pins acceptedAnswerId when caller is the author and provides answerId", async () => {
+    const setup = await setupQuestion(`acc4-${Date.now()}`);
+    await signInAs(setup.authorId);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`, {
+        answerId: setup.answerId,
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.question.status).toBe("answered");
+    expect(json.question.acceptedAnswerId).toBe(setup.answerId);
+
+    const after = await db.question.findUnique({ where: { id: setup.questionId } });
+    expect(after!.acceptedAnswerId).toBe(setup.answerId);
+  });
+
+  it("returns 200 when caller is the group owner", async () => {
+    const setup = await setupQuestion(`acc5-${Date.now()}`);
+    await signInAs(setup.ownerId);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`, {
+        answerId: setup.answerId,
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 when caller is a moderator", async () => {
+    const setup = await setupQuestion(`acc6-${Date.now()}`);
+    await auth.signIn(`mod-${Date.now()}-${Math.random()}@example.com`);
+    const modSess = (await auth.getSession())!;
+    await db.membership.create({
+      data: {
+        groupId: setup.groupId,
+        userId: modSess.user.id,
+        role: "moderator",
+        status: "approved",
+      },
+    });
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${setup.questionId}/accept`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when answerId belongs to a different question", async () => {
+    const a = await setupQuestion(`acc7a-${Date.now()}`);
+    const b = await setupQuestion(`acc7b-${Date.now()}`);
+    await signInAs(a.authorId);
+
+    const res = await POST(
+      jsonReq(`http://x/api/questions/${a.questionId}/accept`, {
+        answerId: b.answerId,
+      }),
+      ctx(a.questionId),
+    );
+    expect(res.status).toBe(404);
+
+    const after = await db.question.findUnique({ where: { id: a.questionId } });
+    expect(after!.status).toBe("open");
+    expect(after!.acceptedAnswerId).toBeNull();
+  });
+});

--- a/src/app/api/questions/[id]/accept/route.ts
+++ b/src/app/api/questions/[id]/accept/route.ts
@@ -1,0 +1,39 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { acceptAnswer } from "@/lib/questions";
+import { acceptQuestionSchema } from "@/lib/validation/questions";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown = {};
+  const text = await req.text();
+  if (text.length > 0) {
+    try {
+      raw = JSON.parse(text);
+    } catch {
+      return Response.json(
+        { error: "ValidationError", message: "Body must be valid JSON." },
+        { status: 400 },
+      );
+    }
+  }
+
+  const parsed = acceptQuestionSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const question = await acceptAnswer(
+      id,
+      parsed.data.answerId ?? null,
+      session.user.id,
+    );
+    return Response.json({ question }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/questions/[id]/reopen/route.test.ts
+++ b/src/app/api/questions/[id]/reopen/route.test.ts
@@ -1,0 +1,230 @@
+/**
+ * POST /api/questions/[id]/reopen route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-reopen-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function postReq(url: string): Request {
+  return new Request(url, { method: "POST" });
+}
+
+type Setup = {
+  groupId: string;
+  questionId: string;
+  ownerId: string;
+  authorId: string;
+  answerId: string;
+};
+
+async function setupAcceptedQuestion(slug: string): Promise<Setup> {
+  const ownerEmail = `o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+
+  cookieStore.clear();
+  const authorEmail = `a-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(authorEmail);
+  const authorSess = (await auth.getSession())!;
+  await applyToGroup(group.id, authorSess.user.id);
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: authorSess.user.id,
+      title: "Seed question for reopen tests",
+      body: "Seed body",
+    },
+  });
+
+  cookieStore.clear();
+  const ansAuthorEmail = `aa-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(ansAuthorEmail);
+  const ansSess = (await auth.getSession())!;
+  await applyToGroup(group.id, ansSess.user.id);
+  const answer = await db.answer.create({
+    data: {
+      questionId: question.id,
+      authorId: ansSess.user.id,
+      body: "Seed answer body.",
+    },
+  });
+
+  await db.question.update({
+    where: { id: question.id },
+    data: { status: "answered", acceptedAnswerId: answer.id },
+  });
+
+  cookieStore.clear();
+  return {
+    groupId: group.id,
+    questionId: question.id,
+    ownerId: ownerSess.user.id,
+    authorId: authorSess.user.id,
+    answerId: answer.id,
+  };
+}
+
+async function signInAs(userId: string): Promise<void> {
+  cookieStore.clear();
+  const u = await db.user.findUnique({ where: { id: userId } });
+  await auth.signIn(u!.email!);
+}
+
+describe("POST /api/questions/[id]/reopen", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(postReq("http://x/api/questions/abc/reopen"), ctx("abc"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when question is unknown", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await POST(
+      postReq("http://x/api/questions/missing/reopen"),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is a plain approved member", async () => {
+    const setup = await setupAcceptedQuestion(`reo1-${Date.now()}`);
+    await auth.signIn(`pm-${Date.now()}-${Math.random()}@example.com`);
+    const session = (await auth.getSession())!;
+    await applyToGroup(setup.groupId, session.user.id);
+
+    const res = await POST(
+      postReq(`http://x/api/questions/${setup.questionId}/reopen`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(403);
+
+    const after = await db.question.findUnique({ where: { id: setup.questionId } });
+    expect(after!.status).toBe("answered");
+  });
+
+  it("returns 403 when caller is not a member of the group", async () => {
+    const setup = await setupAcceptedQuestion(`reo2-${Date.now()}`);
+    await auth.signIn(`stranger-${Date.now()}-${Math.random()}@example.com`);
+
+    const res = await POST(
+      postReq(`http://x/api/questions/${setup.questionId}/reopen`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 and clears state when caller is the question author", async () => {
+    const setup = await setupAcceptedQuestion(`reo3-${Date.now()}`);
+    await signInAs(setup.authorId);
+
+    const res = await POST(
+      postReq(`http://x/api/questions/${setup.questionId}/reopen`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.question.status).toBe("open");
+    expect(json.question.acceptedAnswerId).toBeNull();
+
+    const after = await db.question.findUnique({ where: { id: setup.questionId } });
+    expect(after!.status).toBe("open");
+    expect(after!.acceptedAnswerId).toBeNull();
+  });
+
+  it("returns 200 when caller is the group owner", async () => {
+    const setup = await setupAcceptedQuestion(`reo4-${Date.now()}`);
+    await signInAs(setup.ownerId);
+
+    const res = await POST(
+      postReq(`http://x/api/questions/${setup.questionId}/reopen`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 when caller is a moderator", async () => {
+    const setup = await setupAcceptedQuestion(`reo5-${Date.now()}`);
+    await auth.signIn(`mod-${Date.now()}-${Math.random()}@example.com`);
+    const modSess = (await auth.getSession())!;
+    await db.membership.create({
+      data: {
+        groupId: setup.groupId,
+        userId: modSess.user.id,
+        role: "moderator",
+        status: "approved",
+      },
+    });
+
+    const res = await POST(
+      postReq(`http://x/api/questions/${setup.questionId}/reopen`),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/questions/[id]/reopen/route.ts
+++ b/src/app/api/questions/[id]/reopen/route.ts
@@ -1,0 +1,18 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { reopenQuestion } from "@/lib/questions";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(_req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const question = await reopenQuestion(id, session.user.id);
+    return Response.json({ question }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/q/[id]/accept-answer-button.tsx
+++ b/src/app/q/[id]/accept-answer-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { acceptAnswerAction } from "./actions";
+
+type Props = {
+  questionId: string;
+  answerId: string;
+};
+
+export function AcceptAnswerButton({ questionId, answerId }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await acceptAnswerAction(questionId, answerId);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="text-xs text-green-700 underline hover:text-green-800 disabled:opacity-60 dark:text-green-400 dark:hover:text-green-300"
+      >
+        {pending ? "Accepting…" : "Accept this answer"}
+      </button>
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -12,6 +12,7 @@ import {
   deleteAnswer,
   updateAnswer,
 } from "@/lib/answers";
+import { acceptAnswer, reopenQuestion } from "@/lib/questions";
 import { db } from "@/lib/db";
 import {
   createAnswerSchema,
@@ -114,6 +115,67 @@ export async function updateAnswerAction(
     return {
       error: err instanceof Error ? err.message : "Could not update answer.",
       values: raw,
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export type ResolveQuestionResult = { error?: string; ok?: boolean };
+
+export async function acceptAnswerAction(
+  questionId: string,
+  answerId: string | null,
+): Promise<ResolveQuestionResult> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to mark a question as answered." };
+  }
+
+  try {
+    await acceptAnswer(questionId, answerId, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return {
+        error:
+          "Only the question's author or a group moderator/owner can mark this question as answered.",
+      };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not mark question as answered.",
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export async function reopenQuestionAction(
+  questionId: string,
+): Promise<ResolveQuestionResult> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to reopen a question." };
+  }
+
+  try {
+    await reopenQuestion(questionId, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return {
+        error:
+          "Only the question's author or a group moderator/owner can reopen this question.",
+      };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not reopen question.",
     };
   }
 

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -8,6 +8,8 @@ import { getQuestionById } from "@/lib/questions";
 import { AnswerForm } from "./answer-form";
 import { AnswerActions } from "./answer-actions";
 import { VoteButton } from "./vote-button";
+import { QuestionResolveControls } from "./question-resolve-controls";
+import { AcceptAnswerButton } from "./accept-answer-button";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -33,9 +35,13 @@ export default async function QuestionDetailPage({ params }: Props) {
     ? await getMembership(question.group.id, currentUserId)
     : null;
   const isApprovedViewer = viewerMembership?.status === "approved";
-  const canDeleteAny =
+  const isModOrOwner =
     isApprovedViewer &&
     (viewerMembership?.role === "owner" || viewerMembership?.role === "moderator");
+  const canDeleteAny = isModOrOwner;
+  const canResolve =
+    currentUserId !== null &&
+    (question.author.id === currentUserId || isModOrOwner);
 
   const voteDisabledReason = !currentUserId
     ? "Sign in to vote."
@@ -53,7 +59,14 @@ export default async function QuestionDetailPage({ params }: Props) {
     <div className="mx-auto max-w-3xl space-y-4 py-8">
       <Card>
         <CardHeader className="border-b">
-          <CardTitle className="text-2xl">{question.title}</CardTitle>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="text-2xl">{question.title}</CardTitle>
+            <QuestionResolveControls
+              questionId={question.id}
+              status={question.status}
+              canResolve={canResolve}
+            />
+          </div>
           <p className="mt-1 text-xs text-muted-foreground">
             Asked by {authorLabel(question.author)} in{" "}
             <Link href={`/groups/${question.group.slug}`} className="underline">
@@ -96,10 +109,25 @@ export default async function QuestionDetailPage({ params }: Props) {
               const answerVoteDisabledReason = isOwnAnswer
                 ? "You cannot vote on your own answer."
                 : voteDisabledReason;
+              const isAccepted = a.id === question.acceptedAnswerId;
+              const showAcceptButton = canResolve && !isAccepted;
               return (
                 <li key={a.id}>
-                  <Card>
+                  <Card
+                    className={
+                      isAccepted
+                        ? "border-green-600/60 bg-green-50/40 dark:border-green-500/50 dark:bg-green-950/20"
+                        : undefined
+                    }
+                  >
                     <CardContent className="space-y-2 pt-4">
+                      {isAccepted ? (
+                        <div className="flex items-center gap-2">
+                          <span className="inline-flex items-center rounded-full border border-green-600/40 bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-300">
+                            ✓ Accepted answer
+                          </span>
+                        </div>
+                      ) : null}
                       <div className="flex items-center gap-3">
                         <VoteButton
                           targetType="answer"
@@ -113,6 +141,12 @@ export default async function QuestionDetailPage({ params }: Props) {
                         <p className="text-xs text-muted-foreground">
                           {authorLabel(a.author)}
                         </p>
+                        {showAcceptButton ? (
+                          <AcceptAnswerButton
+                            questionId={question.id}
+                            answerId={a.id}
+                          />
+                        ) : null}
                       </div>
                       <AnswerActions
                         answerId={a.id}

--- a/src/app/q/[id]/question-resolve-controls.tsx
+++ b/src/app/q/[id]/question-resolve-controls.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { acceptAnswerAction, reopenQuestionAction } from "./actions";
+
+type Props = {
+  questionId: string;
+  status: "open" | "answered";
+  canResolve: boolean;
+};
+
+export function QuestionResolveControls({
+  questionId,
+  status,
+  canResolve,
+}: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (status === "answered" && !canResolve) {
+    return (
+      <span className="inline-flex items-center rounded-full border border-green-600/40 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-300">
+        Answered
+      </span>
+    );
+  }
+
+  if (!canResolve) return null;
+
+  const onMarkAnswered = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await acceptAnswerAction(questionId, null);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  const onReopen = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await reopenQuestionAction(questionId);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      {status === "answered" ? (
+        <>
+          <span className="inline-flex items-center rounded-full border border-green-600/40 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-300">
+            Answered
+          </span>
+          <button
+            type="button"
+            onClick={onReopen}
+            disabled={pending}
+            className="text-xs text-zinc-600 underline hover:text-zinc-900 disabled:opacity-60 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            {pending ? "Reopening…" : "Reopen"}
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={onMarkAnswered}
+          disabled={pending}
+          className="rounded border border-zinc-300 px-2.5 py-1 text-xs font-medium hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          {pending ? "Saving…" : "Mark as answered"}
+        </button>
+      )}
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,7 +1,11 @@
 import "server-only";
 import type { Answer, Question, User } from "@prisma/client";
 import { db } from "@/lib/db";
-import { NotFoundError } from "@/lib/memberships";
+import {
+  AuthorizationError,
+  NotFoundError,
+  isOwnerOrModerator,
+} from "@/lib/memberships";
 import { viewerVotesFor, voteScoresFor } from "@/lib/votes";
 import type { CreateQuestionInput } from "@/lib/validation/questions";
 
@@ -123,18 +127,86 @@ export async function getQuestionById(
         : Promise.resolve(new Map<string, 1>()),
     ]);
 
+  const mappedAnswers = q.answers.map((a) => ({
+    id: a.id,
+    body: a.body,
+    createdAt: a.createdAt,
+    updatedAt: a.updatedAt,
+    author: a.author,
+    voteScore: answerScores.get(a.id) ?? 0,
+    viewerVote: viewerAnswerVotes.get(a.id) ?? null,
+  }));
+  const acceptedId = q.acceptedAnswerId;
+  const sortedAnswers = acceptedId
+    ? [...mappedAnswers].sort((a, b) => {
+        if (a.id === acceptedId) return -1;
+        if (b.id === acceptedId) return 1;
+        return 0;
+      })
+    : mappedAnswers;
+
   return {
     ...q,
     voteScore: questionScores.get(q.id) ?? 0,
     viewerVote: viewerQuestionVotes.get(q.id) ?? null,
-    answers: q.answers.map((a) => ({
-      id: a.id,
-      body: a.body,
-      createdAt: a.createdAt,
-      updatedAt: a.updatedAt,
-      author: a.author,
-      voteScore: answerScores.get(a.id) ?? 0,
-      viewerVote: viewerAnswerVotes.get(a.id) ?? null,
-    })),
+    answers: sortedAnswers,
   };
+}
+
+async function assertCanResolveQuestion(
+  question: { authorId: string; groupId: string },
+  userId: string,
+): Promise<void> {
+  if (question.authorId === userId) return;
+  if (await isOwnerOrModerator(question.groupId, userId)) return;
+  throw new AuthorizationError(
+    "Only the question's author or a group moderator/owner can resolve this question.",
+  );
+}
+
+export async function acceptAnswer(
+  questionId: string,
+  answerId: string | null,
+  userId: string,
+): Promise<Question> {
+  const question = await db.question.findUnique({
+    where: { id: questionId },
+    select: { id: true, authorId: true, groupId: true },
+  });
+  if (!question) throw new NotFoundError("Question not found.");
+
+  await assertCanResolveQuestion(question, userId);
+
+  if (answerId) {
+    const answer = await db.answer.findUnique({
+      where: { id: answerId },
+      select: { id: true, questionId: true },
+    });
+    if (!answer || answer.questionId !== questionId) {
+      throw new NotFoundError("Answer not found for this question.");
+    }
+  }
+
+  return db.question.update({
+    where: { id: questionId },
+    data: { status: "answered", acceptedAnswerId: answerId },
+  });
+}
+
+export async function reopenQuestion(
+  questionId: string,
+  userId: string,
+): Promise<Question> {
+  const question = await db.question.findUnique({
+    where: { id: questionId },
+    select: { id: true, authorId: true, groupId: true },
+  });
+  if (!question) throw new NotFoundError("Question not found.");
+
+  await assertCanResolveQuestion(question, userId);
+
+  return db.question.update({
+    where: { id: questionId },
+    data: { status: "open", acceptedAnswerId: null },
+  });
 }

--- a/src/lib/validation/questions.ts
+++ b/src/lib/validation/questions.ts
@@ -25,3 +25,9 @@ export const questionListQuerySchema = z.object({
 });
 
 export type QuestionListQuery = z.input<typeof questionListQuerySchema>;
+
+export const acceptQuestionSchema = z.object({
+  answerId: z.string().min(1).optional().nullable(),
+});
+
+export type AcceptQuestionInput = z.input<typeof acceptQuestionSchema>;


### PR DESCRIPTION
## Summary
- Add `POST /api/questions/:id/accept` (optional `answerId`) and `/reopen` routes, backed by `acceptAnswer`/`reopenQuestion` lib functions that enforce author-or-mod/owner authorization.
- Surface "Mark as answered"/"Reopen" controls on the question and per-answer "Accept this answer" buttons to authorized viewers; the accepted answer renders with a green badge and is pinned to the top.
- Cover the new endpoints with route tests (401/403/404/200) for author, owner, moderator, plain member, and non-member callers, including foreign-`answerId` and reopen-clears-state cases.

## Test plan
- [x] \`npm test\` (217 tests pass, including 16 new)
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [ ] Manual smoke in \`npm run dev\`: author marks/reopens, mod accepts a specific answer, plain member sees no controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)