### PR TITLE
feat(profile): add /me and /u/[userId] profile pages (closes #14)

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ProfileAnswerList } from "@/components/profile/profile-answer-list";
+import { ProfileFavoriteList } from "@/components/profile/profile-favorite-list";
+import { ProfileGroupList } from "@/components/profile/profile-group-list";
+import { ProfileQuestionList } from "@/components/profile/profile-question-list";
+import { requireAuth } from "@/lib/auth";
+import {
+  listAnswersByAuthor,
+  listFavoritesByUser,
+  listGroupsForUser,
+  listQuestionsByAuthor,
+} from "@/lib/profile";
+
+const PAGE_SIZE = 20;
+
+export default async function MePage() {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const [questions, answers, groups, favorites] = await Promise.all([
+    listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listGroupsForUser(userId, { includePending: true }),
+    listFavoritesByUser(userId),
+  ]);
+
+  const display = session.user.name?.trim() || session.user.email;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-xl">{display}</CardTitle>
+          <CardDescription>
+            <span>{session.user.email}</span>
+            {" · "}
+            <span className="font-mono text-xs">{session.user.id}</span>
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Your questions {questions.total > 0 ? `(${questions.total})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileQuestionList
+            items={questions.items}
+            emptyState={
+              <>
+                You haven&rsquo;t asked any questions yet.{" "}
+                <Link href="/groups" className="underline">
+                  Browse groups
+                </Link>{" "}
+                to get started.
+              </>
+            }
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Your answers {answers.total > 0 ? `(${answers.total})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileAnswerList
+            items={answers.items}
+            emptyState="You haven't posted any answers yet."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Favorites {favorites.length > 0 ? `(${favorites.length})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileFavoriteList
+            items={favorites}
+            emptyState="You haven't favorited anything yet."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Your groups {groups.length > 0 ? `(${groups.length})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileGroupList
+            items={groups}
+            viewer="self"
+            emptyState={
+              <>
+                You&rsquo;re not in any groups yet.{" "}
+                <Link href="/groups" className="underline">
+                  Browse groups
+                </Link>
+                .
+              </>
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -1,0 +1,101 @@
+import { notFound } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ProfileAnswerList } from "@/components/profile/profile-answer-list";
+import { ProfileGroupList } from "@/components/profile/profile-group-list";
+import { ProfileQuestionList } from "@/components/profile/profile-question-list";
+import {
+  getPublicUserProfile,
+  listAnswersByAuthor,
+  listGroupsForUser,
+  listQuestionsByAuthor,
+} from "@/lib/profile";
+
+const PAGE_SIZE = 20;
+
+type Props = { params: Promise<{ userId: string }> };
+
+export default async function PublicProfilePage({ params }: Props) {
+  const { userId } = await params;
+  const profile = await getPublicUserProfile(userId);
+  if (!profile) notFound();
+
+  const [questions, answers, groups] = await Promise.all([
+    listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listGroupsForUser(userId, { includePending: false }),
+  ]);
+
+  const display = profile.name?.trim() || "Anonymous user";
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-xl">{display}</CardTitle>
+          <CardDescription>
+            <span>
+              {questions.total} {questions.total === 1 ? "question" : "questions"}
+            </span>
+            {" · "}
+            <span>
+              {answers.total} {answers.total === 1 ? "answer" : "answers"}
+            </span>
+            {" · "}
+            <span>
+              {groups.length} {groups.length === 1 ? "group" : "groups"}
+            </span>
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Questions {questions.total > 0 ? `(${questions.total})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileQuestionList
+            items={questions.items}
+            emptyState="No questions yet."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Answers {answers.total > 0 ? `(${answers.total})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileAnswerList
+            items={answers.items}
+            emptyState="No answers yet."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Groups {groups.length > 0 ? `(${groups.length})` : ""}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileGroupList
+            items={groups}
+            viewer="public"
+            emptyState="Not a member of any groups yet."
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -67,6 +67,7 @@ export function UserMenu() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem render={<Link href="/me" />}>Your profile</DropdownMenuItem>
         <DropdownMenuItem render={<Link href="/account" />}>Account</DropdownMenuItem>
         <DropdownMenuSeparator />
         <form action={signOutAction}>

--- a/src/components/profile/profile-answer-list.tsx
+++ b/src/components/profile/profile-answer-list.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import type { ProfileAnswerItem } from "@/lib/profile";
+
+type Props = {
+  items: ProfileAnswerItem[];
+  emptyState: React.ReactNode;
+};
+
+export function ProfileAnswerList({ items, emptyState }: Props) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyState}</p>;
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {items.map((a) => (
+        <li key={a.id} className="py-3 first:pt-0 last:pb-0">
+          <Link
+            href={`/q/${a.question.id}`}
+            className="text-sm font-medium hover:underline"
+          >
+            {a.question.title}
+          </Link>
+          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            {a.bodyExcerpt}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <Link
+              href={`/groups/${a.question.group.slug}`}
+              className="hover:underline"
+            >
+              {a.question.group.name}
+            </Link>
+            {" · Score "}
+            {a.voteScore}
+            {a.isAccepted ? (
+              <>
+                {" · "}
+                <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">
+                  accepted
+                </span>
+              </>
+            ) : null}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/profile/profile-favorite-list.tsx
+++ b/src/components/profile/profile-favorite-list.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import type { ProfileFavoriteItem } from "@/lib/profile";
+
+type Props = {
+  items: ProfileFavoriteItem[];
+  emptyState: React.ReactNode;
+};
+
+export function ProfileFavoriteList({ items, emptyState }: Props) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyState}</p>;
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {items.map((f) =>
+        f.kind === "question" ? (
+          <li key={`q-${f.id}`} className="py-3 first:pt-0 last:pb-0">
+            <Link
+              href={`/q/${f.id}`}
+              className="text-sm font-medium hover:underline"
+            >
+              {f.title}
+            </Link>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Question in{" "}
+              <Link
+                href={`/groups/${f.groupSlug}`}
+                className="hover:underline"
+              >
+                {f.groupName}
+              </Link>
+            </p>
+          </li>
+        ) : (
+          <li key={`a-${f.id}`} className="py-3 first:pt-0 last:pb-0">
+            <Link
+              href={`/q/${f.questionId}`}
+              className="text-sm font-medium hover:underline"
+            >
+              {f.questionTitle}
+            </Link>
+            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+              {f.bodyExcerpt}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Answer favorite
+            </p>
+          </li>
+        ),
+      )}
+    </ul>
+  );
+}

--- a/src/components/profile/profile-group-list.tsx
+++ b/src/components/profile/profile-group-list.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { ProfileGroupItem } from "@/lib/profile";
+
+type Props = {
+  items: ProfileGroupItem[];
+  viewer: "self" | "public";
+  emptyState: React.ReactNode;
+};
+
+export function ProfileGroupList({ items, viewer, emptyState }: Props) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyState}</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {items.map((g) => (
+        <li key={g.id} className="flex items-center gap-2 text-sm">
+          <Link
+            href={`/groups/${g.slug}`}
+            className="font-medium hover:underline"
+          >
+            {g.name}
+          </Link>
+          <span className="font-mono text-xs text-muted-foreground">
+            {g.slug}
+          </span>
+          {g.role !== "member" ? (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {g.role}
+            </span>
+          ) : null}
+          {viewer === "self" && g.status !== "approved" ? (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+              {g.status}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/profile/profile-question-list.tsx
+++ b/src/components/profile/profile-question-list.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import type { ProfileQuestionItem } from "@/lib/profile";
+
+type Props = {
+  items: ProfileQuestionItem[];
+  emptyState: React.ReactNode;
+};
+
+export function ProfileQuestionList({ items, emptyState }: Props) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyState}</p>;
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {items.map((q) => (
+        <li key={q.id} className="py-3 first:pt-0 last:pb-0">
+          <Link
+            href={`/q/${q.id}`}
+            className="text-sm font-medium hover:underline"
+          >
+            {q.title}
+          </Link>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <Link
+              href={`/groups/${q.group.slug}`}
+              className="hover:underline"
+            >
+              {q.group.name}
+            </Link>
+            {" · "}
+            {q.answerCount} {q.answerCount === 1 ? "answer" : "answers"}
+            {" · Score "}
+            {q.voteScore}
+            {q.status === "answered" ? (
+              <>
+                {" · "}
+                <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  answered
+                </span>
+              </>
+            ) : null}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Profile service tests. Real-DB pattern (mirrors questions.test.ts).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-profile-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { applyToGroup } = await import("./memberships");
+const { createQuestion, acceptAnswer } = await import("./questions");
+const {
+  listQuestionsByAuthor,
+  listAnswersByAuthor,
+  listGroupsForUser,
+  listFavoritesByUser,
+  getPublicUserProfile,
+} = await import("./profile");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({
+    data: { email: `${uniq(label)}@example.com`, name: label },
+  });
+}
+
+describe("listQuestionsByAuthor", () => {
+  it("returns only this user's questions, newest first, with group + counts + score", async () => {
+    const author = await makeUser("qa-author");
+    const other = await makeUser("qa-other");
+    const group = await createGroup(
+      { name: "QA G", slug: uniq("qag"), autoApprove: true },
+      author.id,
+    );
+    await applyToGroup(group.id, other.id);
+
+    const q1 = await createQuestion(
+      { title: "First", body: "first body" },
+      group.id,
+      author.id,
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    const q2 = await createQuestion(
+      { title: "Second", body: "second body" },
+      group.id,
+      author.id,
+    );
+    // Other user's question must be excluded.
+    await createQuestion(
+      { title: "Theirs", body: "irrelevant" },
+      group.id,
+      other.id,
+    );
+
+    // q1 gets one answer + a vote.
+    await db.answer.create({
+      data: { questionId: q1.id, authorId: other.id, body: "answer" },
+    });
+    await db.vote.create({
+      data: { userId: other.id, targetType: "question", targetId: q1.id, value: 1 },
+    });
+
+    const page = await listQuestionsByAuthor(author.id, { page: 1, per: 20 });
+    expect(page.total).toBe(2);
+    expect(page.items.map((q) => q.id)).toEqual([q2.id, q1.id]);
+    const first = page.items[0]!;
+    expect(first.group.slug).toBe(group.slug);
+    expect(first.answerCount).toBe(0);
+    expect(first.voteScore).toBe(0);
+    const second = page.items[1]!;
+    expect(second.answerCount).toBe(1);
+    expect(second.voteScore).toBe(1);
+  });
+});
+
+describe("listAnswersByAuthor", () => {
+  it("returns user's answers across groups with question summary and score", async () => {
+    const answerer = await makeUser("ans-author");
+    const asker = await makeUser("ans-asker");
+    const groupA = await createGroup(
+      { name: "AA", slug: uniq("aa"), autoApprove: true },
+      asker.id,
+    );
+    const groupB = await createGroup(
+      { name: "BB", slug: uniq("bb"), autoApprove: true },
+      asker.id,
+    );
+    await applyToGroup(groupA.id, answerer.id);
+    await applyToGroup(groupB.id, answerer.id);
+
+    const qa = await createQuestion(
+      { title: "QA", body: "?" },
+      groupA.id,
+      asker.id,
+    );
+    const qb = await createQuestion(
+      { title: "QB", body: "?" },
+      groupB.id,
+      asker.id,
+    );
+
+    const aA = await db.answer.create({
+      data: { questionId: qa.id, authorId: answerer.id, body: "A answer" },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const aB = await db.answer.create({
+      data: { questionId: qb.id, authorId: answerer.id, body: "B answer" },
+    });
+
+    // Vote on aA, accept aB.
+    await db.vote.create({
+      data: { userId: asker.id, targetType: "answer", targetId: aA.id, value: 1 },
+    });
+    await acceptAnswer(qb.id, aB.id, asker.id);
+
+    const page = await listAnswersByAuthor(answerer.id, { page: 1, per: 20 });
+    expect(page.total).toBe(2);
+    // Newest first => aB before aA.
+    expect(page.items.map((a) => a.id)).toEqual([aB.id, aA.id]);
+
+    const first = page.items[0]!;
+    expect(first.isAccepted).toBe(true);
+    expect(first.question.title).toBe("QB");
+    expect(first.question.group.slug).toBe(groupB.slug);
+
+    const second = page.items[1]!;
+    expect(second.isAccepted).toBe(false);
+    expect(second.voteScore).toBe(1);
+  });
+
+  it("excludes answers authored by other users", async () => {
+    const me = await makeUser("ans-me");
+    const them = await makeUser("ans-them");
+    const group = await createGroup(
+      { name: "X", slug: uniq("ax"), autoApprove: true },
+      me.id,
+    );
+    await applyToGroup(group.id, them.id);
+    const q = await createQuestion(
+      { title: "T", body: "?" },
+      group.id,
+      me.id,
+    );
+    await db.answer.create({
+      data: { questionId: q.id, authorId: them.id, body: "theirs" },
+    });
+
+    const page = await listAnswersByAuthor(me.id, { page: 1, per: 20 });
+    expect(page.total).toBe(0);
+  });
+});
+
+describe("listGroupsForUser", () => {
+  it("excludes pending memberships when includePending is false", async () => {
+    const user = await makeUser("g-user");
+    const ownerA = await makeUser("g-ownerA");
+    const ownerB = await makeUser("g-ownerB");
+    const auto = await createGroup(
+      { name: "auto", slug: uniq("auto"), autoApprove: true },
+      ownerA.id,
+    );
+    const manual = await createGroup(
+      { name: "manual", slug: uniq("manual"), autoApprove: false },
+      ownerB.id,
+    );
+    await applyToGroup(auto.id, user.id); // approved
+    await applyToGroup(manual.id, user.id); // pending
+
+    const approved = await listGroupsForUser(user.id, { includePending: false });
+    expect(approved.map((g) => g.slug)).toEqual([auto.slug]);
+
+    const all = await listGroupsForUser(user.id, { includePending: true });
+    expect(all.map((g) => g.slug).sort()).toEqual([auto.slug, manual.slug].sort());
+    const manualEntry = all.find((g) => g.slug === manual.slug)!;
+    expect(manualEntry.status).toBe("pending");
+  });
+
+  it("returns owned groups with role=owner", async () => {
+    const owner = await makeUser("g-owner");
+    const group = await createGroup(
+      { name: "owned", slug: uniq("owned"), autoApprove: false },
+      owner.id,
+    );
+    const groups = await listGroupsForUser(owner.id, { includePending: false });
+    const entry = groups.find((g) => g.slug === group.slug)!;
+    expect(entry.role).toBe("owner");
+    expect(entry.status).toBe("approved");
+  });
+});
+
+describe("listFavoritesByUser", () => {
+  it("returns interleaved questions + answers in createdAt desc order, dropping orphans", async () => {
+    const user = await makeUser("fav-user");
+    const author = await makeUser("fav-author");
+    const group = await createGroup(
+      { name: "fav G", slug: uniq("favg"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "fav Q", body: "body" },
+      group.id,
+      author.id,
+    );
+    const a = await db.answer.create({
+      data: { questionId: q.id, authorId: author.id, body: "fav A body" },
+    });
+
+    // Insert favorites in known order.
+    const favQ = await db.favorite.create({
+      data: { userId: user.id, targetType: "question", targetId: q.id },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const favA = await db.favorite.create({
+      data: { userId: user.id, targetType: "answer", targetId: a.id },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    // Orphan favorite (target id that doesn't exist).
+    await db.favorite.create({
+      data: { userId: user.id, targetType: "question", targetId: "ghost-id" },
+    });
+
+    const items = await listFavoritesByUser(user.id);
+    // Newest first; orphan must be silently dropped.
+    expect(items.map((f) => f.kind)).toEqual(["answer", "question"]);
+    expect(items[0]!.id).toBe(a.id);
+    expect(items[1]!.id).toBe(q.id);
+    expect((items[1] as { groupSlug: string }).groupSlug).toBe(group.slug);
+
+    // (silence unused-var lint)
+    void favQ;
+    void favA;
+  });
+
+  it("returns [] when user has no favorites", async () => {
+    const user = await makeUser("fav-empty");
+    const items = await listFavoritesByUser(user.id);
+    expect(items).toEqual([]);
+  });
+});
+
+describe("getPublicUserProfile", () => {
+  it("returns id + name and does NOT include email", async () => {
+    const user = await makeUser("pub-user");
+    const profile = await getPublicUserProfile(user.id);
+    expect(profile).not.toBeNull();
+    expect(profile!.id).toBe(user.id);
+    expect(profile!.name).toBe("pub-user");
+    expect((profile as Record<string, unknown>).email).toBeUndefined();
+  });
+
+  it("returns null for unknown id", async () => {
+    const profile = await getPublicUserProfile("does-not-exist");
+    expect(profile).toBeNull();
+  });
+});

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,291 @@
+import "server-only";
+import type {
+  MembershipStatus,
+  QuestionStatus,
+  Role,
+  User,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+import { voteScoresFor } from "@/lib/votes";
+
+export type ProfileQuestionAuthor = Pick<User, "id" | "email" | "name">;
+
+export type ProfileQuestionItem = {
+  id: string;
+  title: string;
+  status: QuestionStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  author: ProfileQuestionAuthor;
+  answerCount: number;
+  voteScore: number;
+  group: { id: string; slug: string; name: string };
+};
+
+export type ProfileQuestionPage = {
+  items: ProfileQuestionItem[];
+  total: number;
+  page: number;
+  per: number;
+};
+
+export type ProfileAnswerItem = {
+  id: string;
+  bodyExcerpt: string;
+  createdAt: Date;
+  updatedAt: Date;
+  voteScore: number;
+  isAccepted: boolean;
+  question: {
+    id: string;
+    title: string;
+    status: QuestionStatus;
+    group: { slug: string; name: string };
+  };
+};
+
+export type ProfileAnswerPage = {
+  items: ProfileAnswerItem[];
+  total: number;
+  page: number;
+  per: number;
+};
+
+export type ProfileGroupItem = {
+  id: string;
+  slug: string;
+  name: string;
+  role: Role;
+  status: MembershipStatus;
+  joinedAt: Date;
+};
+
+export type ProfileFavoriteItem =
+  | {
+      kind: "question";
+      id: string;
+      title: string;
+      groupSlug: string;
+      groupName: string;
+      favoritedAt: Date;
+    }
+  | {
+      kind: "answer";
+      id: string;
+      bodyExcerpt: string;
+      questionId: string;
+      questionTitle: string;
+      favoritedAt: Date;
+    };
+
+const EXCERPT_LENGTH = 200;
+
+function excerpt(body: string): string {
+  if (body.length <= EXCERPT_LENGTH) return body;
+  return `${body.slice(0, EXCERPT_LENGTH)}…`;
+}
+
+export async function listQuestionsByAuthor(
+  userId: string,
+  opts: { page: number; per: number },
+): Promise<ProfileQuestionPage> {
+  const skip = (opts.page - 1) * opts.per;
+  const [rows, total] = await Promise.all([
+    db.question.findMany({
+      where: { authorId: userId },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: opts.per,
+      include: {
+        author: { select: { id: true, email: true, name: true } },
+        group: { select: { id: true, slug: true, name: true } },
+        _count: { select: { answers: true } },
+      },
+    }),
+    db.question.count({ where: { authorId: userId } }),
+  ]);
+
+  const scores = await voteScoresFor(
+    "question",
+    rows.map((r) => r.id),
+  );
+
+  const items: ProfileQuestionItem[] = rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    status: r.status,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+    author: r.author,
+    answerCount: r._count.answers,
+    voteScore: scores.get(r.id) ?? 0,
+    group: r.group,
+  }));
+
+  return { items, total, page: opts.page, per: opts.per };
+}
+
+export async function listAnswersByAuthor(
+  userId: string,
+  opts: { page: number; per: number },
+): Promise<ProfileAnswerPage> {
+  const skip = (opts.page - 1) * opts.per;
+  const [rows, total] = await Promise.all([
+    db.answer.findMany({
+      where: { authorId: userId },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: opts.per,
+      include: {
+        question: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            acceptedAnswerId: true,
+            group: { select: { slug: true, name: true } },
+          },
+        },
+      },
+    }),
+    db.answer.count({ where: { authorId: userId } }),
+  ]);
+
+  const scores = await voteScoresFor(
+    "answer",
+    rows.map((r) => r.id),
+  );
+
+  const items: ProfileAnswerItem[] = rows.map((r) => ({
+    id: r.id,
+    bodyExcerpt: excerpt(r.body),
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+    voteScore: scores.get(r.id) ?? 0,
+    isAccepted: r.question.acceptedAnswerId === r.id,
+    question: {
+      id: r.question.id,
+      title: r.question.title,
+      status: r.question.status,
+      group: r.question.group,
+    },
+  }));
+
+  return { items, total, page: opts.page, per: opts.per };
+}
+
+export async function listGroupsForUser(
+  userId: string,
+  opts: { includePending: boolean },
+): Promise<ProfileGroupItem[]> {
+  const rows = await db.membership.findMany({
+    where: {
+      userId,
+      ...(opts.includePending ? {} : { status: "approved" }),
+    },
+    orderBy: { createdAt: "asc" },
+    include: { group: { select: { id: true, slug: true, name: true } } },
+  });
+
+  return rows.map((m) => ({
+    id: m.group.id,
+    slug: m.group.slug,
+    name: m.group.name,
+    role: m.role,
+    status: m.status,
+    joinedAt: m.createdAt,
+  }));
+}
+
+export async function listFavoritesByUser(
+  userId: string,
+): Promise<ProfileFavoriteItem[]> {
+  const favorites = await db.favorite.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+  });
+  if (favorites.length === 0) return [];
+
+  const questionIds = favorites
+    .filter((f) => f.targetType === "question")
+    .map((f) => f.targetId);
+  const answerIds = favorites
+    .filter((f) => f.targetType === "answer")
+    .map((f) => f.targetId);
+
+  const [questions, answers] = await Promise.all([
+    questionIds.length
+      ? db.question.findMany({
+          where: { id: { in: questionIds } },
+          select: {
+            id: true,
+            title: true,
+            group: { select: { slug: true, name: true } },
+          },
+        })
+      : Promise.resolve(
+          [] as Array<{
+            id: string;
+            title: string;
+            group: { slug: string; name: string };
+          }>,
+        ),
+    answerIds.length
+      ? db.answer.findMany({
+          where: { id: { in: answerIds } },
+          select: {
+            id: true,
+            body: true,
+            question: { select: { id: true, title: true } },
+          },
+        })
+      : Promise.resolve(
+          [] as Array<{
+            id: string;
+            body: string;
+            question: { id: string; title: string };
+          }>,
+        ),
+  ]);
+
+  const questionsById = new Map(questions.map((q) => [q.id, q]));
+  const answersById = new Map(answers.map((a) => [a.id, a]));
+
+  const items: ProfileFavoriteItem[] = [];
+  for (const f of favorites) {
+    if (f.targetType === "question") {
+      const q = questionsById.get(f.targetId);
+      if (!q) continue;
+      items.push({
+        kind: "question",
+        id: q.id,
+        title: q.title,
+        groupSlug: q.group.slug,
+        groupName: q.group.name,
+        favoritedAt: f.createdAt,
+      });
+    } else {
+      const a = answersById.get(f.targetId);
+      if (!a) continue;
+      items.push({
+        kind: "answer",
+        id: a.id,
+        bodyExcerpt: excerpt(a.body),
+        questionId: a.question.id,
+        questionTitle: a.question.title,
+        favoritedAt: f.createdAt,
+      });
+    }
+  }
+  return items;
+}
+
+export async function getPublicUserProfile(
+  userId: string,
+): Promise<{ id: string; name: string | null } | null> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true },
+  });
+  return user;
+}


### PR DESCRIPTION
## Summary
- Adds `/me` (private) and `/u/[userId]` (public, read-only) profile pages, both built on a new `src/lib/profile` module exposing by-user list helpers for questions, answers, groups, and favorites.
- `/me` shows the current user's questions, answers, favorites, and groups (including pending applications); `/u/[userId]` shows questions, answers, and approved groups only — email is deliberately omitted to avoid leaking the dev sign-in handle.
- Adds a "Your profile" entry to the user-menu dropdown and 9 unit tests covering the new helpers (including a regression guard against email exposure on the public profile).

## Test plan
- [ ] `npm run typecheck`, `npm run lint`, `npm test`, `npm run build` — all green locally.
- [ ] Sign in, visit `/me` — confirm header, questions, answers, favorites (empty), and groups sections render.
- [ ] Visit `/u/<some-user-id>` — confirm Favorites is absent, pending memberships are hidden, email is not in the rendered HTML.
- [ ] Visit `/u/does-not-exist` — 404.
- [ ] Sign out, visit `/me` — redirected to `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)