### PR TITLE
feat(qa): favorite questions and answers (closes #13)

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { requireAuth } from "@/lib/auth";
 
 export default async function AccountPage() {
@@ -19,6 +20,11 @@ export default async function AccountPage() {
         <dt className="text-zinc-500 dark:text-zinc-400">Name</dt>
         <dd>{session.user.name ?? "—"}</dd>
       </dl>
+      <nav className="text-sm">
+        <Link href="/me/favorites" className="underline">
+          My favorites
+        </Link>
+      </nav>
     </div>
   );
 }

--- a/src/app/api/favorites/route.test.ts
+++ b/src/app/api/favorites/route.test.ts
@@ -1,0 +1,211 @@
+/**
+ * POST /api/favorites route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-favorites-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => undefined,
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function jsonReq(method: string, body?: unknown, raw?: string): Request {
+  return new Request("http://x/api/favorites", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: raw !== undefined ? raw : body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function setupGroupWithQuestion() {
+  const ownerEmail = `${uniq("o")}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: uniq("G"), slug: uniq("g"), autoApprove: true },
+    ownerSess.user.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: ownerSess.user.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+  return { group, question, ownerSess };
+}
+
+describe("POST /api/favorites", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: "any" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is malformed JSON", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(jsonReq("POST", undefined, "{not json"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetType is missing", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(jsonReq("POST", { targetId: "x" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetType is invalid", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "comment", targetId: "x" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when target id is unknown", async () => {
+    await auth.signIn(`${uniq("u")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: "does-not-exist" }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with favorited=true on first call", async () => {
+    const { question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("fav")}@example.com`);
+
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.favorited).toBe(true);
+    expect(json.targetType).toBe("question");
+    expect(json.targetId).toBe(question.id);
+  });
+
+  it("returns 200 with favorited=false on second call (toggle off)", async () => {
+    const { question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("tog")}@example.com`);
+
+    await POST(jsonReq("POST", { targetType: "question", targetId: question.id }));
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.favorited).toBe(false);
+  });
+
+  it("allows the author to favorite their own question (no self-restriction)", async () => {
+    const { question } = await setupGroupWithQuestion();
+    // ownerSess is still signed in via cookieStore — author is the caller.
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.favorited).toBe(true);
+  });
+
+  it("allows non-members of the group to favorite", async () => {
+    const { question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("nonmember")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.favorited).toBe(true);
+  });
+
+  it("returns 200 with favorited=true for an answer", async () => {
+    const { question, ownerSess } = await setupGroupWithQuestion();
+    const answer = await db.answer.create({
+      data: {
+        questionId: question.id,
+        authorId: ownerSess.user.id,
+        body: "an answer",
+      },
+    });
+
+    cookieStore.clear();
+    await auth.signIn(`${uniq("af")}@example.com`);
+    const res = await POST(
+      jsonReq("POST", { targetType: "answer", targetId: answer.id }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.favorited).toBe(true);
+    expect(json.targetType).toBe("answer");
+  });
+});

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -1,0 +1,32 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { toggleFavorite } from "@/lib/favorites";
+import { favoriteInputSchema } from "@/lib/validation/favorites";
+
+export async function POST(req: Request): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = favoriteInputSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const result = await toggleFavorite(
+      { targetType: parsed.data.targetType, targetId: parsed.data.targetId },
+      session.user.id,
+    );
+    return Response.json(result, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/me/favorites/page.tsx
+++ b/src/app/me/favorites/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireAuth } from "@/lib/auth";
+import { listFavoritesForUser } from "@/lib/favorites";
+
+function authorLabel(a: { name: string | null; email: string | null }): string {
+  return a.name ?? a.email ?? "unknown";
+}
+
+function excerpt(body: string, max = 200): string {
+  const trimmed = body.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max).trimEnd() + "…";
+}
+
+export default async function MyFavoritesPage() {
+  const session = await requireAuth();
+  const { questions, answers } = await listFavoritesForUser(session.user.id);
+
+  const empty = questions.length === 0 && answers.length === 0;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 py-8">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">My favorites</h1>
+        <p className="text-sm text-muted-foreground">
+          Questions and answers you&rsquo;ve starred.
+        </p>
+      </div>
+
+      {empty ? (
+        <p className="text-sm text-muted-foreground">
+          You haven&rsquo;t favorited anything yet. Open a question and tap the star
+          to save it here.
+        </p>
+      ) : null}
+
+      {questions.length > 0 ? (
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">
+            Questions ({questions.length})
+          </h2>
+          <ul className="space-y-2">
+            {questions.map((q) => (
+              <li key={q.id}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      <Link href={`/q/${q.id}`} className="underline">
+                        {q.title}
+                      </Link>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="text-xs text-muted-foreground">
+                    Asked by {authorLabel(q.author)} in{" "}
+                    <Link href={`/groups/${q.group.slug}`} className="underline">
+                      {q.group.name}
+                    </Link>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {answers.length > 0 ? (
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">Answers ({answers.length})</h2>
+          <ul className="space-y-2">
+            {answers.map((a) => (
+              <li key={a.id}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      <Link href={`/q/${a.question.id}`} className="underline">
+                        {a.question.title}
+                      </Link>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <p className="text-sm whitespace-pre-wrap">
+                      {excerpt(a.body)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Answered by {authorLabel(a.author)}
+                    </p>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/q/[id]/favorite-actions.ts
+++ b/src/app/q/[id]/favorite-actions.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import { NotFoundError } from "@/lib/memberships";
+import { toggleFavorite, type FavoriteTargetType } from "@/lib/favorites";
+
+export type FavoriteActionResult =
+  | { ok: true; favorited: boolean }
+  | { ok: false; error: string };
+
+export async function favoriteAction(
+  targetType: FavoriteTargetType,
+  targetId: string,
+  questionId: string,
+): Promise<FavoriteActionResult> {
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: "You must be signed in to favorite." };
+  }
+
+  try {
+    const result = await toggleFavorite({ targetType, targetId }, session.user.id);
+    revalidatePath(`/q/${questionId}`);
+    revalidatePath("/me/favorites");
+    return { ok: true, favorited: result.favorited };
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return { ok: false, error: err.message };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not update favorite.",
+    };
+  }
+}

--- a/src/app/q/[id]/favorite-button.tsx
+++ b/src/app/q/[id]/favorite-button.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { StarIcon } from "lucide-react";
+import { useState, useTransition } from "react";
+import { favoriteAction } from "./favorite-actions";
+import type { FavoriteTargetType } from "@/lib/favorites";
+
+type Props = {
+  targetType: FavoriteTargetType;
+  targetId: string;
+  questionId: string;
+  initialFavorited: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+};
+
+export function FavoriteButton({
+  targetType,
+  targetId,
+  questionId,
+  initialFavorited,
+  disabled = false,
+  disabledReason,
+}: Props) {
+  const [favorited, setFavorited] = useState(initialFavorited);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (disabled || pending) return;
+    setError(null);
+    const prevFavorited = favorited;
+    setFavorited(!prevFavorited);
+
+    startTransition(async () => {
+      const result = await favoriteAction(targetType, targetId, questionId);
+      if (result.ok) {
+        setFavorited(result.favorited);
+      } else {
+        setFavorited(prevFavorited);
+        setError(result.error);
+      }
+    });
+  };
+
+  const label = favorited ? "Remove from favorites" : "Add to favorites";
+  const title = disabled ? disabledReason ?? label : label;
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || pending}
+        aria-pressed={favorited}
+        aria-label={label}
+        title={title}
+        className={
+          "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs transition-colors " +
+          (favorited
+            ? "border-amber-500 bg-amber-100 text-amber-800 dark:border-amber-400 dark:bg-amber-950/40 dark:text-amber-200"
+            : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800") +
+          " disabled:cursor-not-allowed disabled:opacity-60"
+        }
+      >
+        <StarIcon
+          className="h-3.5 w-3.5"
+          fill={favorited ? "currentColor" : "none"}
+        />
+      </button>
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getQuestionById } from "@/lib/questions";
 import { AnswerForm } from "./answer-form";
 import { AnswerActions } from "./answer-actions";
 import { VoteButton } from "./vote-button";
+import { FavoriteButton } from "./favorite-button";
 import { QuestionResolveControls } from "./question-resolve-controls";
 import { AcceptAnswerButton } from "./accept-answer-button";
 
@@ -75,15 +76,25 @@ export default async function QuestionDetailPage({ params }: Props) {
           </p>
         </CardHeader>
         <CardContent className="space-y-3 pt-4">
-          <VoteButton
-            targetType="question"
-            targetId={question.id}
-            questionId={question.id}
-            initialScore={question.voteScore}
-            initialVoted={question.viewerVote === 1}
-            disabled={questionVoteDisabled}
-            disabledReason={questionVoteDisabledReason}
-          />
+          <div className="flex items-center gap-2">
+            <VoteButton
+              targetType="question"
+              targetId={question.id}
+              questionId={question.id}
+              initialScore={question.voteScore}
+              initialVoted={question.viewerVote === 1}
+              disabled={questionVoteDisabled}
+              disabledReason={questionVoteDisabledReason}
+            />
+            <FavoriteButton
+              targetType="question"
+              targetId={question.id}
+              questionId={question.id}
+              initialFavorited={question.isFavorited}
+              disabled={!currentUserId}
+              disabledReason={!currentUserId ? "Sign in to favorite." : undefined}
+            />
+          </div>
           <MarkdownBody source={question.body} />
         </CardContent>
       </Card>
@@ -137,6 +148,16 @@ export default async function QuestionDetailPage({ params }: Props) {
                           initialVoted={a.viewerVote === 1}
                           disabled={answerVoteDisabled}
                           disabledReason={answerVoteDisabledReason}
+                        />
+                        <FavoriteButton
+                          targetType="answer"
+                          targetId={a.id}
+                          questionId={question.id}
+                          initialFavorited={a.isFavorited}
+                          disabled={!currentUserId}
+                          disabledReason={
+                            !currentUserId ? "Sign in to favorite." : undefined
+                          }
                         />
                         <p className="text-xs text-muted-foreground">
                           {authorLabel(a.author)}

--- a/src/lib/favorites.test.ts
+++ b/src/lib/favorites.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Favorite service tests.
+ *
+ * Real-DB pattern: a throw-away SQLite file initialised by `prisma migrate deploy`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-favorites-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { NotFoundError } = await import("./memberships");
+const {
+  toggleFavorite,
+  viewerFavoritesFor,
+  listFavoritesForUser,
+} = await import("./favorites");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com` } });
+}
+
+async function setupGroupWithQuestion() {
+  const author = await makeUser("author");
+  const group = await createGroup(
+    { name: "G", slug: uniq("g"), autoApprove: true },
+    author.id,
+  );
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: author.id,
+      title: "Seed question for tests",
+      body: "Seed body",
+    },
+  });
+  return { author, group, question };
+}
+
+describe("toggleFavorite on questions", () => {
+  it("creates a favorite and returns favorited=true", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const user = await makeUser("fav");
+
+    const result = await toggleFavorite(
+      { targetType: "question", targetId: question.id },
+      user.id,
+    );
+
+    expect(result.favorited).toBe(true);
+    expect(result.targetType).toBe("question");
+    expect(result.targetId).toBe(question.id);
+
+    const stored = await db.favorite.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: user.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+    });
+    expect(stored).not.toBeNull();
+  });
+
+  it("toggles off on second call and returns favorited=false", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const user = await makeUser("fav-off");
+
+    await toggleFavorite({ targetType: "question", targetId: question.id }, user.id);
+    const second = await toggleFavorite(
+      { targetType: "question", targetId: question.id },
+      user.id,
+    );
+
+    expect(second.favorited).toBe(false);
+
+    const stored = await db.favorite.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: user.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+    });
+    expect(stored).toBeNull();
+  });
+
+  it("allows favoriting your own question", async () => {
+    const { author, question } = await setupGroupWithQuestion();
+    const result = await toggleFavorite(
+      { targetType: "question", targetId: question.id },
+      author.id,
+    );
+    expect(result.favorited).toBe(true);
+  });
+
+  it("allows favoriting from a non-member of the group", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const stranger = await makeUser("stranger");
+    const result = await toggleFavorite(
+      { targetType: "question", targetId: question.id },
+      stranger.id,
+    );
+    expect(result.favorited).toBe(true);
+  });
+
+  it("throws NotFoundError for unknown question id", async () => {
+    const user = await makeUser("nf");
+    await expect(
+      toggleFavorite(
+        { targetType: "question", targetId: "does-not-exist" },
+        user.id,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("toggleFavorite on answers", () => {
+  it("creates a favorite on an answer", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const answerer = await makeUser("answerer");
+    await db.membership.create({
+      data: { groupId: group.id, userId: answerer.id, status: "approved" },
+    });
+    const answer = await db.answer.create({
+      data: { questionId: question.id, authorId: answerer.id, body: "ans" },
+    });
+
+    const user = await makeUser("a-fav");
+    const result = await toggleFavorite(
+      { targetType: "answer", targetId: answer.id },
+      user.id,
+    );
+
+    expect(result.favorited).toBe(true);
+    expect(result.targetType).toBe("answer");
+  });
+
+  it("allows favoriting your own answer", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const answerer = await makeUser("self-ans");
+    await db.membership.create({
+      data: { groupId: group.id, userId: answerer.id, status: "approved" },
+    });
+    const answer = await db.answer.create({
+      data: { questionId: question.id, authorId: answerer.id, body: "mine" },
+    });
+
+    const result = await toggleFavorite(
+      { targetType: "answer", targetId: answer.id },
+      answerer.id,
+    );
+    expect(result.favorited).toBe(true);
+  });
+
+  it("throws NotFoundError for unknown answer id", async () => {
+    const user = await makeUser("a-nf");
+    await expect(
+      toggleFavorite(
+        { targetType: "answer", targetId: "does-not-exist" },
+        user.id,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("viewerFavoritesFor", () => {
+  it("returns an empty set when no ids are supplied", async () => {
+    const user = await makeUser("vf-empty");
+    const set = await viewerFavoritesFor("question", [], user.id);
+    expect(set.size).toBe(0);
+  });
+
+  it("returns only the supplied user's favorited target ids", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const me = await makeUser("me");
+    const other = await makeUser("other");
+    await toggleFavorite({ targetType: "question", targetId: question.id }, other.id);
+
+    const before = await viewerFavoritesFor("question", [question.id], me.id);
+    expect(before.has(question.id)).toBe(false);
+
+    await toggleFavorite({ targetType: "question", targetId: question.id }, me.id);
+    const after = await viewerFavoritesFor("question", [question.id], me.id);
+    expect(after.has(question.id)).toBe(true);
+  });
+});
+
+describe("listFavoritesForUser", () => {
+  it("returns favorited questions and answers in newest-first order", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    const answerer = await makeUser("la-ans");
+    await db.membership.create({
+      data: { groupId: group.id, userId: answerer.id, status: "approved" },
+    });
+    const answer = await db.answer.create({
+      data: { questionId: question.id, authorId: answerer.id, body: "an answer" },
+    });
+
+    const user = await makeUser("lister");
+
+    await toggleFavorite({ targetType: "question", targetId: question.id }, user.id);
+    // small delay to ensure distinct createdAt ordering
+    await new Promise((r) => setTimeout(r, 5));
+    await toggleFavorite({ targetType: "answer", targetId: answer.id }, user.id);
+
+    const result = await listFavoritesForUser(user.id);
+    expect(result.questions).toHaveLength(1);
+    expect(result.questions[0].id).toBe(question.id);
+    expect(result.questions[0].title).toBe("Seed question for tests");
+    expect(result.questions[0].group.id).toBe(group.id);
+    expect(result.answers).toHaveLength(1);
+    expect(result.answers[0].id).toBe(answer.id);
+    expect(result.answers[0].question.id).toBe(question.id);
+  });
+
+  it("omits favorites whose target was deleted", async () => {
+    const { question } = await setupGroupWithQuestion();
+    const user = await makeUser("ghost");
+    await toggleFavorite({ targetType: "question", targetId: question.id }, user.id);
+
+    // Manually drop the question without the cascade (simulate orphan).
+    await db.favorite.update({
+      where: {
+        userId_targetType_targetId: {
+          userId: user.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+      data: { targetId: "no-such-question" },
+    });
+
+    const result = await listFavoritesForUser(user.id);
+    expect(result.questions).toHaveLength(0);
+  });
+
+  it("returns empty arrays when user has no favorites", async () => {
+    const user = await makeUser("none");
+    const result = await listFavoritesForUser(user.id);
+    expect(result.questions).toHaveLength(0);
+    expect(result.answers).toHaveLength(0);
+  });
+});

--- a/src/lib/favorites.ts
+++ b/src/lib/favorites.ts
@@ -1,0 +1,199 @@
+import "server-only";
+import { Prisma, type TargetType } from "@prisma/client";
+import { db } from "@/lib/db";
+import { NotFoundError } from "@/lib/memberships";
+
+export type FavoriteTargetType = TargetType;
+
+export type ToggleFavoriteResult = {
+  favorited: boolean;
+  targetType: FavoriteTargetType;
+  targetId: string;
+};
+
+export type FavoritedQuestion = {
+  id: string;
+  title: string;
+  status: "open" | "answered";
+  createdAt: Date;
+  favoritedAt: Date;
+  author: { id: string; email: string | null; name: string | null };
+  group: { id: string; slug: string; name: string };
+};
+
+export type FavoritedAnswer = {
+  id: string;
+  body: string;
+  createdAt: Date;
+  favoritedAt: Date;
+  author: { id: string; email: string | null; name: string | null };
+  question: { id: string; title: string };
+};
+
+export type FavoritesForUser = {
+  questions: FavoritedQuestion[];
+  answers: FavoritedAnswer[];
+};
+
+export async function viewerFavoritesFor(
+  targetType: FavoriteTargetType,
+  ids: string[],
+  userId: string,
+): Promise<Set<string>> {
+  if (ids.length === 0) return new Set<string>();
+  const rows = await db.favorite.findMany({
+    where: { userId, targetType, targetId: { in: ids } },
+    select: { targetId: true },
+  });
+  return new Set(rows.map((r) => r.targetId));
+}
+
+async function assertTargetExists(
+  targetType: FavoriteTargetType,
+  targetId: string,
+): Promise<void> {
+  if (targetType === "question") {
+    const q = await db.question.findUnique({
+      where: { id: targetId },
+      select: { id: true },
+    });
+    if (!q) throw new NotFoundError("Question not found.");
+    return;
+  }
+  const a = await db.answer.findUnique({
+    where: { id: targetId },
+    select: { id: true },
+  });
+  if (!a) throw new NotFoundError("Answer not found.");
+}
+
+export async function toggleFavorite(
+  input: { targetType: FavoriteTargetType; targetId: string },
+  userId: string,
+): Promise<ToggleFavoriteResult> {
+  await assertTargetExists(input.targetType, input.targetId);
+
+  const existing = await db.favorite.findUnique({
+    where: {
+      userId_targetType_targetId: {
+        userId,
+        targetType: input.targetType,
+        targetId: input.targetId,
+      },
+    },
+    select: { id: true },
+  });
+
+  let favorited: boolean;
+  if (existing) {
+    try {
+      await db.favorite.delete({ where: { id: existing.id } });
+    } catch (err) {
+      // P2025: row already removed by a concurrent request — same outcome.
+      if (
+        !(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025")
+      ) {
+        throw err;
+      }
+    }
+    favorited = false;
+  } else {
+    try {
+      await db.favorite.create({
+        data: {
+          userId,
+          targetType: input.targetType,
+          targetId: input.targetId,
+        },
+      });
+    } catch (err) {
+      // P2002: a concurrent request inserted the same row — same outcome.
+      if (
+        !(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")
+      ) {
+        throw err;
+      }
+    }
+    favorited = true;
+  }
+
+  return {
+    favorited,
+    targetType: input.targetType,
+    targetId: input.targetId,
+  };
+}
+
+export async function listFavoritesForUser(
+  userId: string,
+): Promise<FavoritesForUser> {
+  const rows = await db.favorite.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    select: { targetType: true, targetId: true, createdAt: true },
+  });
+
+  const questionIds: string[] = [];
+  const answerIds: string[] = [];
+  const favoritedAt = new Map<string, Date>();
+  for (const r of rows) {
+    favoritedAt.set(`${r.targetType}:${r.targetId}`, r.createdAt);
+    if (r.targetType === "question") questionIds.push(r.targetId);
+    else answerIds.push(r.targetId);
+  }
+
+  const [questionRows, answerRows] = await Promise.all([
+    questionIds.length === 0
+      ? Promise.resolve([])
+      : db.question.findMany({
+          where: { id: { in: questionIds } },
+          include: {
+            author: { select: { id: true, email: true, name: true } },
+            group: { select: { id: true, slug: true, name: true } },
+          },
+        }),
+    answerIds.length === 0
+      ? Promise.resolve([])
+      : db.answer.findMany({
+          where: { id: { in: answerIds } },
+          include: {
+            author: { select: { id: true, email: true, name: true } },
+            question: { select: { id: true, title: true } },
+          },
+        }),
+  ]);
+
+  const questionsById = new Map(questionRows.map((q) => [q.id, q]));
+  const answersById = new Map(answerRows.map((a) => [a.id, a]));
+
+  const questions: FavoritedQuestion[] = [];
+  const answers: FavoritedAnswer[] = [];
+  for (const r of rows) {
+    if (r.targetType === "question") {
+      const q = questionsById.get(r.targetId);
+      if (!q) continue;
+      questions.push({
+        id: q.id,
+        title: q.title,
+        status: q.status,
+        createdAt: q.createdAt,
+        favoritedAt: r.createdAt,
+        author: q.author,
+        group: q.group,
+      });
+    } else {
+      const a = answersById.get(r.targetId);
+      if (!a) continue;
+      answers.push({
+        id: a.id,
+        body: a.body,
+        createdAt: a.createdAt,
+        favoritedAt: r.createdAt,
+        author: a.author,
+        question: a.question,
+      });
+    }
+  }
+
+  return { questions, answers };
+}

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -7,6 +7,7 @@ import {
   isOwnerOrModerator,
 } from "@/lib/memberships";
 import { viewerVotesFor, voteScoresFor } from "@/lib/votes";
+import { viewerFavoritesFor } from "@/lib/favorites";
 import type { CreateQuestionInput } from "@/lib/validation/questions";
 
 export type QuestionAuthor = Pick<User, "id" | "email" | "name">;
@@ -35,10 +36,12 @@ export type QuestionDetail = Question & {
       author: QuestionAuthor;
       voteScore: number;
       viewerVote: 1 | null;
+      isFavorited: boolean;
     }
   >;
   voteScore: number;
   viewerVote: 1 | null;
+  isFavorited: boolean;
 };
 
 export async function createQuestion(
@@ -115,17 +118,29 @@ export async function getQuestionById(
 
   const answerIds = q.answers.map((a) => a.id);
 
-  const [questionScores, answerScores, viewerQuestionVotes, viewerAnswerVotes] =
-    await Promise.all([
-      voteScoresFor("question", [q.id]),
-      voteScoresFor("answer", answerIds),
-      viewerUserId
-        ? viewerVotesFor("question", [q.id], viewerUserId)
-        : Promise.resolve(new Map<string, 1>()),
-      viewerUserId
-        ? viewerVotesFor("answer", answerIds, viewerUserId)
-        : Promise.resolve(new Map<string, 1>()),
-    ]);
+  const [
+    questionScores,
+    answerScores,
+    viewerQuestionVotes,
+    viewerAnswerVotes,
+    viewerQuestionFavorites,
+    viewerAnswerFavorites,
+  ] = await Promise.all([
+    voteScoresFor("question", [q.id]),
+    voteScoresFor("answer", answerIds),
+    viewerUserId
+      ? viewerVotesFor("question", [q.id], viewerUserId)
+      : Promise.resolve(new Map<string, 1>()),
+    viewerUserId
+      ? viewerVotesFor("answer", answerIds, viewerUserId)
+      : Promise.resolve(new Map<string, 1>()),
+    viewerUserId
+      ? viewerFavoritesFor("question", [q.id], viewerUserId)
+      : Promise.resolve(new Set<string>()),
+    viewerUserId
+      ? viewerFavoritesFor("answer", answerIds, viewerUserId)
+      : Promise.resolve(new Set<string>()),
+  ]);
 
   const mappedAnswers = q.answers.map((a) => ({
     id: a.id,
@@ -135,6 +150,7 @@ export async function getQuestionById(
     author: a.author,
     voteScore: answerScores.get(a.id) ?? 0,
     viewerVote: viewerAnswerVotes.get(a.id) ?? null,
+    isFavorited: viewerAnswerFavorites.has(a.id),
   }));
   const acceptedId = q.acceptedAnswerId;
   const sortedAnswers = acceptedId
@@ -149,6 +165,7 @@ export async function getQuestionById(
     ...q,
     voteScore: questionScores.get(q.id) ?? 0,
     viewerVote: viewerQuestionVotes.get(q.id) ?? null,
+    isFavorited: viewerQuestionFavorites.has(q.id),
     answers: sortedAnswers,
   };
 }

--- a/src/lib/validation/favorites.ts
+++ b/src/lib/validation/favorites.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const favoriteTargetTypeSchema = z.enum(["question", "answer"]);
+
+export const favoriteInputSchema = z.object({
+  targetType: favoriteTargetTypeSchema,
+  targetId: z.string().min(1, "targetId is required."),
+});
+
+export type FavoriteInput = z.input<typeof favoriteInputSchema>;


### PR DESCRIPTION
## Summary
- Adds `Favorite` toggle (`POST /api/favorites`) plus `viewerFavoritesFor` / `listFavoritesForUser` helpers in `src/lib/favorites.ts`.
- Wires `isFavorited` into `getQuestionById` and renders a `FavoriteButton` (lucide `StarIcon`, optimistic toggle) next to each `VoteButton` on `/q/[id]`.
- New `/me/favorites` page lists favorited questions and answers, linked from `/account`.

Two intentional differences from voting (per issue language *"any authenticated user… regardless of whether they authored it"*): no group-membership requirement and self-favoriting is allowed.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm test` (240/240 passing — 23 new tests covering toggle, self-favorite, non-member favorite, NotFound on stale targets, list ordering, orphan filtering, and all API status paths)
- [ ] Manual smoke: sign in → star a question and an answer → refresh persists → visit `/me/favorites` → unfavorite → item disappears