### PR TITLE
feat(search): server-side search API with group scoping (closes #15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10306,6 +10306,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/prisma/migrations/20260504151656_add_search_fts/migration.sql
+++ b/prisma/migrations/20260504151656_add_search_fts/migration.sql
@@ -1,0 +1,48 @@
+-- SQLite FTS5 search index for Question and Answer.
+-- Question.id and Answer.id are TEXT cuids, so we use a contentless shadow
+-- table indexed by an UNINDEXED `id` column rather than FTS5 external content
+-- (which requires INTEGER rowids). Triggers keep each shadow in sync.
+
+CREATE VIRTUAL TABLE question_fts USING fts5(
+  id UNINDEXED,
+  title,
+  body,
+  tokenize = 'porter unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER question_fts_ai AFTER INSERT ON "Question" BEGIN
+  INSERT INTO question_fts (id, title, body) VALUES (new.id, new.title, new.body);
+END;
+
+CREATE TRIGGER question_fts_ad AFTER DELETE ON "Question" BEGIN
+  DELETE FROM question_fts WHERE id = old.id;
+END;
+
+CREATE TRIGGER question_fts_au AFTER UPDATE ON "Question" BEGIN
+  UPDATE question_fts SET title = new.title, body = new.body WHERE id = old.id;
+END;
+
+CREATE VIRTUAL TABLE answer_fts USING fts5(
+  id UNINDEXED,
+  body,
+  tokenize = 'porter unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER answer_fts_ai AFTER INSERT ON "Answer" BEGIN
+  INSERT INTO answer_fts (id, body) VALUES (new.id, new.body);
+END;
+
+CREATE TRIGGER answer_fts_ad AFTER DELETE ON "Answer" BEGIN
+  DELETE FROM answer_fts WHERE id = old.id;
+END;
+
+CREATE TRIGGER answer_fts_au AFTER UPDATE ON "Answer" BEGIN
+  UPDATE answer_fts SET body = new.body WHERE id = old.id;
+END;
+
+-- Backfill any pre-existing rows.
+INSERT INTO question_fts (id, title, body)
+  SELECT id, title, body FROM "Question";
+
+INSERT INTO answer_fts (id, body)
+  SELECT id, body FROM "Answer";

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,205 @@
+/**
+ * GET /api/search route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-search-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: () => undefined,
+    set: () => {},
+    delete: () => {},
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { createQuestion } = await import("@/lib/questions");
+const { GET } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com`, name: label } });
+}
+
+function getReq(qs: string): Request {
+  return new Request(`http://x/api/search${qs}`, { method: "GET" });
+}
+
+describe("GET /api/search", () => {
+  it("returns 400 when q is missing", async () => {
+    const res = await GET(getReq("?scope=all"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when q is empty", async () => {
+    const res = await GET(getReq("?q="));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when scope=current without groupIds", async () => {
+    const res = await GET(getReq("?q=foo&scope=current"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when scope=current has multiple groupIds", async () => {
+    const res = await GET(getReq("?q=foo&scope=current&groupIds=a,b"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when per is out of range", async () => {
+    const res = await GET(getReq("?q=foo&per=999"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with empty items + zero total when there are no matches", async () => {
+    const res = await GET(getReq("?q=zzzunlikelytokenzzz"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toEqual([]);
+    expect(json.total).toBe(0);
+    expect(json.page).toBe(1);
+    expect(json.per).toBe(20);
+  });
+
+  it("returns 200 with question + answer hits matching the query", async () => {
+    const author = await makeUser("rh");
+    const group = await createGroup(
+      { name: "RH", slug: uniq("rh"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Best ergonomic keyboard tray for posture", body: "discussion of trays" },
+      group.id,
+      author.id,
+    );
+    await db.answer.create({
+      data: {
+        questionId: q.id,
+        authorId: author.id,
+        body: "I use the GreatCo ergonomic keyboard daily.",
+      },
+    });
+
+    const res = await GET(getReq("?q=ergonomic&scope=all&per=10"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.total).toBeGreaterThanOrEqual(2);
+    const types = new Set(json.items.map((i: { type: string }) => i.type));
+    expect(types.has("question")).toBe(true);
+    expect(types.has("answer")).toBe(true);
+    for (const item of json.items) {
+      expect(item.group).toMatchObject({ id: expect.any(String), slug: expect.any(String) });
+      expect(item.author).toMatchObject({ id: expect.any(String) });
+    }
+  });
+
+  it("filters by group when scope=selected", async () => {
+    const author = await makeUser("scope");
+    const groupA = await createGroup(
+      { name: "SA", slug: uniq("sa"), autoApprove: true },
+      author.id,
+    );
+    const groupB = await createGroup(
+      { name: "SB", slug: uniq("sb"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "Echidna habitat in group A", body: "x" },
+      groupA.id,
+      author.id,
+    );
+    await createQuestion(
+      { title: "Echidna habitat in group B", body: "y" },
+      groupB.id,
+      author.id,
+    );
+
+    const res = await GET(
+      getReq(`?q=echidna&scope=selected&groupIds=${encodeURIComponent(groupA.id)}`),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items.length).toBeGreaterThanOrEqual(1);
+    for (const item of json.items) {
+      expect(item.group.id).toBe(groupA.id);
+    }
+  });
+
+  it("respects page and per for pagination", async () => {
+    const author = await makeUser("pg");
+    const group = await createGroup(
+      { name: "PG", slug: uniq("pg"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "Platypus fact one", body: "monotreme" },
+      group.id,
+      author.id,
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    await createQuestion(
+      { title: "Platypus fact two", body: "monotreme" },
+      group.id,
+      author.id,
+    );
+
+    const res1 = await GET(
+      getReq(
+        `?q=platypus&scope=selected&groupIds=${encodeURIComponent(group.id)}&page=1&per=1`,
+      ),
+    );
+    const json1 = await res1.json();
+    expect(json1.items).toHaveLength(1);
+    expect(json1.total).toBeGreaterThanOrEqual(2);
+
+    const res2 = await GET(
+      getReq(
+        `?q=platypus&scope=selected&groupIds=${encodeURIComponent(group.id)}&page=2&per=1`,
+      ),
+    );
+    const json2 = await res2.json();
+    expect(json2.items).toHaveLength(1);
+    expect(json2.items[0].questionId).not.toBe(json1.items[0].questionId);
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,22 @@
+import { errorToResponse, validationFailed } from "@/lib/api/errors";
+import { searchContent } from "@/lib/search";
+import { searchQuerySchema } from "@/lib/validation/search";
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parsed = searchQuerySchema.safeParse({
+    q: url.searchParams.get("q") ?? undefined,
+    scope: url.searchParams.get("scope") ?? undefined,
+    groupIds: url.searchParams.get("groupIds") ?? undefined,
+    page: url.searchParams.get("page") ?? undefined,
+    per: url.searchParams.get("per") ?? undefined,
+  });
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const page = await searchContent(parsed.data);
+    return Response.json(page, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { searchContent, type SearchHit } from "@/lib/search";
+import { searchQuerySchema } from "@/lib/validation/search";
+
+type Props = {
+  searchParams: Promise<{
+    q?: string;
+    scope?: string;
+    groupIds?: string;
+    page?: string;
+    per?: string;
+  }>;
+};
+
+const SNIPPET_MARK = /<mark>([\s\S]*?)<\/mark>/g;
+
+/**
+ * Render an FTS-emitted snippet ("…match <mark>foo</mark> here…") as React,
+ * escaping everything outside <mark> tags and replacing <mark>...</mark> with
+ * a styled span. We do this manually rather than dangerouslySetInnerHTML so
+ * arbitrary user content can't inject markup.
+ */
+function renderSnippet(snippet: string): ReactNode {
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  for (const m of snippet.matchAll(SNIPPET_MARK)) {
+    const idx = m.index ?? 0;
+    if (idx > cursor) out.push(snippet.slice(cursor, idx));
+    out.push(
+      <mark
+        key={key++}
+        className="rounded-sm bg-yellow-200 px-0.5 text-foreground dark:bg-yellow-500/30"
+      >
+        {m[1]}
+      </mark>,
+    );
+    cursor = idx + m[0].length;
+  }
+  if (cursor < snippet.length) out.push(snippet.slice(cursor));
+  return out;
+}
+
+function authorLabel(a: { name: string | null; email: string | null }): string {
+  return a.name ?? a.email ?? "unknown";
+}
+
+function HitCard({ hit }: { hit: SearchHit }) {
+  const titleNode = hit.titleSnippet ? renderSnippet(hit.titleSnippet) : hit.title;
+  return (
+    <li className="rounded-lg border border-border p-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="rounded-sm border border-border px-1.5 py-0.5 font-medium uppercase tracking-wide">
+          {hit.type === "question" ? "Question" : "Answer"}
+        </span>
+        <Link href={`/groups/${hit.group.slug}`} className="hover:underline">
+          {hit.group.name}
+        </Link>
+        <span aria-hidden>·</span>
+        <span>{authorLabel(hit.author)}</span>
+      </div>
+      <h2 className="mt-1 text-lg font-semibold leading-snug">
+        <Link
+          href={hit.answerId ? `/q/${hit.questionId}#a-${hit.answerId}` : `/q/${hit.questionId}`}
+          className="hover:underline"
+        >
+          {titleNode}
+        </Link>
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {renderSnippet(hit.bodyExcerpt)}
+      </p>
+    </li>
+  );
+}
+
+function PageLink({
+  to,
+  q,
+  scope,
+  groupIds,
+  per,
+  children,
+  disabled,
+}: {
+  to: number;
+  q: string;
+  scope: string;
+  groupIds: string | undefined;
+  per: number;
+  children: ReactNode;
+  disabled?: boolean;
+}) {
+  if (disabled) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        {children}
+      </Button>
+    );
+  }
+  const params = new URLSearchParams({ q, scope, page: String(to), per: String(per) });
+  if (groupIds) params.set("groupIds", groupIds);
+  return (
+    <Button variant="outline" size="sm" render={<Link href={`/search?${params.toString()}`} />}>
+      {children}
+    </Button>
+  );
+}
+
+export default async function SearchPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const rawQ = sp.q?.trim() ?? "";
+  const scopeRaw = sp.scope ?? "all";
+  const scope: "all" | "current" | "selected" =
+    scopeRaw === "current" || scopeRaw === "selected" ? scopeRaw : "all";
+  const groupIdsRaw = sp.groupIds;
+  const per = Math.min(Math.max(Number(sp.per) || 20, 1), 50);
+  const requestedPage = Math.max(Number(sp.page) || 1, 1);
+
+  let results:
+    | { items: SearchHit[]; total: number; page: number; per: number }
+    | null = null;
+  let validationMessage: string | null = null;
+
+  if (rawQ.length > 0) {
+    const parsed = searchQuerySchema.safeParse({
+      q: rawQ,
+      scope,
+      groupIds: groupIdsRaw,
+      page: String(requestedPage),
+      per: String(per),
+    });
+    if (parsed.success) {
+      results = await searchContent(parsed.data);
+    } else {
+      validationMessage = parsed.error.issues[0]?.message ?? "Invalid query.";
+    }
+  }
+
+  const totalPages = results ? Math.max(Math.ceil(results.total / per), 1) : 1;
+  const currentPage = results?.page ?? requestedPage;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Search</h1>
+        <p className="text-sm text-muted-foreground">
+          Search questions and answers across groups.
+        </p>
+      </div>
+
+      <form className="flex flex-wrap items-center gap-2" method="get" action="/search">
+        <Input
+          name="q"
+          defaultValue={rawQ}
+          placeholder="Search…"
+          aria-label="Search query"
+          className="max-w-md flex-1"
+          autoFocus
+        />
+        <select
+          name="scope"
+          defaultValue={scope}
+          aria-label="Scope"
+          className="h-8 rounded-lg border border-input bg-transparent px-2 text-sm"
+        >
+          <option value="all">All groups</option>
+          <option value="selected">Selected groups</option>
+          <option value="current">Current group</option>
+        </select>
+        {groupIdsRaw ? <input type="hidden" name="groupIds" value={groupIdsRaw} /> : null}
+        <Button type="submit">Search</Button>
+      </form>
+
+      {validationMessage ? (
+        <p className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          {validationMessage}
+        </p>
+      ) : null}
+
+      {results && rawQ.length > 0 ? (
+        results.items.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+            No matches for <span className="font-medium">“{rawQ}”</span>.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-xs text-muted-foreground">
+              {results.total} match{results.total === 1 ? "" : "es"} · page {currentPage} of {totalPages}
+            </p>
+            <ul className="space-y-3">
+              {results.items.map((hit) => (
+                <HitCard key={`${hit.type}-${hit.answerId ?? hit.questionId}`} hit={hit} />
+              ))}
+            </ul>
+            <div className="flex items-center justify-between">
+              <PageLink
+                to={currentPage - 1}
+                q={rawQ}
+                scope={scope}
+                groupIds={groupIdsRaw}
+                per={per}
+                disabled={currentPage <= 1}
+              >
+                Previous
+              </PageLink>
+              <PageLink
+                to={currentPage + 1}
+                q={rawQ}
+                scope={scope}
+                groupIds={groupIdsRaw}
+                per={per}
+                disabled={currentPage >= totalPages}
+              >
+                Next
+              </PageLink>
+            </div>
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Search service tests — exercises FTS5 triggers, tokenizer, and scope filter.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-search-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { createQuestion } = await import("./questions");
+const { searchContent, toFtsMatchExpr } = await import("./search");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com`, name: label } });
+}
+
+describe("toFtsMatchExpr", () => {
+  it("returns null when the query reduces to nothing", () => {
+    expect(toFtsMatchExpr("")).toBeNull();
+    expect(toFtsMatchExpr("   ")).toBeNull();
+    expect(toFtsMatchExpr("***")).toBeNull();
+    expect(toFtsMatchExpr('"!@#$"')).toBeNull();
+  });
+
+  it("strips FTS syntax characters and prefix-matches the trailing token", () => {
+    expect(toFtsMatchExpr("rust")).toBe('"rust"*');
+    expect(toFtsMatchExpr("how to rust")).toBe('"how" AND "to" AND "rust"*');
+    // Special chars are stripped per token.
+    expect(toFtsMatchExpr('rust*())"')).toBe('"rust"*');
+    expect(toFtsMatchExpr("foo:bar baz-qux")).toBe('"foobar" AND "bazqux"*');
+  });
+});
+
+describe("searchContent", () => {
+  it("returns empty results when the query has no usable tokens", async () => {
+    const page = await searchContent({
+      q: "***",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 10,
+    });
+    expect(page).toEqual({ items: [], total: 0, page: 1, per: 10 });
+  });
+
+  it("finds a question by title and includes group + author + snippet", async () => {
+    const author = await makeUser("titleAuthor");
+    const group = await createGroup(
+      { name: "T", slug: uniq("t"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "How to integrate Stripe webhooks safely", body: "Asking about idempotency." },
+      group.id,
+      author.id,
+    );
+
+    const page = await searchContent({
+      q: "stripe",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 10,
+    });
+
+    expect(page.total).toBeGreaterThanOrEqual(1);
+    const hit = page.items.find((i) => i.title.includes("Stripe"));
+    expect(hit).toBeDefined();
+    expect(hit?.type).toBe("question");
+    expect(hit?.group.id).toBe(group.id);
+    expect(hit?.author.id).toBe(author.id);
+    expect(hit?.titleSnippet).toMatch(/<mark>Stripe<\/mark>/i);
+    expect(hit?.bodyExcerpt).toBeTypeOf("string");
+  });
+
+  it("finds a question by body when the title doesn't match", async () => {
+    const author = await makeUser("bodyAuthor");
+    const group = await createGroup(
+      { name: "B", slug: uniq("b"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "An ordinary question", body: "Has anyone used pgvector with Prisma?" },
+      group.id,
+      author.id,
+    );
+
+    const page = await searchContent({
+      q: "pgvector",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 10,
+    });
+
+    const hit = page.items.find((i) => i.questionId);
+    expect(hit?.type).toBe("question");
+    expect(hit?.bodyExcerpt).toMatch(/<mark>pgvector<\/mark>/i);
+  });
+
+  it("finds an answer by body and surfaces the parent question's title + group", async () => {
+    const author = await makeUser("ansAuthor");
+    const group = await createGroup(
+      { name: "A", slug: uniq("a"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Parent question title here", body: "context body" },
+      group.id,
+      author.id,
+    );
+    const answer = await db.answer.create({
+      data: { questionId: q.id, authorId: author.id, body: "Try the kestrel toolkit." },
+    });
+
+    const page = await searchContent({
+      q: "kestrel",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 10,
+    });
+
+    const hit = page.items.find((i) => i.answerId === answer.id);
+    expect(hit).toBeDefined();
+    expect(hit?.type).toBe("answer");
+    expect(hit?.title).toBe("Parent question title here");
+    expect(hit?.group.id).toBe(group.id);
+    expect(hit?.titleSnippet).toBeNull();
+    expect(hit?.bodyExcerpt).toMatch(/<mark>kestrel<\/mark>/i);
+  });
+
+  it("filters by groupIds when scope=selected", async () => {
+    const author = await makeUser("scopeA");
+    const groupA = await createGroup(
+      { name: "GA", slug: uniq("ga"), autoApprove: true },
+      author.id,
+    );
+    const groupB = await createGroup(
+      { name: "GB", slug: uniq("gb"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "Quokka husbandry tips group A", body: "anything" },
+      groupA.id,
+      author.id,
+    );
+    await createQuestion(
+      { title: "Quokka husbandry tips group B", body: "anything" },
+      groupB.id,
+      author.id,
+    );
+
+    const all = await searchContent({
+      q: "quokka",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 10,
+    });
+    expect(all.items.filter((i) => i.title.includes("Quokka")).length).toBeGreaterThanOrEqual(2);
+
+    const onlyA = await searchContent({
+      q: "quokka",
+      scope: "selected",
+      groupIds: [groupA.id],
+      page: 1,
+      per: 10,
+    });
+    const aHits = onlyA.items.filter((i) => i.title.includes("Quokka"));
+    expect(aHits.every((h) => h.group.id === groupA.id)).toBe(true);
+    expect(aHits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("paginates with page + per", async () => {
+    const author = await makeUser("pager");
+    const group = await createGroup(
+      { name: "P", slug: uniq("p"), autoApprove: true },
+      author.id,
+    );
+    await createQuestion(
+      { title: "Macropod fact one", body: "facts about macropod" },
+      group.id,
+      author.id,
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    await createQuestion(
+      { title: "Macropod fact two", body: "more macropod" },
+      group.id,
+      author.id,
+    );
+
+    const p1 = await searchContent({
+      q: "macropod",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 1,
+    });
+    expect(p1.total).toBeGreaterThanOrEqual(2);
+    expect(p1.items).toHaveLength(1);
+
+    const p2 = await searchContent({
+      q: "macropod",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 2,
+      per: 1,
+    });
+    expect(p2.items).toHaveLength(1);
+    expect(p2.items[0]!.questionId).not.toBe(p1.items[0]!.questionId);
+  });
+
+  it("reflects question updates via the FTS update trigger", async () => {
+    const author = await makeUser("upd");
+    const group = await createGroup(
+      { name: "U", slug: uniq("u"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Initially about bandicoots", body: "marsupial body" },
+      group.id,
+      author.id,
+    );
+
+    const before = await searchContent({
+      q: "bandicoots",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(before.items.some((i) => i.questionId === q.id)).toBe(true);
+
+    await db.question.update({
+      where: { id: q.id },
+      data: { title: "Renamed to wombats now" },
+    });
+
+    const afterRename = await searchContent({
+      q: "bandicoots",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(afterRename.items.some((i) => i.questionId === q.id)).toBe(false);
+
+    const wombats = await searchContent({
+      q: "wombats",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(wombats.items.some((i) => i.questionId === q.id)).toBe(true);
+  });
+
+  it("removes a question from results after deletion via the FTS delete trigger", async () => {
+    const author = await makeUser("del");
+    const group = await createGroup(
+      { name: "D", slug: uniq("d"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Numbat sighting today", body: "extra body" },
+      group.id,
+      author.id,
+    );
+
+    const before = await searchContent({
+      q: "numbat",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(before.items.some((i) => i.questionId === q.id)).toBe(true);
+
+    await db.question.delete({ where: { id: q.id } });
+
+    const after = await searchContent({
+      q: "numbat",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(after.items.some((i) => i.questionId === q.id)).toBe(false);
+  });
+});

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,249 @@
+import "server-only";
+import { Prisma } from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type SearchMatchType = "question" | "answer";
+
+export type SearchHitAuthor = {
+  id: string;
+  email: string | null;
+  name: string | null;
+};
+
+export type SearchHitGroup = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export type SearchHit = {
+  type: SearchMatchType;
+  questionId: string;
+  answerId: string | null;
+  title: string;
+  titleSnippet: string | null;
+  bodyExcerpt: string;
+  group: SearchHitGroup;
+  author: SearchHitAuthor;
+  score: number;
+  createdAt: Date;
+};
+
+export type SearchResultsPage = {
+  items: SearchHit[];
+  total: number;
+  page: number;
+  per: number;
+};
+
+export type SearchOptions = {
+  q: string;
+  scope: "current" | "selected" | "all";
+  groupIds: string[];
+  page: number;
+  per: number;
+};
+
+/**
+ * Convert a free-form user query into a safe FTS5 MATCH expression.
+ * - Lowercases, splits on whitespace.
+ * - Strips characters FTS5 treats as syntax (`"`, `*`, `:`, parens, `-`, etc.).
+ * - Wraps each remaining token in double quotes and ANDs them together.
+ * - Appends `*` to the final token for prefix matching.
+ *
+ * Returns null if the query reduces to zero usable tokens, in which case the
+ * caller should short-circuit to an empty result set rather than running FTS.
+ */
+export function toFtsMatchExpr(q: string): string | null {
+  const tokens = q
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^\p{L}\p{N}]+/gu, ""))
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+  const quoted = tokens.map((t) => `"${t}"`);
+  // Prefix-match the trailing token so partial typing returns hits.
+  quoted[quoted.length - 1] = `${quoted[quoted.length - 1]}*`;
+  return quoted.join(" AND ");
+}
+
+type RawQuestionHit = {
+  question_id: string;
+  title: string;
+  title_snippet: string;
+  body_excerpt: string;
+  created_at: Date;
+  group_id: string;
+  author_id: string;
+  score: number;
+};
+
+type RawAnswerHit = {
+  answer_id: string;
+  question_id: string;
+  title: string;
+  body_excerpt: string;
+  created_at: Date;
+  group_id: string;
+  author_id: string;
+  score: number;
+};
+
+export async function searchContent(opts: SearchOptions): Promise<SearchResultsPage> {
+  const { q, scope, groupIds, page, per } = opts;
+  const expr = toFtsMatchExpr(q);
+
+  if (expr === null) {
+    return { items: [], total: 0, page, per };
+  }
+
+  const useGroupFilter =
+    (scope === "current" || scope === "selected") && groupIds.length > 0;
+
+  const groupFilterQuestion = useGroupFilter
+    ? Prisma.sql`AND q."groupId" IN (${Prisma.join(groupIds)})`
+    : Prisma.empty;
+
+  // Fetch enough rows from each side to cover the requested page after merge.
+  const fetchLimit = page * per;
+
+  const [questionRows, answerRows, questionTotalRows, answerTotalRows] =
+    await Promise.all([
+      db.$queryRaw<RawQuestionHit[]>(Prisma.sql`
+        SELECT
+          q.id AS question_id,
+          q.title AS title,
+          snippet(question_fts, 1, '<mark>', '</mark>', '…', 12) AS title_snippet,
+          snippet(question_fts, 2, '<mark>', '</mark>', '…', 24) AS body_excerpt,
+          q."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          q."authorId" AS author_id,
+          bm25(question_fts) AS score
+        FROM question_fts
+        JOIN "Question" q ON q.id = question_fts.id
+        WHERE question_fts MATCH ${expr}
+        ${groupFilterQuestion}
+        ORDER BY score ASC, created_at DESC
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<RawAnswerHit[]>(Prisma.sql`
+        SELECT
+          a.id AS answer_id,
+          a."questionId" AS question_id,
+          q.title AS title,
+          snippet(answer_fts, 1, '<mark>', '</mark>', '…', 24) AS body_excerpt,
+          a."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          a."authorId" AS author_id,
+          bm25(answer_fts) AS score
+        FROM answer_fts
+        JOIN "Answer" a ON a.id = answer_fts.id
+        JOIN "Question" q ON q.id = a."questionId"
+        WHERE answer_fts MATCH ${expr}
+        ${groupFilterQuestion}
+        ORDER BY score ASC, created_at DESC
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*) AS n
+        FROM question_fts
+        JOIN "Question" q ON q.id = question_fts.id
+        WHERE question_fts MATCH ${expr}
+        ${groupFilterQuestion}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*) AS n
+        FROM answer_fts
+        JOIN "Answer" a ON a.id = answer_fts.id
+        JOIN "Question" q ON q.id = a."questionId"
+        WHERE answer_fts MATCH ${expr}
+        ${groupFilterQuestion}
+      `),
+    ]);
+
+  const total =
+    Number(questionTotalRows[0]?.n ?? 0) + Number(answerTotalRows[0]?.n ?? 0);
+
+  if (questionRows.length === 0 && answerRows.length === 0) {
+    return { items: [], total, page, per };
+  }
+
+  const allGroupIds = new Set<string>();
+  const allAuthorIds = new Set<string>();
+  for (const r of questionRows) {
+    allGroupIds.add(r.group_id);
+    allAuthorIds.add(r.author_id);
+  }
+  for (const r of answerRows) {
+    allGroupIds.add(r.group_id);
+    allAuthorIds.add(r.author_id);
+  }
+
+  const [groupRows, authorRows] = await Promise.all([
+    db.group.findMany({
+      where: { id: { in: [...allGroupIds] } },
+      select: { id: true, slug: true, name: true },
+    }),
+    db.user.findMany({
+      where: { id: { in: [...allAuthorIds] } },
+      select: { id: true, email: true, name: true },
+    }),
+  ]);
+  const groupsById = new Map(groupRows.map((g) => [g.id, g]));
+  const authorsById = new Map(authorRows.map((u) => [u.id, u]));
+
+  // Convert FTS5 BM25 (lower = better, often negative) to a positive
+  // "higher is better" score by negating. Callers can compare scores within a
+  // single response, but the absolute magnitude is opaque.
+  const toPublicScore = (bm25: number) => -bm25;
+
+  const questionHits: SearchHit[] = questionRows.flatMap((r) => {
+    const group = groupsById.get(r.group_id);
+    const author = authorsById.get(r.author_id);
+    if (!group || !author) return [];
+    return [
+      {
+        type: "question",
+        questionId: r.question_id,
+        answerId: null,
+        title: r.title,
+        titleSnippet: r.title_snippet,
+        bodyExcerpt: r.body_excerpt,
+        group,
+        author,
+        score: toPublicScore(r.score),
+        createdAt: r.created_at,
+      },
+    ];
+  });
+
+  const answerHits: SearchHit[] = answerRows.flatMap((r) => {
+    const group = groupsById.get(r.group_id);
+    const author = authorsById.get(r.author_id);
+    if (!group || !author) return [];
+    return [
+      {
+        type: "answer",
+        questionId: r.question_id,
+        answerId: r.answer_id,
+        title: r.title,
+        titleSnippet: null,
+        bodyExcerpt: r.body_excerpt,
+        group,
+        author,
+        score: toPublicScore(r.score),
+        createdAt: r.created_at,
+      },
+    ];
+  });
+
+  const merged = [...questionHits, ...answerHits].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  });
+
+  const start = (page - 1) * per;
+  const items = merged.slice(start, start + per);
+
+  return { items, total, page, per };
+}

--- a/src/lib/validation/search.ts
+++ b/src/lib/validation/search.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z
+  .object({
+    q: z
+      .string()
+      .trim()
+      .min(1, "Query is required.")
+      .max(200, "Query must be at most 200 characters."),
+    scope: z.enum(["current", "selected", "all"]).default("all"),
+    groupIds: z
+      .string()
+      .optional()
+      .transform((v) => (v ? v.split(",").map((s) => s.trim()).filter(Boolean) : []))
+      .pipe(z.array(z.string().min(1)).max(50, "At most 50 groupIds.")),
+    page: z.coerce.number().int().min(1).default(1),
+    per: z.coerce.number().int().min(1).max(50).default(20),
+  })
+  .superRefine((val, ctx) => {
+    if ((val.scope === "current" || val.scope === "selected") && val.groupIds.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["groupIds"],
+        message: "groupIds is required for this scope.",
+      });
+    }
+    if (val.scope === "current" && val.groupIds.length > 1) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["groupIds"],
+        message: "scope=current accepts exactly one groupId.",
+      });
+    }
+  });
+
+export type SearchQueryInput = z.input<typeof searchQuerySchema>;
+export type SearchQuery = z.output<typeof searchQuerySchema>;


### PR DESCRIPTION
## Summary
- Adds `GET /api/search?q=...&scope=...&groupIds=...` (public, paginated) plus a minimal `/search` page that surfaces matches with highlighted snippets — implements M5 acceptance criteria for issue #15 except the deferred Postgres path.
- Search is backed by new SQLite FTS5 virtual tables (`question_fts`, `answer_fts`) and insert/update/delete triggers added in a new Prisma migration; the query layer (`src/lib/search.ts`) tokenizes user input into a safe FTS5 `MATCH` expression, runs ranked `\$queryRaw` against both shadows, batches group/author hydration, and merges + paginates results.
- 19 new tests cover tokenizer edge cases, trigger correctness (insert/update/delete), title/body/answer matches, scope filtering, and HTTP-level validation/pagination.

## Notes
- Per discussion, the Postgres `tsvector` track + `DATABASE_PROVIDER` gating from the issue's AC are intentionally deferred until the connector swap is staged — the repo is sqlite-only today, so the dual-track is revisited then.
- The diff also includes 105 incidental lines in `package-lock.json` (cross-platform `@next/swc-*` optional-dep entries that resolved during \`npm run build\`); harmless but unrelated to the feature.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` (268 passed)
- [x] \`npm run build\` (\`/api/search\` and \`/search\` registered)
- [ ] Manual smoke: \`npm run dev\`, post a question + answer, hit \`/api/search\` and \`/search\`