### PR TITLE
feat(search): header search input and scope toggle UI (closes #16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,6 +1215,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -10305,111 +10410,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,0 +1,21 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6" aria-busy="true" aria-live="polite">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Search</h1>
+        <p className="text-sm text-muted-foreground">Search questions and answers across groups.</p>
+      </div>
+      <div className="h-8 w-full max-w-md animate-pulse rounded-lg bg-muted" />
+      <div className="flex gap-2">
+        <div className="h-7 w-24 animate-pulse rounded-md bg-muted" />
+        <div className="h-7 w-24 animate-pulse rounded-md bg-muted" />
+        <div className="h-7 w-24 animate-pulse rounded-md bg-muted" />
+      </div>
+      <ul className="space-y-3">
+        {[0, 1, 2].map((i) => (
+          <li key={i} className="h-24 animate-pulse rounded-lg border border-border bg-muted/30" />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/search/normalize.test.ts
+++ b/src/app/search/normalize.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { applyGroupSlugDefault } from "./normalize";
+
+describe("applyGroupSlugDefault", () => {
+  it("defaults scope to 'current' when entering with a resolved groupSlug and no scope/groupIds", () => {
+    const out = applyGroupSlugDefault(undefined, undefined, "g_123", "engineering");
+    expect(out).toEqual({
+      scope: "current",
+      groupIds: ["g_123"],
+      groupSlugForUrl: "engineering",
+    });
+  });
+
+  it("ignores groupSlug default when scope is set explicitly", () => {
+    const out = applyGroupSlugDefault("all", undefined, "g_123", "engineering");
+    expect(out.scope).toBe("all");
+    expect(out.groupIds).toEqual([]);
+    expect(out.groupSlugForUrl).toBeNull();
+  });
+
+  it("ignores groupSlug default when groupIds is set explicitly", () => {
+    const out = applyGroupSlugDefault(undefined, "g_other", "g_123", "engineering");
+    expect(out.scope).toBe("all");
+    expect(out.groupIds).toEqual(["g_other"]);
+    expect(out.groupSlugForUrl).toBeNull();
+  });
+
+  it("falls back to 'all' when no slug context and no scope provided", () => {
+    const out = applyGroupSlugDefault(undefined, undefined, null, undefined);
+    expect(out).toEqual({ scope: "all", groupIds: [], groupSlugForUrl: null });
+  });
+
+  it("does not apply slug default when slug provided but unresolved (non-existent group)", () => {
+    const out = applyGroupSlugDefault(undefined, undefined, null, "ghost-slug");
+    expect(out.scope).toBe("all");
+    expect(out.groupIds).toEqual([]);
+    expect(out.groupSlugForUrl).toBeNull();
+  });
+
+  it("parses csv groupIds when scope=selected", () => {
+    const out = applyGroupSlugDefault("selected", "a,b,c", null, undefined);
+    expect(out.scope).toBe("selected");
+    expect(out.groupIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("treats unknown scope strings as 'all'", () => {
+    const out = applyGroupSlugDefault("bogus", undefined, null, undefined);
+    expect(out.scope).toBe("all");
+  });
+
+  it("trims whitespace and drops empty entries from csv groupIds", () => {
+    const out = applyGroupSlugDefault("selected", " a , ,b ", null, undefined);
+    expect(out.groupIds).toEqual(["a", "b"]);
+  });
+});

--- a/src/app/search/normalize.ts
+++ b/src/app/search/normalize.ts
@@ -1,0 +1,40 @@
+export type NormalizedScope = "all" | "current" | "selected";
+
+export type Normalized = {
+  scope: NormalizedScope;
+  groupIds: string[];
+  groupSlugForUrl: string | null;
+};
+
+/**
+ * Apply the group-context default: when /search is entered with `groupSlug` and
+ * the user hasn't picked a different scope, scope to that group. Once the user
+ * sets `scope` or `groupIds` explicitly, those win.
+ */
+export function applyGroupSlugDefault(
+  rawScope: string | undefined,
+  rawGroupIds: string | undefined,
+  resolvedSlugId: string | null,
+  groupSlug: string | undefined,
+): Normalized {
+  const explicitScope = rawScope === "all" || rawScope === "current" || rawScope === "selected";
+  const hasGroupIds = (rawGroupIds ?? "").length > 0;
+
+  if (!explicitScope && !hasGroupIds && resolvedSlugId) {
+    return {
+      scope: "current",
+      groupIds: [resolvedSlugId],
+      groupSlugForUrl: groupSlug ?? null,
+    };
+  }
+
+  const scope: NormalizedScope =
+    rawScope === "current" || rawScope === "selected" ? rawScope : "all";
+  const groupIds = rawGroupIds
+    ? rawGroupIds
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+  return { scope, groupIds, groupSlugForUrl: null };
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,15 +2,21 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { getSession } from "@/lib/auth";
+import { getGroupBySlug } from "@/lib/groups";
+import { listGroupsForUser } from "@/lib/profile";
 import { searchContent, type SearchHit } from "@/lib/search";
 import { searchQuerySchema } from "@/lib/validation/search";
+
+import { applyGroupSlugDefault } from "./normalize";
+import { SearchControls, type MyGroup } from "./search-controls";
 
 type Props = {
   searchParams: Promise<{
     q?: string;
     scope?: string;
     groupIds?: string;
+    groupSlug?: string;
     page?: string;
     per?: string;
   }>;
@@ -71,9 +77,7 @@ function HitCard({ hit }: { hit: SearchHit }) {
           {titleNode}
         </Link>
       </h2>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {renderSnippet(hit.bodyExcerpt)}
-      </p>
+      <p className="mt-1 text-sm text-muted-foreground">{renderSnippet(hit.bodyExcerpt)}</p>
     </li>
   );
 }
@@ -83,6 +87,7 @@ function PageLink({
   q,
   scope,
   groupIds,
+  groupSlug,
   per,
   children,
   disabled,
@@ -91,6 +96,7 @@ function PageLink({
   q: string;
   scope: string;
   groupIds: string | undefined;
+  groupSlug: string | undefined;
   per: number;
   children: ReactNode;
   disabled?: boolean;
@@ -104,6 +110,7 @@ function PageLink({
   }
   const params = new URLSearchParams({ q, scope, page: String(to), per: String(per) });
   if (groupIds) params.set("groupIds", groupIds);
+  if (groupSlug) params.set("groupSlug", groupSlug);
   return (
     <Button variant="outline" size="sm" render={<Link href={`/search?${params.toString()}`} />}>
       {children}
@@ -114,23 +121,39 @@ function PageLink({
 export default async function SearchPage({ searchParams }: Props) {
   const sp = await searchParams;
   const rawQ = sp.q?.trim() ?? "";
-  const scopeRaw = sp.scope ?? "all";
-  const scope: "all" | "current" | "selected" =
-    scopeRaw === "current" || scopeRaw === "selected" ? scopeRaw : "all";
-  const groupIdsRaw = sp.groupIds;
   const per = Math.min(Math.max(Number(sp.per) || 20, 1), 50);
   const requestedPage = Math.max(Number(sp.page) || 1, 1);
 
-  let results:
-    | { items: SearchHit[]; total: number; page: number; per: number }
-    | null = null;
+  const [session, contextGroup] = await Promise.all([
+    getSession(),
+    sp.groupSlug ? getGroupBySlug(sp.groupSlug) : Promise.resolve(null),
+  ]);
+
+  const myGroups: MyGroup[] = session
+    ? (await listGroupsForUser(session.user.id, { includePending: false })).map((g) => ({
+        id: g.id,
+        slug: g.slug,
+        name: g.name,
+      }))
+    : [];
+
+  const normalized = applyGroupSlugDefault(
+    sp.scope,
+    sp.groupIds,
+    contextGroup?.id ?? null,
+    sp.groupSlug,
+  );
+
+  const groupIdsCsv = normalized.groupIds.length > 0 ? normalized.groupIds.join(",") : undefined;
+
+  let results: { items: SearchHit[]; total: number; page: number; per: number } | null = null;
   let validationMessage: string | null = null;
 
   if (rawQ.length > 0) {
     const parsed = searchQuerySchema.safeParse({
       q: rawQ,
-      scope,
-      groupIds: groupIdsRaw,
+      scope: normalized.scope,
+      groupIds: groupIdsCsv,
       page: String(requestedPage),
       per: String(per),
     });
@@ -150,31 +173,21 @@ export default async function SearchPage({ searchParams }: Props) {
         <h1 className="text-2xl font-semibold tracking-tight">Search</h1>
         <p className="text-sm text-muted-foreground">
           Search questions and answers across groups.
+          {contextGroup ? (
+            <>
+              {" "}
+              Defaulting to <span className="font-medium">{contextGroup.name}</span>.
+            </>
+          ) : null}
         </p>
       </div>
 
-      <form className="flex flex-wrap items-center gap-2" method="get" action="/search">
-        <Input
-          name="q"
-          defaultValue={rawQ}
-          placeholder="Search…"
-          aria-label="Search query"
-          className="max-w-md flex-1"
-          autoFocus
-        />
-        <select
-          name="scope"
-          defaultValue={scope}
-          aria-label="Scope"
-          className="h-8 rounded-lg border border-input bg-transparent px-2 text-sm"
-        >
-          <option value="all">All groups</option>
-          <option value="selected">Selected groups</option>
-          <option value="current">Current group</option>
-        </select>
-        {groupIdsRaw ? <input type="hidden" name="groupIds" value={groupIdsRaw} /> : null}
-        <Button type="submit">Search</Button>
-      </form>
+      <SearchControls
+        initialQ={rawQ}
+        initialScope={normalized.scope}
+        initialGroupIds={normalized.groupIds}
+        myGroups={myGroups}
+      />
 
       {validationMessage ? (
         <p className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
@@ -182,7 +195,11 @@ export default async function SearchPage({ searchParams }: Props) {
         </p>
       ) : null}
 
-      {results && rawQ.length > 0 ? (
+      {rawQ.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+          Type a query to search.
+        </p>
+      ) : results ? (
         results.items.length === 0 ? (
           <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
             No matches for <span className="font-medium">“{rawQ}”</span>.
@@ -190,7 +207,8 @@ export default async function SearchPage({ searchParams }: Props) {
         ) : (
           <div className="space-y-4">
             <p className="text-xs text-muted-foreground">
-              {results.total} match{results.total === 1 ? "" : "es"} · page {currentPage} of {totalPages}
+              {results.total} match{results.total === 1 ? "" : "es"} · page {currentPage} of{" "}
+              {totalPages}
             </p>
             <ul className="space-y-3">
               {results.items.map((hit) => (
@@ -201,8 +219,9 @@ export default async function SearchPage({ searchParams }: Props) {
               <PageLink
                 to={currentPage - 1}
                 q={rawQ}
-                scope={scope}
-                groupIds={groupIdsRaw}
+                scope={normalized.scope}
+                groupIds={groupIdsCsv}
+                groupSlug={normalized.groupSlugForUrl ?? undefined}
                 per={per}
                 disabled={currentPage <= 1}
               >
@@ -211,8 +230,9 @@ export default async function SearchPage({ searchParams }: Props) {
               <PageLink
                 to={currentPage + 1}
                 q={rawQ}
-                scope={scope}
-                groupIds={groupIdsRaw}
+                scope={normalized.scope}
+                groupIds={groupIdsCsv}
+                groupSlug={normalized.groupSlugForUrl ?? undefined}
                 per={per}
                 disabled={currentPage >= totalPages}
               >

--- a/src/app/search/search-controls.tsx
+++ b/src/app/search/search-controls.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const DEBOUNCE_MS = 250;
+const MAX_GROUP_IDS = 50;
+
+export type ScopeOption = "all" | "my" | "pick";
+
+export type MyGroup = { id: string; slug: string; name: string };
+
+type Props = {
+  initialQ: string;
+  initialScope: "all" | "selected" | "current";
+  initialGroupIds: string[];
+  myGroups: MyGroup[];
+};
+
+function arraysEqualSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  for (const x of b) if (!sa.has(x)) return false;
+  return true;
+}
+
+function deriveSurfaceScope(
+  apiScope: "all" | "selected" | "current",
+  groupIds: string[],
+  myGroupIds: string[],
+): ScopeOption {
+  if (apiScope === "all") return "all";
+  if (apiScope === "selected" && myGroupIds.length > 0 && arraysEqualSet(groupIds, myGroupIds)) {
+    return "my";
+  }
+  return "pick";
+}
+
+export function SearchControls({ initialQ, initialScope, initialGroupIds, myGroups }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const myGroupIds = useMemo(() => myGroups.map((g) => g.id), [myGroups]);
+
+  const [q, setQ] = useState(initialQ);
+  const [surfaceScope, setSurfaceScope] = useState<ScopeOption>(() =>
+    deriveSurfaceScope(initialScope, initialGroupIds, myGroupIds),
+  );
+  const [pickedGroupIds, setPickedGroupIds] = useState<string[]>(() => {
+    if (initialScope === "selected" || initialScope === "current") return initialGroupIds;
+    return [];
+  });
+
+  // When the URL's q changes from outside (header submit, back button), reset
+  // the local typing buffer. Uses React's "adjust state during render" pattern.
+  const [prevInitialQ, setPrevInitialQ] = useState(initialQ);
+  if (prevInitialQ !== initialQ) {
+    setPrevInitialQ(initialQ);
+    setQ(initialQ);
+  }
+
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const handle = setTimeout(() => {
+      const params = new URLSearchParams();
+      const trimmed = q.trim();
+      if (trimmed) params.set("q", trimmed);
+
+      if (surfaceScope === "all") {
+        params.set("scope", "all");
+      } else if (surfaceScope === "my") {
+        if (myGroupIds.length > 0) {
+          params.set("scope", "selected");
+          params.set("groupIds", myGroupIds.join(","));
+        } else {
+          params.set("scope", "all");
+        }
+      } else {
+        params.set("scope", "selected");
+        if (pickedGroupIds.length > 0) {
+          params.set("groupIds", pickedGroupIds.join(","));
+        }
+      }
+
+      const qs = params.toString();
+      startTransition(() => {
+        router.replace(qs ? `/search?${qs}` : "/search", { scroll: false });
+      });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [q, surfaceScope, pickedGroupIds, myGroupIds, router]);
+
+  const myDisabled = myGroups.length === 0;
+  const noPicked = surfaceScope === "pick" && pickedGroupIds.length === 0;
+
+  function togglePicked(groupId: string) {
+    setPickedGroupIds((prev) => {
+      if (prev.includes(groupId)) return prev.filter((g) => g !== groupId);
+      if (prev.length >= MAX_GROUP_IDS) return prev;
+      return [...prev, groupId];
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          name="q"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search questions and answers…"
+          aria-label="Search query"
+          className="max-w-md flex-1"
+          autoFocus
+        />
+        {isPending ? (
+          <span className="text-xs text-muted-foreground" aria-live="polite">
+            Searching…
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className="flex flex-wrap items-center gap-1"
+        role="radiogroup"
+        aria-label="Search scope"
+      >
+        <ScopeButton pressed={surfaceScope === "all"} onClick={() => setSurfaceScope("all")}>
+          All groups
+        </ScopeButton>
+        <ScopeButton
+          pressed={surfaceScope === "my"}
+          onClick={() => setSurfaceScope("my")}
+          disabled={myDisabled}
+          title={myDisabled ? "Join a group to use this scope." : undefined}
+        >
+          My groups
+        </ScopeButton>
+        <ScopeButton pressed={surfaceScope === "pick"} onClick={() => setSurfaceScope("pick")}>
+          Pick groups
+        </ScopeButton>
+      </div>
+
+      {surfaceScope === "pick" ? (
+        myGroups.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+            You aren&apos;t a member of any groups yet.
+          </p>
+        ) : (
+          <fieldset className="space-y-1 rounded-lg border border-border p-3">
+            <legend className="px-1 text-xs font-medium text-muted-foreground">
+              Choose groups ({pickedGroupIds.length} selected)
+            </legend>
+            <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+              {myGroups.slice(0, MAX_GROUP_IDS).map((g) => {
+                const checked = pickedGroupIds.includes(g.id);
+                return (
+                  <li key={g.id}>
+                    <label className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-sm hover:bg-muted">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => togglePicked(g.id)}
+                        className="size-4 rounded border-input"
+                      />
+                      <span className="truncate">{g.name}</span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+            {noPicked ? (
+              <p className="px-1 pt-1 text-xs text-muted-foreground">
+                Pick at least one group to see results.
+              </p>
+            ) : null}
+          </fieldset>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function ScopeButton({
+  pressed,
+  onClick,
+  disabled,
+  title,
+  children,
+}: {
+  pressed: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant={pressed ? "secondary" : "outline"}
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-pressed={pressed}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const GROUP_PATH = /^\/groups\/([^/]+)/;
+
+function currentGroupSlug(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const match = pathname.match(GROUP_PATH);
+  if (!match) return null;
+  const slug = match[1];
+  if (slug === "new") return null;
+  return slug;
+}
+
+export function HeaderSearch() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [value, setValue] = useState("");
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const q = value.trim();
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    const slug = currentGroupSlug(pathname);
+    if (slug) params.set("groupSlug", slug);
+    const qs = params.toString();
+    router.push(qs ? `/search?${qs}` : "/search");
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="hidden w-full max-w-xs items-center gap-1 md:flex"
+      role="search"
+    >
+      <div className="relative flex-1">
+        <SearchIcon
+          aria-hidden
+          className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          type="search"
+          name="q"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Search…"
+          aria-label="Search"
+          className="pl-7"
+        />
+      </div>
+      <Button variant="ghost" size="icon-sm" type="submit" aria-label="Submit search">
+        <SearchIcon className="size-3.5" />
+      </Button>
+    </form>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link";
-import { SearchIcon } from "lucide-react";
 
 import { UserMenu } from "@/components/auth/user-menu";
+import { HeaderSearch } from "@/components/header-search";
 import { ModeToggle } from "@/components/mode-toggle";
 import { NotificationBell } from "@/components/notification-bell";
-import { Button } from "@/components/ui/button";
 
 export function SiteHeader() {
   return (
@@ -14,15 +13,7 @@ export function SiteHeader() {
           SME Directory
         </Link>
         <div className="flex flex-1 items-center justify-end gap-3">
-          <Button
-            variant="outline"
-            size="sm"
-            className="hidden w-full max-w-xs justify-start gap-2 text-muted-foreground md:flex"
-            render={<Link href="/search" />}
-          >
-            <SearchIcon className="size-3.5" />
-            <span>Search…</span>
-          </Button>
+          <HeaderSearch />
           <nav className="flex items-center gap-3 text-sm">
             <Link href="/groups" className="text-muted-foreground hover:text-foreground">
               Groups


### PR DESCRIPTION
## Summary
- Adds a global header search input (`<HeaderSearch>`) that submits to `/search` and includes the current group's slug when on `/groups/<slug>` so the results page can default scope to that group.
- Adds a `<SearchControls>` client component on the `/search` page with an All groups / My groups / Pick groups toggle, multi-select group picker (capped at 50 to match the API), debounced (250 ms) URL updates via `router.replace`, and a `useTransition`-driven "Searching…" indicator.
- Adds `loading.tsx` skeleton, a pre-search empty state, and a pure `applyGroupSlugDefault` helper (with 8 unit tests) that resolves `groupSlug` → `scope=current` only when the user hasn't picked an explicit scope/groupIds.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 28 files / 276 tests pass (incl. 8 new normalize tests)
- [ ] Manual smoke: header search from `/`, `/groups`, `/me`; scope toggle on `/search`; entering search from `/groups/<slug>` defaults to that group; copy/paste URL restores state

🤖 Generated with [Claude Code](https://claude.com/claude-code)