### PR TITLE
feat(questions): allow authors to edit a question (closes #39)

### DIFF
--- a/src/app/api/questions/[id]/route.test.ts
+++ b/src/app/api/questions/[id]/route.test.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/questions/[id] route handler tests.
+ * GET + PATCH + DELETE /api/questions/[id] route handler tests.
  */
 
 import fs from "node:fs";
@@ -37,7 +37,7 @@ const auth = await import("@/lib/auth");
 const { db } = await import("@/lib/db");
 const { createGroup } = await import("@/lib/groups");
 const { applyToGroup } = await import("@/lib/memberships");
-const { GET, DELETE } = await import("./route");
+const { GET, PATCH, DELETE } = await import("./route");
 
 beforeAll(async () => {
   const root = path.resolve(import.meta.dirname, "../../../../..");
@@ -76,6 +76,22 @@ function delReq(id: string): Request {
   return new Request(`http://x/api/questions/${id}`, { method: "DELETE" });
 }
 
+function jsonReq(url: string, method: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function rawReq(url: string, method: string, body: string): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
 type DeleteSetup = {
   groupId: string;
   questionId: string;
@@ -112,6 +128,42 @@ async function setupForDelete(slug: string): Promise<DeleteSetup> {
     groupId: group.id,
     questionId: question.id,
     ownerId: ownerSess.user.id,
+    authorId: authorSess.user.id,
+  };
+}
+
+type PatchSetup = {
+  groupId: string;
+  questionId: string;
+  authorId: string;
+};
+
+async function setupQuestion(slug: string): Promise<PatchSetup> {
+  const ownerEmail = `o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+
+  cookieStore.clear();
+  const authorEmail = `a-${slug}-${Math.random()}@example.com`;
+  await auth.signIn(authorEmail);
+  const authorSess = (await auth.getSession())!;
+  await applyToGroup(group.id, authorSess.user.id);
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: authorSess.user.id,
+      title: "Original question title",
+      body: "Original question body.",
+    },
+  });
+
+  return {
+    groupId: group.id,
+    questionId: question.id,
     authorId: authorSess.user.id,
   };
 }
@@ -264,5 +316,112 @@ describe("DELETE /api/questions/[id]", () => {
 
     const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/questions/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await PATCH(
+      jsonReq("http://x/api/questions/abc", "PATCH", {
+        title: "A new title here",
+        body: "Some new body content.",
+      }),
+      ctx("abc"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when question is unknown", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await PATCH(
+      jsonReq("http://x/api/questions/missing", "PATCH", {
+        title: "A new title here",
+        body: "Some new body content.",
+      }),
+      ctx("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when JSON body is malformed", async () => {
+    await auth.signIn(`m-${Date.now()}@example.com`);
+    const res = await PATCH(
+      rawReq("http://x/api/questions/anything", "PATCH", "{ not json"),
+      ctx("anything"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is too short", async () => {
+    const setup = await setupQuestion(`v1-${Date.now()}`);
+    const res = await PATCH(
+      jsonReq(`http://x/api/questions/${setup.questionId}`, "PATCH", {
+        title: "hi",
+        body: "Some valid body content.",
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is empty", async () => {
+    const setup = await setupQuestion(`v2-${Date.now()}`);
+    const res = await PATCH(
+      jsonReq(`http://x/api/questions/${setup.questionId}`, "PATCH", {
+        title: "A perfectly valid title",
+        body: "",
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller is not the author", async () => {
+    const setup = await setupQuestion(`f1-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`other-${Date.now()}-${Math.random()}@example.com`);
+    const res = await PATCH(
+      jsonReq(`http://x/api/questions/${setup.questionId}`, "PATCH", {
+        title: "Stranger's edited title",
+        body: "Stranger's edited body.",
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(403);
+
+    const stillThere = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    expect(stillThere!.title).toBe("Original question title");
+    expect(stillThere!.body).toBe("Original question body.");
+  });
+
+  it("returns 200 with the updated question for the author", async () => {
+    const setup = await setupQuestion(`h1-${Date.now()}`);
+    const before = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const res = await PATCH(
+      jsonReq(`http://x/api/questions/${setup.questionId}`, "PATCH", {
+        title: "Updated question title",
+        body: "Updated question body.",
+      }),
+      ctx(setup.questionId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.question.title).toBe("Updated question title");
+    expect(json.question.body).toBe("Updated question body.");
+
+    const after = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    expect(after!.title).toBe("Updated question title");
+    expect(after!.body).toBe("Updated question body.");
+    expect(after!.updatedAt.getTime()).toBeGreaterThan(
+      before!.updatedAt.getTime(),
+    );
   });
 });

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,6 +1,15 @@
 import { getSession } from "@/lib/auth";
-import { errorToResponse, unauthorized } from "@/lib/api/errors";
-import { getQuestionById, softDeleteQuestion } from "@/lib/questions";
+import {
+  errorToResponse,
+  unauthorized,
+  validationFailed,
+} from "@/lib/api/errors";
+import {
+  getQuestionById,
+  softDeleteQuestion,
+  updateQuestion,
+} from "@/lib/questions";
+import { updateQuestionSchema } from "@/lib/validation/questions";
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -8,6 +17,32 @@ export async function GET(_req: Request, ctx: Ctx): Promise<Response> {
   const { id } = await ctx.params;
   try {
     const question = await getQuestionById(id);
+    return Response.json({ question }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}
+
+export async function PATCH(req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateQuestionSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const question = await updateQuestion(id, parsed.data, session.user.id);
     return Response.json({ question }, { status: 200 });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -12,12 +12,18 @@ import {
   deleteAnswer,
   updateAnswer,
 } from "@/lib/answers";
-import { acceptAnswer, reopenQuestion, softDeleteQuestion } from "@/lib/questions";
+import {
+  acceptAnswer,
+  reopenQuestion,
+  softDeleteQuestion,
+  updateQuestion,
+} from "@/lib/questions";
 import { db } from "@/lib/db";
 import {
   createAnswerSchema,
   updateAnswerSchema,
 } from "@/lib/validation/answers";
+import { updateQuestionSchema } from "@/lib/validation/questions";
 
 export type FieldError = { path: string; message: string };
 
@@ -114,6 +120,57 @@ export async function updateAnswerAction(
     }
     return {
       error: err instanceof Error ? err.message : "Could not update answer.",
+      values: raw,
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export type QuestionFormState = {
+  ok?: boolean;
+  error?: string;
+  fieldErrors?: FieldError[];
+  values?: { title?: string; body?: string };
+};
+
+export async function updateQuestionAction(
+  questionId: string,
+  _prev: QuestionFormState,
+  formData: FormData,
+): Promise<QuestionFormState> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to edit a question." };
+  }
+
+  const raw = {
+    title: String(formData.get("title") ?? ""),
+    body: String(formData.get("body") ?? ""),
+  };
+  const parsed = updateQuestionSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+      values: raw,
+    };
+  }
+
+  try {
+    await updateQuestion(questionId, parsed.data, session.user.id);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only the question's author can edit it.", values: raw };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message, values: raw };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not update question.",
       values: raw,
     };
   }

--- a/src/app/q/[id]/edit-question-form.tsx
+++ b/src/app/q/[id]/edit-question-form.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { MarkdownBody } from "@/components/markdown-body";
+import { updateQuestionAction, type QuestionFormState } from "./actions";
+
+const initialState: QuestionFormState = {};
+
+function fieldError(state: QuestionFormState, path: string): string | undefined {
+  return state.fieldErrors?.find((e) => e.path === path)?.message;
+}
+
+type Props = {
+  questionId: string;
+  title: string;
+  body: string;
+  canEdit: boolean;
+};
+
+export function EditQuestionForm({ questionId, title, body, canEdit }: Props) {
+  const [editing, setEditing] = useState(false);
+
+  const action = updateQuestionAction.bind(null, questionId);
+  const [state, formAction, isPending] = useActionState(action, initialState);
+
+  useEffect(() => {
+    if (state.ok) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEditing(false);
+    }
+  }, [state.ok]);
+
+  if (editing) {
+    return (
+      <form action={formAction} className="space-y-3">
+        <div className="space-y-1">
+          <label htmlFor="edit-question-title" className="block text-sm font-medium">
+            Title
+          </label>
+          <input
+            id="edit-question-title"
+            name="title"
+            type="text"
+            required
+            minLength={5}
+            maxLength={200}
+            defaultValue={state.values?.title ?? title}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+          />
+          {fieldError(state, "title") ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {fieldError(state, "title")}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="edit-question-body" className="block text-sm font-medium">
+            Body <span className="text-zinc-500">(Markdown supported)</span>
+          </label>
+          <textarea
+            id="edit-question-body"
+            name="body"
+            rows={12}
+            required
+            minLength={1}
+            maxLength={20000}
+            defaultValue={state.values?.body ?? body}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+          />
+          {fieldError(state, "body") ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {fieldError(state, "body")}
+            </p>
+          ) : null}
+        </div>
+
+        {state.error ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {state.error}
+          </p>
+        ) : null}
+
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="rounded bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {isPending ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="rounded border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <>
+      <MarkdownBody source={body} />
+      {canEdit ? (
+        <div className="pt-1">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-xs text-zinc-600 underline hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            Edit
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { MarkdownBody } from "@/components/markdown-body";
 import { getSession } from "@/lib/auth";
 import { NotFoundError, getMembership } from "@/lib/memberships";
 import { getQuestionById } from "@/lib/questions";
@@ -12,6 +11,7 @@ import { FavoriteButton } from "./favorite-button";
 import { QuestionResolveControls } from "./question-resolve-controls";
 import { QuestionDeleteButton } from "./question-delete-button";
 import { AcceptAnswerButton } from "./accept-answer-button";
+import { EditQuestionForm } from "./edit-question-form";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -81,12 +81,14 @@ export default async function QuestionDetailPage({ params }: Props) {
     isApprovedViewer &&
     (viewerMembership?.role === "owner" || viewerMembership?.role === "moderator");
   const canDeleteAny = isModOrOwner;
+  const isAuthor =
+    currentUserId !== null && question.author.id === currentUserId;
   const canResolve =
-    currentUserId !== null &&
-    (question.author.id === currentUserId || isModOrOwner);
+    currentUserId !== null && (isAuthor || isModOrOwner);
   const canDeleteQuestion =
-    currentUserId !== null &&
-    (question.author.id === currentUserId || isModOrOwner);
+    currentUserId !== null && (isAuthor || isModOrOwner);
+  const isEdited =
+    question.updatedAt.getTime() > question.createdAt.getTime();
 
   const voteDisabledReason = !currentUserId
     ? "Sign in to vote."
@@ -122,6 +124,11 @@ export default async function QuestionDetailPage({ params }: Props) {
             <Link href={`/groups/${question.group.slug}`} className="underline">
               {question.group.name}
             </Link>
+            {isEdited ? (
+              <span className="ml-2 inline-flex items-center rounded-full border border-zinc-300 bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+                edited
+              </span>
+            ) : null}
           </p>
         </CardHeader>
         <CardContent className="space-y-3 pt-4">
@@ -144,7 +151,12 @@ export default async function QuestionDetailPage({ params }: Props) {
               disabledReason={!currentUserId ? "Sign in to favorite." : undefined}
             />
           </div>
-          <MarkdownBody source={question.body} />
+          <EditQuestionForm
+            questionId={question.id}
+            title={question.title}
+            body={question.body}
+            canEdit={isAuthor}
+          />
         </CardContent>
       </Card>
 

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -8,7 +8,10 @@ import {
 } from "@/lib/memberships";
 import { viewerVotesFor, voteScoresFor } from "@/lib/votes";
 import { viewerFavoritesFor } from "@/lib/favorites";
-import type { CreateQuestionInput } from "@/lib/validation/questions";
+import type {
+  CreateQuestionInput,
+  UpdateQuestionInput,
+} from "@/lib/validation/questions";
 
 export type QuestionAuthor = Pick<User, "id" | "email" | "name">;
 
@@ -56,6 +59,25 @@ export async function createQuestion(
       title: input.title,
       body: input.body,
     },
+  });
+}
+
+export async function updateQuestion(
+  questionId: string,
+  input: UpdateQuestionInput,
+  userId: string,
+): Promise<Question> {
+  const existing = await db.question.findUnique({
+    where: { id: questionId },
+    select: { id: true, authorId: true },
+  });
+  if (!existing) throw new NotFoundError("Question not found.");
+  if (existing.authorId !== userId) {
+    throw new AuthorizationError("Only the question's author can edit it.");
+  }
+  return db.question.update({
+    where: { id: questionId },
+    data: { title: input.title, body: input.body },
   });
 }
 

--- a/src/lib/validation/questions.ts
+++ b/src/lib/validation/questions.ts
@@ -19,6 +19,13 @@ export const createQuestionSchema = z.object({
 
 export type CreateQuestionInput = z.input<typeof createQuestionSchema>;
 
+export const updateQuestionSchema = z.object({
+  title: questionTitleSchema,
+  body: questionBodySchema,
+});
+
+export type UpdateQuestionInput = z.input<typeof updateQuestionSchema>;
+
 export const questionListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   per: z.coerce.number().int().min(1).max(50).default(20),


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/questions/:id` (author-only; validation matches `POST` — title 5–200 chars, body up to 20k) plus a `updateQuestion` lib helper backed by `NotFoundError`/`AuthorizationError`.
- Adds an inline edit form on `/q/:id` (`EditQuestionForm` client component + `updateQuestionAction` server action) shown only when the viewer is the question's author.
- Surfaces an "edited" pill next to the byline when `updatedAt > createdAt`.
- Tests cover unauthenticated (401), unknown id (404), malformed JSON / short title / empty body (400), non-author (403, DB unchanged), and the author happy path (200, `updatedAt` advances).

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npx prisma validate\`
- [x] \`npm test\` (28 files / 283 tests pass)
- [ ] Manual: as the author, click Edit on \`/q/:id\`, change title/body, Save → "edited" pill appears; as a non-author, no Edit button is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)