### PR TITLE
feat(qa): soft delete a question (closes #40)

### DIFF
--- a/prisma/migrations/20260505000000_add_question_soft_delete/migration.sql
+++ b/prisma/migrations/20260505000000_add_question_soft_delete/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Question" ADD COLUMN "deletedAt" DATETIME;
+
+-- CreateIndex
+CREATE INDEX "Question_deletedAt_idx" ON "Question"("deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Question {
   body             String
   status           QuestionStatus @default(open)
   acceptedAnswerId String?        @unique
+  deletedAt        DateTime?
   createdAt        DateTime       @default(now())
   updatedAt        DateTime       @updatedAt
 
@@ -98,6 +99,7 @@ model Question {
 
   @@index([groupId])
   @@index([authorId])
+  @@index([deletedAt])
 }
 
 model Answer {

--- a/src/app/api/groups/[slug]/questions/route.test.ts
+++ b/src/app/api/groups/[slug]/questions/route.test.ts
@@ -243,4 +243,43 @@ describe("GET /api/groups/[slug]/questions", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("excludes soft-deleted questions from the listing and total count", async () => {
+    const ownerEmail = `gd-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `gdel-${Date.now()}`;
+    const group = await createGroup(
+      { name: "GDel", slug, autoApprove: true },
+      ownerSess.user.id,
+    );
+    const visible = await db.question.create({
+      data: {
+        groupId: group.id,
+        authorId: ownerSess.user.id,
+        title: "still here",
+        body: "body",
+      },
+    });
+    const deleted = await db.question.create({
+      data: {
+        groupId: group.id,
+        authorId: ownerSess.user.id,
+        title: "tombstone",
+        body: "body",
+        deletedAt: new Date(),
+      },
+    });
+
+    cookieStore.clear();
+    const res = await GET(
+      jsonReq(`http://x/api/groups/${slug}/questions?page=1&per=10`, "GET"),
+      ctx(slug),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.total).toBe(1);
+    expect(json.items.map((i: { id: string }) => i.id)).toEqual([visible.id]);
+    expect(json.items.find((i: { id: string }) => i.id === deleted.id)).toBeUndefined();
+  });
 });

--- a/src/app/api/questions/[id]/answers/route.ts
+++ b/src/app/api/questions/[id]/answers/route.ts
@@ -28,9 +28,11 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
   try {
     const question = await db.question.findUnique({
       where: { id },
-      select: { id: true, groupId: true },
+      select: { id: true, groupId: true, deletedAt: true },
     });
-    if (!question) throw new NotFoundError("Question not found.");
+    if (!question || question.deletedAt) {
+      throw new NotFoundError("Question not found.");
+    }
     await assertApprovedMember(question.groupId, session.user.id);
     const answer = await createAnswer(parsed.data, question.id, session.user.id);
     return Response.json({ answer }, { status: 201 });

--- a/src/app/api/questions/[id]/route.test.ts
+++ b/src/app/api/questions/[id]/route.test.ts
@@ -36,7 +36,8 @@ vi.mock("next/navigation", () => ({
 const auth = await import("@/lib/auth");
 const { db } = await import("@/lib/db");
 const { createGroup } = await import("@/lib/groups");
-const { GET } = await import("./route");
+const { applyToGroup } = await import("@/lib/memberships");
+const { GET, DELETE } = await import("./route");
 
 beforeAll(async () => {
   const root = path.resolve(import.meta.dirname, "../../../../..");
@@ -69,6 +70,56 @@ function ctx(id: string) {
 
 function req(id: string): Request {
   return new Request(`http://x/api/questions/${id}`, { method: "GET" });
+}
+
+function delReq(id: string): Request {
+  return new Request(`http://x/api/questions/${id}`, { method: "DELETE" });
+}
+
+type DeleteSetup = {
+  groupId: string;
+  questionId: string;
+  ownerId: string;
+  authorId: string;
+};
+
+async function setupForDelete(slug: string): Promise<DeleteSetup> {
+  cookieStore.clear();
+  const ownerEmail = `del-o-${slug}@example.com`;
+  await auth.signIn(ownerEmail);
+  const ownerSess = (await auth.getSession())!;
+  const group = await createGroup(
+    { name: slug, slug, autoApprove: true },
+    ownerSess.user.id,
+  );
+
+  cookieStore.clear();
+  const authorEmail = `del-a-${slug}@example.com`;
+  await auth.signIn(authorEmail);
+  const authorSess = (await auth.getSession())!;
+  await applyToGroup(group.id, authorSess.user.id);
+  const question = await db.question.create({
+    data: {
+      groupId: group.id,
+      authorId: authorSess.user.id,
+      title: "To be deleted",
+      body: "Delete me.",
+    },
+  });
+
+  cookieStore.clear();
+  return {
+    groupId: group.id,
+    questionId: question.id,
+    ownerId: ownerSess.user.id,
+    authorId: authorSess.user.id,
+  };
+}
+
+async function signInAs(userId: string): Promise<void> {
+  cookieStore.clear();
+  const u = await db.user.findUnique({ where: { id: userId } });
+  await auth.signIn(u!.email!);
 }
 
 describe("GET /api/questions/[id]", () => {
@@ -104,5 +155,114 @@ describe("GET /api/questions/[id]", () => {
     expect(json.question.author.email).toBe(email);
     expect(json.question.group.slug).toBe(slug);
     expect(json.question.answers).toEqual([]);
+  });
+
+  it("returns 200 with deletedAt populated for a soft-deleted question (tombstone)", async () => {
+    const setup = await setupForDelete(`gd-${Date.now()}`);
+    await db.question.update({
+      where: { id: setup.questionId },
+      data: { deletedAt: new Date() },
+    });
+
+    cookieStore.clear();
+    const res = await GET(req(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.question.id).toBe(setup.questionId);
+    expect(json.question.deletedAt).not.toBeNull();
+    expect(json.question.answers).toEqual([]);
+  });
+});
+
+describe("DELETE /api/questions/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const setup = await setupForDelete(`d1-${Date.now()}`);
+    cookieStore.clear();
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the question does not exist", async () => {
+    await auth.signIn(`d-missing-${Date.now()}@example.com`);
+    const res = await DELETE(delReq("nope"), ctx("nope"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 and sets deletedAt when caller is the author", async () => {
+    const setup = await setupForDelete(`d2-${Date.now()}`);
+    await signInAs(setup.authorId);
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(200);
+    const after = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    expect(after!.deletedAt).not.toBeNull();
+  });
+
+  it("returns 200 when caller is the group owner", async () => {
+    const setup = await setupForDelete(`d3-${Date.now()}`);
+    await signInAs(setup.ownerId);
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(200);
+    const after = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    expect(after!.deletedAt).not.toBeNull();
+  });
+
+  it("returns 200 when caller is a group moderator", async () => {
+    const setup = await setupForDelete(`d4-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`mod-${Date.now()}@example.com`);
+    const modSess = (await auth.getSession())!;
+    await db.membership.create({
+      data: {
+        groupId: setup.groupId,
+        userId: modSess.user.id,
+        role: "moderator",
+        status: "approved",
+      },
+    });
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when caller is a plain approved member", async () => {
+    const setup = await setupForDelete(`d5-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`pm-${Date.now()}@example.com`);
+    const pmSess = (await auth.getSession())!;
+    await applyToGroup(setup.groupId, pmSess.user.id);
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(403);
+    const after = await db.question.findUnique({
+      where: { id: setup.questionId },
+    });
+    expect(after!.deletedAt).toBeNull();
+  });
+
+  it("returns 403 when caller is not a member of the group", async () => {
+    const setup = await setupForDelete(`d6-${Date.now()}`);
+    cookieStore.clear();
+    await auth.signIn(`stranger-${Date.now()}@example.com`);
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when the question is already deleted (idempotent failure)", async () => {
+    const setup = await setupForDelete(`d7-${Date.now()}`);
+    await db.question.update({
+      where: { id: setup.questionId },
+      data: { deletedAt: new Date() },
+    });
+    await signInAs(setup.authorId);
+
+    const res = await DELETE(delReq(setup.questionId), ctx(setup.questionId));
+    expect(res.status).toBe(404);
   });
 });

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,5 +1,6 @@
-import { errorToResponse } from "@/lib/api/errors";
-import { getQuestionById } from "@/lib/questions";
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { getQuestionById, softDeleteQuestion } from "@/lib/questions";
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -8,6 +9,19 @@ export async function GET(_req: Request, ctx: Ctx): Promise<Response> {
   try {
     const question = await getQuestionById(id);
     return Response.json({ question }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}
+
+export async function DELETE(_req: Request, ctx: Ctx): Promise<Response> {
+  const { id } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    await softDeleteQuestion(id, session.user.id);
+    return Response.json({ ok: true }, { status: 200 });
   } catch (err) {
     return errorToResponse(err);
   }

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -12,7 +12,7 @@ import {
   deleteAnswer,
   updateAnswer,
 } from "@/lib/answers";
-import { acceptAnswer, reopenQuestion } from "@/lib/questions";
+import { acceptAnswer, reopenQuestion, softDeleteQuestion } from "@/lib/questions";
 import { db } from "@/lib/db";
 import {
   createAnswerSchema,
@@ -53,9 +53,9 @@ export async function createAnswerAction(
   try {
     const question = await db.question.findUnique({
       where: { id: questionId },
-      select: { id: true, groupId: true },
+      select: { id: true, groupId: true, deletedAt: true },
     });
-    if (!question) {
+    if (!question || question.deletedAt) {
       return { error: "Question not found.", values: raw };
     }
     await assertApprovedMember(question.groupId, session.user.id);
@@ -180,6 +180,40 @@ export async function reopenQuestionAction(
   }
 
   revalidatePath(`/q/${questionId}`);
+  return { ok: true };
+}
+
+export type DeleteQuestionResult = { error?: string; ok?: boolean };
+
+export async function deleteQuestionAction(
+  questionId: string,
+): Promise<DeleteQuestionResult> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to delete a question." };
+  }
+
+  let groupSlug: string | null = null;
+  try {
+    const result = await softDeleteQuestion(questionId, session.user.id);
+    groupSlug = result.groupSlug;
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return {
+        error:
+          "Only the question's author or a group moderator/owner can delete this question.",
+      };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not delete question.",
+    };
+  }
+
+  revalidatePath(`/q/${questionId}`);
+  if (groupSlug) revalidatePath(`/groups/${groupSlug}`);
   return { ok: true };
 }
 

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -10,6 +10,7 @@ import { AnswerActions } from "./answer-actions";
 import { VoteButton } from "./vote-button";
 import { FavoriteButton } from "./favorite-button";
 import { QuestionResolveControls } from "./question-resolve-controls";
+import { QuestionDeleteButton } from "./question-delete-button";
 import { AcceptAnswerButton } from "./accept-answer-button";
 
 type Props = { params: Promise<{ id: string }> };
@@ -32,6 +33,46 @@ export default async function QuestionDetailPage({ params }: Props) {
     throw err;
   }
 
+  if (question.deletedAt) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 py-8">
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle className="text-2xl text-muted-foreground line-through">
+              {question.title}
+            </CardTitle>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Asked by {authorLabel(question.author)} in{" "}
+              <Link
+                href={`/groups/${question.group.slug}`}
+                className="underline"
+              >
+                {question.group.name}
+              </Link>
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-2 pt-4">
+            <p className="text-sm text-muted-foreground">
+              This question has been deleted on{" "}
+              <time dateTime={question.deletedAt.toISOString()}>
+                {question.deletedAt.toLocaleDateString()}
+              </time>
+              . It is no longer listed in the group, search, or notifications.
+            </p>
+            <p className="text-sm">
+              <Link
+                href={`/groups/${question.group.slug}`}
+                className="underline"
+              >
+                Back to {question.group.name}
+              </Link>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   const viewerMembership = currentUserId
     ? await getMembership(question.group.id, currentUserId)
     : null;
@@ -41,6 +82,9 @@ export default async function QuestionDetailPage({ params }: Props) {
     (viewerMembership?.role === "owner" || viewerMembership?.role === "moderator");
   const canDeleteAny = isModOrOwner;
   const canResolve =
+    currentUserId !== null &&
+    (question.author.id === currentUserId || isModOrOwner);
+  const canDeleteQuestion =
     currentUserId !== null &&
     (question.author.id === currentUserId || isModOrOwner);
 
@@ -62,11 +106,16 @@ export default async function QuestionDetailPage({ params }: Props) {
         <CardHeader className="border-b">
           <div className="flex items-start justify-between gap-3">
             <CardTitle className="text-2xl">{question.title}</CardTitle>
-            <QuestionResolveControls
-              questionId={question.id}
-              status={question.status}
-              canResolve={canResolve}
-            />
+            <div className="flex flex-col items-end gap-2">
+              <QuestionResolveControls
+                questionId={question.id}
+                status={question.status}
+                canResolve={canResolve}
+              />
+              {canDeleteQuestion ? (
+                <QuestionDeleteButton questionId={question.id} />
+              ) : null}
+            </div>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
             Asked by {authorLabel(question.author)} in{" "}

--- a/src/app/q/[id]/question-delete-button.tsx
+++ b/src/app/q/[id]/question-delete-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { deleteQuestionAction } from "./actions";
+
+type Props = {
+  questionId: string;
+};
+
+export function QuestionDeleteButton({ questionId }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (
+      !confirm(
+        "Delete this question? It will be hidden from listings and search. Existing answers stay in the database but the page will show a tombstone.",
+      )
+    ) {
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteQuestionAction(questionId);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="text-xs text-red-600 underline hover:text-red-700 disabled:opacity-60 dark:text-red-400 dark:hover:text-red-300"
+      >
+        {pending ? "Deleting…" : "Delete question"}
+      </button>
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/favorites.ts
+++ b/src/lib/favorites.ts
@@ -55,16 +55,16 @@ async function assertTargetExists(
   if (targetType === "question") {
     const q = await db.question.findUnique({
       where: { id: targetId },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
-    if (!q) throw new NotFoundError("Question not found.");
+    if (!q || q.deletedAt) throw new NotFoundError("Question not found.");
     return;
   }
   const a = await db.answer.findUnique({
     where: { id: targetId },
-    select: { id: true },
+    select: { id: true, question: { select: { deletedAt: true } } },
   });
-  if (!a) throw new NotFoundError("Answer not found.");
+  if (!a || a.question.deletedAt) throw new NotFoundError("Answer not found.");
 }
 
 export async function toggleFavorite(
@@ -146,7 +146,7 @@ export async function listFavoritesForUser(
     questionIds.length === 0
       ? Promise.resolve([])
       : db.question.findMany({
-          where: { id: { in: questionIds } },
+          where: { id: { in: questionIds }, deletedAt: null },
           include: {
             author: { select: { id: true, email: true, name: true } },
             group: { select: { id: true, slug: true, name: true } },
@@ -155,7 +155,10 @@ export async function listFavoritesForUser(
     answerIds.length === 0
       ? Promise.resolve([])
       : db.answer.findMany({
-          where: { id: { in: answerIds } },
+          where: {
+            id: { in: answerIds },
+            question: { deletedAt: null },
+          },
           include: {
             author: { select: { id: true, email: true, name: true } },
             question: { select: { id: true, title: true } },

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -161,6 +161,60 @@ describe("listForUser", () => {
     expect(result.unreadCount).toBe(1);
   });
 
+  it("excludes notifications whose referenced question is soft-deleted", async () => {
+    const u = await makeUser("delU");
+    const owner = await makeUser("delOwner");
+    const group = await createGroup(
+      { name: "DN", slug: uniq("dn"), autoApprove: true },
+      owner.id,
+    );
+    const visible = await createQuestion(
+      { title: "Visible Q", body: "b" },
+      group.id,
+      owner.id,
+    );
+    const hidden = await createQuestion(
+      { title: "Hidden Q", body: "b" },
+      group.id,
+      owner.id,
+    );
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: visible.id,
+          questionTitle: "Visible Q",
+          groupSlug: group.slug,
+          groupName: group.name,
+          authorName: "x",
+        }),
+      },
+    });
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: hidden.id,
+          questionTitle: "Hidden Q",
+          groupSlug: group.slug,
+          groupName: group.name,
+          authorName: "x",
+        }),
+      },
+    });
+    await db.question.update({
+      where: { id: hidden.id },
+      data: { deletedAt: new Date() },
+    });
+
+    const result = await listForUser(u.id);
+    const ids = result.items.map((i) => i.payload.questionId);
+    expect(ids).toContain(visible.id);
+    expect(ids).not.toContain(hidden.id);
+  });
+
   it("respects the limit option", async () => {
     const u = await makeUser("limU");
     for (let i = 0; i < 3; i += 1) {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -67,7 +67,27 @@ export async function listForUser(
     }),
     db.notification.count({ where: { userId, readAt: null } }),
   ]);
-  return { items: rows.map(parsePayload), unreadCount };
+
+  const parsed = rows.map(parsePayload);
+  const referencedQuestionIds = Array.from(
+    new Set(parsed.map((p) => p.payload.questionId)),
+  );
+  const deletedIds = referencedQuestionIds.length
+    ? new Set(
+        (
+          await db.question.findMany({
+            where: {
+              id: { in: referencedQuestionIds },
+              deletedAt: { not: null },
+            },
+            select: { id: true },
+          })
+        ).map((q) => q.id),
+      )
+    : new Set<string>();
+
+  const items = parsed.filter((p) => !deletedIds.has(p.payload.questionId));
+  return { items, unreadCount };
 }
 
 export async function markRead(

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -92,7 +92,7 @@ export async function listQuestionsByAuthor(
   const skip = (opts.page - 1) * opts.per;
   const [rows, total] = await Promise.all([
     db.question.findMany({
-      where: { authorId: userId },
+      where: { authorId: userId, deletedAt: null },
       orderBy: { createdAt: "desc" },
       skip,
       take: opts.per,
@@ -102,7 +102,7 @@ export async function listQuestionsByAuthor(
         _count: { select: { answers: true } },
       },
     }),
-    db.question.count({ where: { authorId: userId } }),
+    db.question.count({ where: { authorId: userId, deletedAt: null } }),
   ]);
 
   const scores = await voteScoresFor(
@@ -132,7 +132,7 @@ export async function listAnswersByAuthor(
   const skip = (opts.page - 1) * opts.per;
   const [rows, total] = await Promise.all([
     db.answer.findMany({
-      where: { authorId: userId },
+      where: { authorId: userId, question: { deletedAt: null } },
       orderBy: { createdAt: "desc" },
       skip,
       take: opts.per,
@@ -148,7 +148,9 @@ export async function listAnswersByAuthor(
         },
       },
     }),
-    db.answer.count({ where: { authorId: userId } }),
+    db.answer.count({
+      where: { authorId: userId, question: { deletedAt: null } },
+    }),
   ]);
 
   const scores = await voteScoresFor(
@@ -216,7 +218,7 @@ export async function listFavoritesByUser(
   const [questions, answers] = await Promise.all([
     questionIds.length
       ? db.question.findMany({
-          where: { id: { in: questionIds } },
+          where: { id: { in: questionIds }, deletedAt: null },
           select: {
             id: true,
             title: true,
@@ -232,7 +234,10 @@ export async function listFavoritesByUser(
         ),
     answerIds.length
       ? db.answer.findMany({
-          where: { id: { in: answerIds } },
+          where: {
+            id: { in: answerIds },
+            question: { deletedAt: null },
+          },
           select: {
             id: true,
             body: true,

--- a/src/lib/questions.test.ts
+++ b/src/lib/questions.test.ts
@@ -17,7 +17,15 @@ process.env["DATABASE_URL"] = `file:${testDbPath}`;
 const { db } = await import("./db");
 const { createGroup } = await import("./groups");
 const { NotFoundError } = await import("./memberships");
-const { createQuestion, getQuestionById, listQuestionsForGroup } = await import("./questions");
+const {
+  createQuestion,
+  getQuestionById,
+  listQuestionsForGroup,
+  softDeleteQuestion,
+  acceptAnswer,
+  reopenQuestion,
+} = await import("./questions");
+const { applyToGroup, AuthorizationError } = await import("./memberships");
 
 beforeAll(async () => {
   const root = path.resolve(import.meta.dirname, "../..");
@@ -241,5 +249,192 @@ describe("getQuestionById", () => {
     const detail = await getQuestionById(q.id, viewer.id);
     expect(detail.voteScore).toBe(1);
     expect(detail.viewerVote).toBeNull();
+  });
+});
+
+describe("softDeleteQuestion", () => {
+  async function setup(label: string) {
+    const owner = await makeUser(`owner-${label}`);
+    const group = await createGroup(
+      { name: label, slug: uniq(label), autoApprove: true },
+      owner.id,
+    );
+    const author = await makeUser(`author-${label}`);
+    await applyToGroup(group.id, author.id);
+    const q = await createQuestion(
+      { title: `Title ${label}`, body: `Body ${label}` },
+      group.id,
+      author.id,
+    );
+    return { owner, group, author, question: q };
+  }
+
+  it("sets deletedAt when called by the author", async () => {
+    const s = await setup("sda");
+    const result = await softDeleteQuestion(s.question.id, s.author.id);
+    expect(result.id).toBe(s.question.id);
+    expect(result.groupSlug).toBe(s.group.slug);
+    const after = await db.question.findUnique({
+      where: { id: s.question.id },
+    });
+    expect(after!.deletedAt).not.toBeNull();
+  });
+
+  it("sets deletedAt when called by the group owner", async () => {
+    const s = await setup("sdo");
+    await softDeleteQuestion(s.question.id, s.owner.id);
+    const after = await db.question.findUnique({
+      where: { id: s.question.id },
+    });
+    expect(after!.deletedAt).not.toBeNull();
+  });
+
+  it("sets deletedAt when called by a moderator", async () => {
+    const s = await setup("sdm");
+    const mod = await makeUser("mod-sdm");
+    await db.membership.create({
+      data: {
+        groupId: s.group.id,
+        userId: mod.id,
+        role: "moderator",
+        status: "approved",
+      },
+    });
+    await softDeleteQuestion(s.question.id, mod.id);
+    const after = await db.question.findUnique({
+      where: { id: s.question.id },
+    });
+    expect(after!.deletedAt).not.toBeNull();
+  });
+
+  it("throws AuthorizationError for a plain approved member", async () => {
+    const s = await setup("sdp");
+    const member = await makeUser("plain-sdp");
+    await applyToGroup(s.group.id, member.id);
+    await expect(
+      softDeleteQuestion(s.question.id, member.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws AuthorizationError for a non-member", async () => {
+    const s = await setup("sdn");
+    const stranger = await makeUser("stranger-sdn");
+    await expect(
+      softDeleteQuestion(s.question.id, stranger.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws NotFoundError when the question is already deleted", async () => {
+    const s = await setup("sdd");
+    await softDeleteQuestion(s.question.id, s.author.id);
+    await expect(
+      softDeleteQuestion(s.question.id, s.author.id),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("throws NotFoundError for an unknown id", async () => {
+    const author = await makeUser("nf");
+    await expect(
+      softDeleteQuestion("does-not-exist", author.id),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("getQuestionById on deleted questions", () => {
+  it("returns the row with deletedAt set and stripped joins", async () => {
+    const owner = await makeUser("g-del-o");
+    const group = await createGroup(
+      { name: "GDel", slug: uniq("gdel"), autoApprove: true },
+      owner.id,
+    );
+    const q = await createQuestion(
+      { title: "Will be deleted", body: "Body" },
+      group.id,
+      owner.id,
+    );
+    await db.answer.create({
+      data: { questionId: q.id, authorId: owner.id, body: "Once visible." },
+    });
+    await db.question.update({
+      where: { id: q.id },
+      data: { deletedAt: new Date() },
+    });
+
+    const detail = await getQuestionById(q.id, owner.id);
+    expect(detail.id).toBe(q.id);
+    expect(detail.deletedAt).not.toBeNull();
+    expect(detail.answers).toEqual([]);
+    expect(detail.voteScore).toBe(0);
+    expect(detail.viewerVote).toBeNull();
+  });
+});
+
+describe("listQuestionsForGroup excludes soft-deleted", () => {
+  it("filters deletedAt from listings and total count", async () => {
+    const owner = await makeUser("listdel");
+    const group = await createGroup(
+      { name: "ListDel", slug: uniq("ldel"), autoApprove: true },
+      owner.id,
+    );
+    const visible = await createQuestion(
+      { title: "still here", body: "b" },
+      group.id,
+      owner.id,
+    );
+    const hidden = await createQuestion(
+      { title: "tombstone", body: "b" },
+      group.id,
+      owner.id,
+    );
+    await db.question.update({
+      where: { id: hidden.id },
+      data: { deletedAt: new Date() },
+    });
+
+    const page = await listQuestionsForGroup(group.id, { page: 1, per: 10 });
+    expect(page.total).toBe(1);
+    expect(page.items.map((i) => i.id)).toEqual([visible.id]);
+  });
+});
+
+describe("acceptAnswer / reopenQuestion on deleted questions", () => {
+  it("acceptAnswer throws NotFoundError when the question is deleted", async () => {
+    const owner = await makeUser("acc-del");
+    const group = await createGroup(
+      { name: "AD", slug: uniq("ad"), autoApprove: true },
+      owner.id,
+    );
+    const q = await createQuestion(
+      { title: "T", body: "B" },
+      group.id,
+      owner.id,
+    );
+    await db.question.update({
+      where: { id: q.id },
+      data: { deletedAt: new Date() },
+    });
+    await expect(acceptAnswer(q.id, null, owner.id)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("reopenQuestion throws NotFoundError when the question is deleted", async () => {
+    const owner = await makeUser("ro-del");
+    const group = await createGroup(
+      { name: "RO", slug: uniq("ro"), autoApprove: true },
+      owner.id,
+    );
+    const q = await createQuestion(
+      { title: "T", body: "B" },
+      group.id,
+      owner.id,
+    );
+    await db.question.update({
+      where: { id: q.id },
+      data: { status: "answered", deletedAt: new Date() },
+    });
+    await expect(reopenQuestion(q.id, owner.id)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
   });
 });

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -66,7 +66,7 @@ export async function listQuestionsForGroup(
   const skip = (opts.page - 1) * opts.per;
   const [rows, total] = await Promise.all([
     db.question.findMany({
-      where: { groupId },
+      where: { groupId, deletedAt: null },
       orderBy: { createdAt: "desc" },
       skip,
       take: opts.per,
@@ -75,7 +75,7 @@ export async function listQuestionsForGroup(
         _count: { select: { answers: true } },
       },
     }),
-    db.question.count({ where: { groupId } }),
+    db.question.count({ where: { groupId, deletedAt: null } }),
   ]);
 
   const scores = await voteScoresFor(
@@ -115,6 +115,18 @@ export async function getQuestionById(
     },
   });
   if (!q) throw new NotFoundError("Question not found.");
+
+  // Soft-deleted: return a stripped detail so callers can render a tombstone
+  // without paying for vote/favorite/answer joins. Permalinks still resolve.
+  if (q.deletedAt) {
+    return {
+      ...q,
+      voteScore: 0,
+      viewerVote: null,
+      isFavorited: false,
+      answers: [],
+    };
+  }
 
   const answerIds = q.answers.map((a) => a.id);
 
@@ -188,9 +200,11 @@ export async function acceptAnswer(
 ): Promise<Question> {
   const question = await db.question.findUnique({
     where: { id: questionId },
-    select: { id: true, authorId: true, groupId: true },
+    select: { id: true, authorId: true, groupId: true, deletedAt: true },
   });
-  if (!question) throw new NotFoundError("Question not found.");
+  if (!question || question.deletedAt) {
+    throw new NotFoundError("Question not found.");
+  }
 
   await assertCanResolveQuestion(question, userId);
 
@@ -216,9 +230,11 @@ export async function reopenQuestion(
 ): Promise<Question> {
   const question = await db.question.findUnique({
     where: { id: questionId },
-    select: { id: true, authorId: true, groupId: true },
+    select: { id: true, authorId: true, groupId: true, deletedAt: true },
   });
-  if (!question) throw new NotFoundError("Question not found.");
+  if (!question || question.deletedAt) {
+    throw new NotFoundError("Question not found.");
+  }
 
   await assertCanResolveQuestion(question, userId);
 
@@ -226,4 +242,53 @@ export async function reopenQuestion(
     where: { id: questionId },
     data: { status: "open", acceptedAnswerId: null },
   });
+}
+
+async function assertCanDeleteQuestion(
+  question: { authorId: string; groupId: string },
+  userId: string,
+): Promise<void> {
+  if (question.authorId === userId) return;
+  if (await isOwnerOrModerator(question.groupId, userId)) return;
+  throw new AuthorizationError(
+    "Only the question's author or a group moderator/owner can delete this question.",
+  );
+}
+
+export type SoftDeleteQuestionResult = {
+  id: string;
+  groupId: string;
+  groupSlug: string;
+};
+
+export async function softDeleteQuestion(
+  questionId: string,
+  userId: string,
+): Promise<SoftDeleteQuestionResult> {
+  const question = await db.question.findUnique({
+    where: { id: questionId },
+    select: {
+      id: true,
+      authorId: true,
+      groupId: true,
+      deletedAt: true,
+      group: { select: { slug: true } },
+    },
+  });
+  if (!question || question.deletedAt) {
+    throw new NotFoundError("Question not found.");
+  }
+
+  await assertCanDeleteQuestion(question, userId);
+
+  await db.question.update({
+    where: { id: questionId },
+    data: { deletedAt: new Date() },
+  });
+
+  return {
+    id: question.id,
+    groupId: question.groupId,
+    groupSlug: question.group.slug,
+  };
 }

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -321,4 +321,52 @@ describe("searchContent", () => {
     });
     expect(after.items.some((i) => i.questionId === q.id)).toBe(false);
   });
+
+  it("excludes soft-deleted questions and their answers", async () => {
+    const author = await makeUser("softdel");
+    const group = await createGroup(
+      { name: "SD", slug: uniq("sd"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Quokka habitat survey", body: "hidden after delete" },
+      group.id,
+      author.id,
+    );
+    const answer = await db.answer.create({
+      data: {
+        questionId: q.id,
+        authorId: author.id,
+        body: "Quokka colonies are stable.",
+      },
+    });
+
+    const before = await searchContent({
+      q: "quokka",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(before.items.some((i) => i.questionId === q.id)).toBe(true);
+    expect(
+      before.items.some((i) => i.type === "answer" && i.answerId === answer.id),
+    ).toBe(true);
+    const beforeTotal = before.total;
+
+    await db.question.update({
+      where: { id: q.id },
+      data: { deletedAt: new Date() },
+    });
+
+    const after = await searchContent({
+      q: "quokka",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(after.items.some((i) => i.questionId === q.id)).toBe(false);
+    expect(after.total).toBeLessThan(beforeTotal);
+  });
 });

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -122,6 +122,7 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         FROM question_fts
         JOIN "Question" q ON q.id = question_fts.id
         WHERE question_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
         ${groupFilterQuestion}
         ORDER BY score ASC, created_at DESC
         LIMIT ${fetchLimit}
@@ -140,6 +141,7 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         JOIN "Answer" a ON a.id = answer_fts.id
         JOIN "Question" q ON q.id = a."questionId"
         WHERE answer_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
         ${groupFilterQuestion}
         ORDER BY score ASC, created_at DESC
         LIMIT ${fetchLimit}
@@ -149,6 +151,7 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         FROM question_fts
         JOIN "Question" q ON q.id = question_fts.id
         WHERE question_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
         ${groupFilterQuestion}
       `),
       db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
@@ -157,6 +160,7 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         JOIN "Answer" a ON a.id = answer_fts.id
         JOIN "Question" q ON q.id = a."questionId"
         WHERE answer_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
         ${groupFilterQuestion}
       `),
     ]);

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -53,19 +53,19 @@ async function resolveTarget(
   if (targetType === "question") {
     const q = await db.question.findUnique({
       where: { id: targetId },
-      select: { groupId: true, authorId: true },
+      select: { groupId: true, authorId: true, deletedAt: true },
     });
-    if (!q) throw new NotFoundError("Question not found.");
-    return q;
+    if (!q || q.deletedAt) throw new NotFoundError("Question not found.");
+    return { groupId: q.groupId, authorId: q.authorId };
   }
   const a = await db.answer.findUnique({
     where: { id: targetId },
     select: {
       authorId: true,
-      question: { select: { groupId: true } },
+      question: { select: { groupId: true, deletedAt: true } },
     },
   });
-  if (!a) throw new NotFoundError("Answer not found.");
+  if (!a || a.question.deletedAt) throw new NotFoundError("Answer not found.");
   return { groupId: a.question.groupId, authorId: a.authorId };
 }
 


### PR DESCRIPTION
## Summary
- Adds `deletedAt` to `Question` and a `DELETE /api/questions/:id` route — author or group moderator/owner only.
- Listings, search (FTS), profile pages, favorites, votes, answer creation, and notifications all exclude soft-deleted questions.
- Question detail page renders a tombstone Card instead of 404 so permalinks keep resolving; delete button uses native confirm + server action.

## Test plan
- [x] `npm run typecheck` and `npm run lint` clean
- [x] `npx prisma validate` passes; new migration `20260505000000_add_question_soft_delete` applies cleanly
- [x] `npm test` — 299/299 pass, including new DELETE route, soft-delete authorization matrix, search/listing/notifications exclusion, and tombstone GET cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)