### PR TITLE
feat(seed): notifications, more variety, edge-case fixtures, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ After seeding, dev sign-in works with any of:
 `alice@example.com`, `bob@example.com`, `carol@example.com`, `dave@example.com`, `eve@example.com`.
 The seed is idempotent — re-running it converges on the same dataset.
 
+For the full test-data reference (membership matrix, edge-case fixtures,
+notification read/unread split, search keywords planted for FTS testing),
+see [`prisma/README.md`](prisma/README.md).
+
 ## Scripts
 
 | Script                 | What it does                                        |

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,148 @@
+# Dev seed reference
+
+This directory holds the Prisma schema, migrations, and the dev seed script
+([`seed.ts`](seed.ts)). The seed populates the local SQLite database with a
+fixed cast of users, groups, memberships, Q&A, votes, favorites, and
+notifications — enough to exercise every flow in the app without manual
+data entry.
+
+## How to run
+
+| Command             | What it does                                                              |
+| ------------------- | ------------------------------------------------------------------------- |
+| `npm run db:seed`   | Idempotent — re-running converges on the same dataset, never destructive. |
+| `npm run db:reset`  | Wipes the dev DB, re-applies migrations, then auto-runs the seed.         |
+| `npm run db:studio` | Browse the data in Prisma Studio.                                         |
+
+After seeding, sign in (dev-only) at http://localhost:3000 with any of the
+emails in the [Test users](#test-users) table.
+
+## Final row counts
+
+After a clean seed, expect:
+
+| Entity        | Count |
+| ------------- | ----- |
+| Users         | 5     |
+| Groups        | 5     |
+| Memberships   | 25    |
+| Questions     | 50    |
+| Answers       | 34    |
+| Votes         | 25    |
+| Favorites     | 10    |
+| Notifications | 140   |
+
+The seed script logs the same counts at the end of each run — diff the
+two runs to confirm idempotency.
+
+## Test users
+
+| Email               | Display name | ID                | Role summary                                                                  |
+| ------------------- | ------------ | ----------------- | ----------------------------------------------------------------------------- |
+| `alice@example.com` | Alice Adams  | `seed-user-alice` | Owner of **Go**; member of every other group; has read **all** notifications. |
+| `bob@example.com`   | Bob Brown    | `seed-user-bob`   | Owner of **React**; mixed roles elsewhere; has unread notifications.          |
+| `carol@example.com` | Carol Chen   | `seed-user-carol` | Owner of **Kubernetes**; moderator in Go; has read **all** notifications.     |
+| `dave@example.com`  | Dave Davis   | `seed-user-dave`  | Owner of **Python**; moderator in React; has unread notifications.            |
+| `eve@example.com`   | Eve Evans    | `seed-user-eve`   | Owner of **DevOps**; mixed states (rejected, pending) elsewhere.              |
+
+## Groups
+
+| Slug         | Name       | Auto-approve | Owner |
+| ------------ | ---------- | ------------ | ----- |
+| `golang`     | Go         | ✅           | alice |
+| `react`      | React      | ❌           | bob   |
+| `kubernetes` | Kubernetes | ✅           | carol |
+| `python`     | Python     | ✅           | dave  |
+| `devops`     | DevOps     | ❌           | eve   |
+
+## Membership matrix
+
+`role/status` for each user × group. Use this to pick a user/group combo
+for any scenario without rereading the seed source.
+
+| User      | golang             | react              | kubernetes          | python            | devops             |
+| --------- | ------------------ | ------------------ | ------------------- | ----------------- | ------------------ |
+| **alice** | owner / approved   | member / approved  | moderator / approved | member / approved | member / approved  |
+| **bob**   | member / approved  | owner / approved   | member / approved   | member / pending  | moderator / approved |
+| **carol** | moderator / approved | member / approved  | owner / approved    | member / approved | member / pending   |
+| **dave**  | member / pending   | moderator / approved | member / approved   | owner / approved  | member / approved  |
+| **eve**   | member / rejected  | member / pending   | member / pending    | member / approved | owner / approved   |
+
+## Edge-case fixtures
+
+Named scenarios planted for e2e and manual targeting:
+
+- **Pending application awaiting moderator review** — sign in as
+  `eve@example.com`, visit `/g/react`. Eve's row in `react` is `pending`,
+  and `dave` (react moderator) can approve/reject from the moderation UI.
+- **Rejected applicant** — `eve` in `golang` (`status: rejected`).
+- **Mixed-state user** — `eve` covers all four states across groups
+  (`approved`, `pending`, `rejected`, `owner`).
+- **Net-negative answer with mixed votes** — `seed-a-golang-01-2` has
+  `dave -1`, `carol -1`, `alice +1` → net `-1`.
+- **Strongly-negative answer** — `seed-a-golang-06-2` has two downvotes
+  and zero upvotes → net `-2`.
+- **Accepted answer that is also downvoted** — `seed-a-react-01-1` is
+  the accepted answer on `seed-q-react-01` and carries one downvote
+  alongside two upvotes (good for testing "accepted + contested" UI).
+
+## Notification fixtures
+
+The seed creates one `question.created` notification per
+question-recipient pair, where recipients are approved members of the
+group excluding the author — mirroring `notifyQuestionCreated()` in
+[`src/lib/notifications.ts`](../src/lib/notifications.ts).
+
+- Total: **140 rows** (50 questions × ~3 approved non-author recipients).
+- **alice + carol**: every notification marked read (`readAt` set to
+  2026-05-01). Use to verify the empty-unread bell state and
+  `markAllRead` no-op.
+- **bob, dave, eve**: every notification unread. Use to verify the bell
+  badge count, polling, mark-read, and mark-all-read flows.
+
+## Search keywords planted for FTS testing
+
+The query layer in [`src/lib/search.ts`](../src/lib/search.ts) uses SQLite
+FTS5 with `porter unicode61 remove_diacritics 2` and prefix matching on
+the trailing token. Keywords below appear in multiple groups so the scope
+toggle (`current` vs `all`) returns visibly different result counts.
+
+| Query              | Where it appears                                       | Why                                |
+| ------------------ | ------------------------------------------------------ | ---------------------------------- |
+| `sync pool`        | golang (3 questions), devops (1)                       | cross-group multi-match            |
+| `context cancellation` | golang, kubernetes, python                          | cross-group multi-match            |
+| `react server component` | react (1 question + 2 answers)                     | exact phrase, single group         |
+| `kubernetes ingress` | kubernetes (2)                                       | exact phrase, single group         |
+| `python asyncio`   | python (2)                                            | exact phrase, single group         |
+| `terraform plan`   | devops (3)                                            | exact phrase, single group         |
+| `gener`            | golang, kubernetes, python, devops                    | prefix → generic / generation / generator |
+| `café`             | `seed-q-golang-10`                                    | diacritic — should match via `cafe` too |
+| `naïve`            | `seed-q-react-10`                                     | diacritic                          |
+
+## Idempotency
+
+Every entity is `upsert`-ed by deterministic `seed-*` ID. Running
+`npm run db:seed` against an already-seeded DB produces no new rows and
+no errors — diff the printed counts before/after to confirm.
+
+The seed is **non-destructive**: it does not delete rows you've added
+manually. Use `npm run db:reset` if you need a clean wipe.
+
+## What is not seeded
+
+- **Other notification types.** The app currently only emits
+  `question.created`; seeding any other `type` would create rows the bell
+  UI can't render. Extend [`src/lib/notifications.ts`](../src/lib/notifications.ts)
+  first, then add fixtures here.
+- **Notifications for pending/rejected members.** Fan-out is restricted
+  to approved members, matching the runtime helper.
+- **Authored content from non-approved members.** Questions and answers
+  in the seed are always written by approved members of the relevant
+  group — keeps fixtures realistic for moderation UI testing.
+- **Vote/favorite coverage on every question.** Many questions have no
+  votes or favorites; if you need denser interactions, add them to the
+  `votes` / `favorites` arrays in `seed.ts` rather than mutating the DB
+  directly.
+
+For schema-level details (field types, indexes, FK rules) see
+[`schema.prisma`](schema.prisma).

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -458,6 +458,281 @@ const questions: SeedQuestion[] = [
     body: "Step-by-step for rotating a DB password used by ~10 services.",
     status: "open",
   },
+
+  // -----------------------------------------------------------------------
+  // Volume + search-keyword fixtures (questions 05..10 in each group).
+  // Repeated phrases ("sync pool", "context cancellation", "react server
+  // component", "kubernetes ingress", "python asyncio", "terraform plan")
+  // appear across multiple groups so the search scope toggle has visibly
+  // different result counts. Diacritics ("café", "naïve") and prefix-match
+  // tokens ("generic", "generation", "generator") exercise the FTS tokenizer.
+  // -----------------------------------------------------------------------
+
+  // golang (additional)
+  {
+    id: "seed-q-golang-05",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-carol",
+    title: "How does context cancellation propagate through goroutines?",
+    body: "Looking for a clean pattern for fan-out goroutines that all need to honor context cancellation when the request is dropped.",
+    status: "answered",
+    acceptAnswerId: "seed-a-golang-05-1",
+  },
+  {
+    id: "seed-q-golang-06",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-bob",
+    title: "sync pool vs custom buffer pool — when does it actually pay?",
+    body: "Profiling shows allocator pressure. sync pool is tempting but I've heard the GC interaction is subtle.",
+    status: "answered",
+    acceptAnswerId: "seed-a-golang-06-1",
+  },
+  {
+    id: "seed-q-golang-07",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-alice",
+    title: "Generators and lazy sequences via channels",
+    body: "Coming from Python, I want generator-style iteration. Is a channel + goroutine the idiomatic Go answer?",
+    status: "open",
+  },
+  {
+    id: "seed-q-golang-08",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-bob",
+    title: "Profiling allocator pressure: pprof tips",
+    body: "What flags and views do you reach for first when allocations are too high?",
+    status: "answered",
+    acceptAnswerId: "seed-a-golang-08-1",
+  },
+  {
+    id: "seed-q-golang-09",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-carol",
+    title: "Designing generic container types in Go 1.21+",
+    body: "When does it make sense to write a generic container vs reaching for a stdlib type?",
+    status: "answered",
+    acceptAnswerId: "seed-a-golang-09-1",
+  },
+  {
+    id: "seed-q-golang-10",
+    groupId: "seed-group-golang",
+    authorId: "seed-user-bob",
+    title: "café latency: tracing slow handlers in net/http",
+    body: "We have a /café endpoint with intermittent p99 spikes. What's the right way to instrument it without redeploying?",
+    status: "open",
+  },
+
+  // react (additional)
+  {
+    id: "seed-q-react-05",
+    groupId: "seed-group-react",
+    authorId: "seed-user-carol",
+    title: "React server component data fetching patterns",
+    body: "What's the canonical react server component data fetching pattern when the same data is needed by a client island below it?",
+    status: "answered",
+    acceptAnswerId: "seed-a-react-05-1",
+  },
+  {
+    id: "seed-q-react-06",
+    groupId: "seed-group-react",
+    authorId: "seed-user-alice",
+    title: "When to break out a server component into a route handler",
+    body: "I keep finding myself wanting a JSON endpoint anyway. What's the heuristic?",
+    status: "open",
+  },
+  {
+    id: "seed-q-react-07",
+    groupId: "seed-group-react",
+    authorId: "seed-user-dave",
+    title: "Code generation for typed API clients in Next.js",
+    body: "Looking at openapi-typescript, kubb, and hand-rolled. Anyone landed on a generation pipeline they like?",
+    status: "answered",
+    acceptAnswerId: "seed-a-react-07-1",
+  },
+  {
+    id: "seed-q-react-08",
+    groupId: "seed-group-react",
+    authorId: "seed-user-bob",
+    title: "Memoization vs server components for expensive renders",
+    body: "Where's the line between useMemo on the client and just moving the computation server-side?",
+    status: "answered",
+    acceptAnswerId: "seed-a-react-08-1",
+  },
+  {
+    id: "seed-q-react-09",
+    groupId: "seed-group-react",
+    authorId: "seed-user-carol",
+    title: "Suspense boundaries and streaming HTML",
+    body: "What's the right granularity for Suspense boundaries when streaming?",
+    status: "open",
+  },
+  {
+    id: "seed-q-react-10",
+    groupId: "seed-group-react",
+    authorId: "seed-user-alice",
+    title: "naïve hashing for cache keys in RSC",
+    body: "I'm using a naïve string concat as a cache key. What goes wrong at scale?",
+    status: "open",
+  },
+
+  // kubernetes (additional)
+  {
+    id: "seed-q-kubernetes-05",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-bob",
+    title: "Kubernetes ingress controller selection: nginx vs traefik vs envoy",
+    body: "Picking a kubernetes ingress controller for a new platform. What's the 2026 default?",
+    status: "answered",
+    acceptAnswerId: "seed-a-kubernetes-05-1",
+  },
+  {
+    id: "seed-q-kubernetes-06",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-alice",
+    title: "Generic kubernetes ingress patterns for multi-tenant clusters",
+    body: "Looking for a generic ingress topology that scales across teams without per-tenant controllers.",
+    status: "open",
+  },
+  {
+    id: "seed-q-kubernetes-07",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-dave",
+    title: "Pod-level context cancellation on graceful shutdown",
+    body: "How do you wire SIGTERM into context cancellation cleanly across language ecosystems?",
+    status: "answered",
+    acceptAnswerId: "seed-a-kubernetes-07-1",
+  },
+  {
+    id: "seed-q-kubernetes-08",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-carol",
+    title: "Sidecar containers vs init containers: decision matrix",
+    body: "When does a sidecar make more sense than an init container for setup work?",
+    status: "open",
+  },
+  {
+    id: "seed-q-kubernetes-09",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-bob",
+    title: "Operator generation tooling: kubebuilder vs operator-sdk",
+    body: "Which generation pipeline are folks using for new operators in 2026?",
+    status: "answered",
+    acceptAnswerId: "seed-a-kubernetes-09-1",
+  },
+  {
+    id: "seed-q-kubernetes-10",
+    groupId: "seed-group-kubernetes",
+    authorId: "seed-user-alice",
+    title: "Network policies that don't lock you out",
+    body: "What's a safe default-deny rollout that doesn't break dev access?",
+    status: "open",
+  },
+
+  // python (additional)
+  {
+    id: "seed-q-python-05",
+    groupId: "seed-group-python",
+    authorId: "seed-user-alice",
+    title: "Python asyncio cancellation scope nesting",
+    body: "How do you reason about python asyncio cancellation when scopes are nested deeply?",
+    status: "answered",
+    acceptAnswerId: "seed-a-python-05-1",
+  },
+  {
+    id: "seed-q-python-06",
+    groupId: "seed-group-python",
+    authorId: "seed-user-carol",
+    title: "Python asyncio timeouts: why my context manager leaks tasks",
+    body: "Hitting a case where context cancellation under timeout leaves child tasks dangling. Pattern I'm missing?",
+    status: "open",
+  },
+  {
+    id: "seed-q-python-07",
+    groupId: "seed-group-python",
+    authorId: "seed-user-dave",
+    title: "Generic types vs Protocol generics in modern Python",
+    body: "When does a generic class outperform a Protocol with type vars?",
+    status: "answered",
+    acceptAnswerId: "seed-a-python-07-1",
+  },
+  {
+    id: "seed-q-python-08",
+    groupId: "seed-group-python",
+    authorId: "seed-user-eve",
+    title: "PEP 695 generic syntax: when to migrate?",
+    body: "Is the new generic syntax stable enough for production code, or wait?",
+    status: "open",
+  },
+  {
+    id: "seed-q-python-09",
+    groupId: "seed-group-python",
+    authorId: "seed-user-alice",
+    title: "Generator-based pipelines vs async streams",
+    body: "When does a generator pipeline beat asyncio.Queue for streaming work?",
+    status: "open",
+  },
+  {
+    id: "seed-q-python-10",
+    groupId: "seed-group-python",
+    authorId: "seed-user-carol",
+    title: "Threading vs asyncio for CPU-bound work — actual numbers",
+    body: "Has anyone benchmarked threading vs asyncio for mixed CPU/IO workloads recently?",
+    status: "answered",
+    acceptAnswerId: "seed-a-python-10-1",
+  },
+
+  // devops (additional)
+  {
+    id: "seed-q-devops-05",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-bob",
+    title: "terraform plan diff hygiene in CI",
+    body: "Our terraform plan output is impossible to read in PRs. How are you scoping it?",
+    status: "answered",
+    acceptAnswerId: "seed-a-devops-05-1",
+  },
+  {
+    id: "seed-q-devops-06",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-alice",
+    title: "Generic terraform module API design",
+    body: "How do you keep a generic terraform plan output stable across module versions?",
+    status: "open",
+  },
+  {
+    id: "seed-q-devops-07",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-dave",
+    title: "OpenTelemetry context propagation across service mesh",
+    body: "Where does context get lost most often, and what fixes are stable?",
+    status: "answered",
+    acceptAnswerId: "seed-a-devops-07-1",
+  },
+  {
+    id: "seed-q-devops-08",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-eve",
+    title: "Zero-downtime database migrations playbook",
+    body: "Step-by-step for online schema changes on Postgres at moderate scale.",
+    status: "open",
+  },
+  {
+    id: "seed-q-devops-09",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-bob",
+    title: "sync pool tuning for connection pools at scale",
+    body: "Borrowing the sync pool idea from Go — how are folks tuning DB connection pools that aggressively?",
+    status: "answered",
+    acceptAnswerId: "seed-a-devops-09-1",
+  },
+  {
+    id: "seed-q-devops-10",
+    groupId: "seed-group-devops",
+    authorId: "seed-user-dave",
+    title: "Generation of SBOMs in CI pipelines",
+    body: "What generation tooling produces SBOMs that auditors actually accept?",
+    status: "open",
+  },
 ];
 
 type SeedAnswer = {
@@ -560,6 +835,141 @@ const answers: SeedAnswer[] = [
     questionId: "seed-q-devops-03",
     authorId: "seed-user-alice",
     body: "Agent-per-node for collection, gateway for export. The split keeps blast radius small.",
+  },
+
+  // -----------------------------------------------------------------------
+  // Additional answers paired with the volume questions above.
+  // seed-a-golang-06-2 is intentionally net-negative (see votes section).
+  // -----------------------------------------------------------------------
+
+  // golang (additional)
+  {
+    id: "seed-a-golang-05-1",
+    questionId: "seed-q-golang-05",
+    authorId: "seed-user-alice",
+    body: "Pass ctx as the first arg, derive child contexts per goroutine, and select on ctx.Done() inside any blocking op. Cancellation is just a closed channel under the hood.",
+  },
+  {
+    id: "seed-a-golang-06-1",
+    questionId: "seed-q-golang-06",
+    authorId: "seed-user-carol",
+    body: "sync pool wins when the same goroutine reuses the buffer many times in a tight loop. Across goroutines or with mixed sizes, a custom pool is usually clearer.",
+  },
+  {
+    id: "seed-a-golang-06-2",
+    questionId: "seed-q-golang-06",
+    authorId: "seed-user-alice",
+    body: "Honestly I'd skip the pool entirely until the allocator is the proven bottleneck.",
+  },
+  {
+    id: "seed-a-golang-08-1",
+    questionId: "seed-q-golang-08",
+    authorId: "seed-user-carol",
+    body: "Start with -alloc_objects in pprof, look at the flame graph, and only then reach for sync pool or arenas.",
+  },
+  {
+    id: "seed-a-golang-09-1",
+    questionId: "seed-q-golang-09",
+    authorId: "seed-user-alice",
+    body: "Generic containers pay off when callers would otherwise duplicate the same code or lose type safety. For one-off internal helpers, a concrete type is still simpler.",
+  },
+
+  // react (additional)
+  {
+    id: "seed-a-react-05-1",
+    questionId: "seed-q-react-05",
+    authorId: "seed-user-bob",
+    body: "Fetch in the react server component, hand the data down as props, and let the client island re-fetch only what it owns. Don't share an in-memory cache across the boundary.",
+  },
+  {
+    id: "seed-a-react-05-2",
+    questionId: "seed-q-react-05",
+    authorId: "seed-user-dave",
+    body: "Or expose a tiny route handler the client island calls — sometimes that's clearer than threading props through.",
+  },
+  {
+    id: "seed-a-react-07-1",
+    questionId: "seed-q-react-07",
+    authorId: "seed-user-bob",
+    body: "openapi-typescript for type generation, a thin fetch wrapper for runtime. Tools that try to do both end up rigid.",
+  },
+  {
+    id: "seed-a-react-08-1",
+    questionId: "seed-q-react-08",
+    authorId: "seed-user-alice",
+    body: "If the input doesn't change between renders for the same user, hoist it to the server. useMemo is cheaper, but server work is free for the client.",
+  },
+
+  // kubernetes (additional)
+  {
+    id: "seed-a-kubernetes-05-1",
+    questionId: "seed-q-kubernetes-05",
+    authorId: "seed-user-alice",
+    body: "Default to ingress-nginx unless you need traefik's middleware ergonomics or envoy's xDS hooks. The boring choice still works.",
+  },
+  {
+    id: "seed-a-kubernetes-05-2",
+    questionId: "seed-q-kubernetes-05",
+    authorId: "seed-user-dave",
+    body: "Envoy via Gateway API if you're greenfield — the API is converging and the controller story is finally stable.",
+  },
+  {
+    id: "seed-a-kubernetes-07-1",
+    questionId: "seed-q-kubernetes-07",
+    authorId: "seed-user-carol",
+    body: "Trap SIGTERM, trigger context cancellation on a top-level context, and let the request handlers exit on ctx.Done(). Match terminationGracePeriodSeconds to your slowest in-flight call.",
+  },
+  {
+    id: "seed-a-kubernetes-09-1",
+    questionId: "seed-q-kubernetes-09",
+    authorId: "seed-user-carol",
+    body: "kubebuilder for the generation pipeline, controller-runtime for the reconcile loop. operator-sdk wraps the same thing with extra opinions.",
+  },
+
+  // python (additional)
+  {
+    id: "seed-a-python-05-1",
+    questionId: "seed-q-python-05",
+    authorId: "seed-user-carol",
+    body: "Use TaskGroup — nested cancellation is its whole job. Hand-rolling cancel scopes around create_task is where leaks come from.",
+  },
+  {
+    id: "seed-a-python-07-1",
+    questionId: "seed-q-python-07",
+    authorId: "seed-user-alice",
+    body: "Generic class when you own the inheritance chain; Protocol with type vars when you want structural typing across third-party types.",
+  },
+  {
+    id: "seed-a-python-10-1",
+    questionId: "seed-q-python-10",
+    authorId: "seed-user-eve",
+    body: "Threads still win for CPU-bound under the GIL-removal builds; asyncio is for IO. Mixed workloads need run_in_executor at the boundary.",
+  },
+
+  // devops (additional)
+  {
+    id: "seed-a-devops-05-1",
+    questionId: "seed-q-devops-05",
+    authorId: "seed-user-alice",
+    body: "Run terraform plan against a known good state file and post only the resource diff in PR comments. Atlantis handles this out of the box.",
+  },
+  {
+    id: "seed-a-devops-05-2",
+    questionId: "seed-q-devops-05",
+    authorId: "seed-user-dave",
+    body: "We pipe terraform plan through tfsec + a custom diff trimmer. Anything matching a stable allowlist is collapsed.",
+  },
+  {
+    id: "seed-a-devops-07-1",
+    questionId: "seed-q-devops-07",
+    authorId: "seed-user-alice",
+    body: "Mesh-injected sidecars usually drop context across protocol boundaries (HTTP→gRPC). Pin to W3C tracecontext on every hop and stop relying on B3.",
+  },
+  {
+    id: "seed-a-devops-09-1",
+    questionId: "seed-q-devops-09",
+    authorId: "seed-user-eve",
+    body: "Treat the connection pool like a sync pool: warm it eagerly, cap it well below DB max_connections, and recycle on idle.",
   },
 ];
 
@@ -717,6 +1127,56 @@ const votes: SeedVote[] = [
     targetId: "seed-a-python-01-2",
     value: -1,
   },
+
+  // -----------------------------------------------------------------------
+  // Edge-case fixtures (named for e2e/manual targeting):
+  //
+  // 1. Net-negative answer with mixed votes:
+  //    seed-a-golang-01-2 picks up a second downvote from carol and one
+  //    upvote from alice. Combined with the existing dave -1, final tally
+  //    is -1 (dave -1, carol -1, alice +1).
+  // 2. Accepted answer that is also downvoted:
+  //    seed-a-react-01-1 (the accepted answer on react-01) gets a -1 from
+  //    dave so the UI must show "accepted + contested".
+  // 3. Strongly net-negative fresh answer:
+  //    seed-a-golang-06-2 collects two downvotes (alice + carol) for a
+  //    clean -2 with no upvotes — useful for sort/score testing.
+  // -----------------------------------------------------------------------
+  {
+    id: "seed-v-a-golang-01-2-carol",
+    userId: "seed-user-carol",
+    targetType: "answer",
+    targetId: "seed-a-golang-01-2",
+    value: -1,
+  },
+  {
+    id: "seed-v-a-golang-01-2-alice",
+    userId: "seed-user-alice",
+    targetType: "answer",
+    targetId: "seed-a-golang-01-2",
+    value: 1,
+  },
+  {
+    id: "seed-v-a-react-01-1-dave",
+    userId: "seed-user-dave",
+    targetType: "answer",
+    targetId: "seed-a-react-01-1",
+    value: -1,
+  },
+  {
+    id: "seed-v-a-golang-06-2-alice",
+    userId: "seed-user-alice",
+    targetType: "answer",
+    targetId: "seed-a-golang-06-2",
+    value: -1,
+  },
+  {
+    id: "seed-v-a-golang-06-2-carol",
+    userId: "seed-user-carol",
+    targetType: "answer",
+    targetId: "seed-a-golang-06-2",
+    value: -1,
+  },
 ];
 
 type SeedFavorite = {
@@ -788,6 +1248,72 @@ const favorites: SeedFavorite[] = [
     targetId: "seed-a-golang-02-1",
   },
 ];
+
+// -----------------------------------------------------------------------
+// Notifications: fanned out per question to every approved member of the
+// question's group, excluding the author. Mirrors the runtime behavior of
+// notifyQuestionCreated() in src/lib/notifications.ts. Re-declared here
+// (instead of imported) because that module is server-only.
+//
+// Read/unread split for e2e/manual testing:
+//   - alice + carol: every notification marked read (use to verify the
+//     "no unread" UI state).
+//   - bob, dave, eve: every notification unread (use to verify the bell
+//     badge, polling, mark-read, and mark-all-read flows).
+// -----------------------------------------------------------------------
+
+type SeedQuestionCreatedPayload = {
+  questionId: string;
+  questionTitle: string;
+  groupSlug: string;
+  groupName: string;
+  authorName: string | null;
+};
+
+type SeedNotification = {
+  id: string;
+  userId: string;
+  type: "question.created";
+  payload: string;
+  readAt: Date | null;
+};
+
+const READ_USER_IDS = new Set(["seed-user-alice", "seed-user-carol"]);
+const SEED_READ_AT = new Date("2026-05-01T00:00:00Z");
+
+const notifications: SeedNotification[] = (() => {
+  const out: SeedNotification[] = [];
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  const userById = new Map(users.map((u) => [u.id, u]));
+  for (const q of questions) {
+    const group = groupById.get(q.groupId);
+    const author = userById.get(q.authorId);
+    if (!group || !author) continue;
+    const recipients = memberships
+      .filter(
+        (m) => m.groupId === q.groupId && m.status === "approved" && m.userId !== q.authorId,
+      )
+      .map((m) => m.userId);
+    const payload: SeedQuestionCreatedPayload = {
+      questionId: q.id,
+      questionTitle: q.title,
+      groupSlug: group.slug,
+      groupName: group.name,
+      authorName: author.name,
+    };
+    const payloadJson = JSON.stringify(payload);
+    for (const userId of recipients) {
+      out.push({
+        id: `seed-n-${q.id}-${userId}`,
+        userId,
+        type: "question.created",
+        payload: payloadJson,
+        readAt: READ_USER_IDS.has(userId) ? SEED_READ_AT : null,
+      });
+    }
+  }
+  return out;
+})();
 
 async function main() {
   for (const u of users) {
@@ -902,6 +1428,20 @@ async function main() {
     });
   }
 
+  for (const n of notifications) {
+    await prisma.notification.upsert({
+      where: { id: n.id },
+      create: {
+        id: n.id,
+        userId: n.userId,
+        type: n.type,
+        payload: n.payload,
+        readAt: n.readAt,
+      },
+      update: { type: n.type, payload: n.payload, readAt: n.readAt },
+    });
+  }
+
   const counts = {
     users: await prisma.user.count(),
     groups: await prisma.group.count(),
@@ -910,6 +1450,7 @@ async function main() {
     answers: await prisma.answer.count(),
     votes: await prisma.vote.count(),
     favorites: await prisma.favorite.count(),
+    notifications: await prisma.notification.count(),
   };
 
   console.log("Seed complete:", counts);


### PR DESCRIPTION
## Summary

- Extend `prisma/seed.ts`: +30 questions (50 total) and +20 answers planted with FTS-friendly keywords (`sync pool`, `context cancellation`, `terraform plan`, etc.), diacritics (`café`, `naïve`), and prefix-match (`gener*`); +5 votes for named edge cases (net-negative, strongly-negative, accepted-but-contested).
- Add 140 `question.created` notifications fanned out to approved members (mirroring `notifyQuestionCreated`), with a deterministic read/unread split (alice + carol all-read; bob/dave/eve all-unread) so the bell UI flows are exercisable.
- Add `prisma/README.md` as the canonical test-data reference: how-to-run, test users, membership matrix, edge-case fixtures with IDs/emails, notification fixtures, search keywords, idempotency note, what's not seeded. Linked from the top-level README.
- All additions use deterministic `seed-*` IDs + `upsert` — `npm run db:seed` remains idempotent.

## Test plan

- [x] `npm run db:seed` runs cleanly. Final counts: users 5, groups 5, memberships 25, questions 50, answers 34, votes 25, favorites 10, notifications 140.
- [x] `npm run db:seed` a second time → identical counts (idempotent).
- [x] `npm run lint`, `npm run typecheck`, `npm run test` all pass (276/276).
- [ ] `npm run db:reset` from a clean DB (blocked from agent execution; verify locally).
- [ ] Manual: sign in as `bob@example.com` → bell shows unread; sign in as `alice@example.com` → bell shows zero unread.
- [ ] Manual: search `"sync pool"` with scope=current (in Go) vs scope=all → counts differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)