### PR TITLE
docs(readme): add dev sign-in section with seeded test users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,28 @@ npm run dev
 
 The app will be available at http://localhost:3000.
 
-After seeding, dev sign-in works with any of:
-`alice@example.com`, `bob@example.com`, `carol@example.com`, `dave@example.com`, `eve@example.com`.
 The seed is idempotent — re-running it converges on the same dataset.
 
-For the full test-data reference (membership matrix, edge-case fixtures,
-notification read/unread split, search keywords planted for FTS testing),
-see [`prisma/README.md`](prisma/README.md).
+## Dev sign-in
+
+Authentication is currently a dev-only shim ([`src/lib/auth.ts`](src/lib/auth.ts)) that will be replaced with Active Directory. It is **email-only — no password** — and `signIn()` throws when `NODE_ENV === "production"`, so this flow cannot ship.
+
+To sign in:
+
+1. Visit http://localhost:3000/login.
+2. Type one of the seeded emails below and submit.
+
+Typing an unseeded email creates a new bare-bones user on first sign-in (no group memberships) — that's expected, not a bug.
+
+| Email               | Name        | Pick this user to test…                                                        |
+| ------------------- | ----------- | ------------------------------------------------------------------------------ |
+| `alice@example.com` | Alice Adams | Owner flows in **Go**; all-notifications-read state                            |
+| `bob@example.com`   | Bob Brown   | Owner flows in **React**; unread-notifications bell badge                      |
+| `carol@example.com` | Carol Chen  | Owner of **Kubernetes**; moderator actions in Go                               |
+| `dave@example.com`  | Dave Davis  | Owner of **Python**; moderator actions in React                                |
+| `eve@example.com`   | Eve Evans   | Mixed membership states (pending, rejected, owner) for moderation/edge-case UI |
+
+For the full membership matrix, edge-case fixtures, notification read/unread split, and search keywords planted for FTS testing, see [`prisma/README.md`](prisma/README.md).
 
 ## Scripts
 


### PR DESCRIPTION
## Summary

- Replaces the buried one-liner under **Setup** in `README.md` with a dedicated **Dev sign-in** section.
- Documents the email-only auth shim, the `NODE_ENV === "production"` guard, and the two-step login flow at `http://localhost:3000/login`.
- Adds a "Pick this user to test…" table for the five seeded users, framed by scenario (owner/moderator flows, notification read-state, mixed membership) rather than duplicating the comprehensive role summary in `prisma/README.md`.

## Test plan

- [ ] `npx prettier --check README.md` passes.
- [ ] Render the README on the PR page and confirm the table and links display correctly.