### PR TITLE
feat(groups): archive and unarchive a group (closes #41)

### DIFF
--- a/prisma/migrations/20260505010000_add_group_archive/migration.sql
+++ b/prisma/migrations/20260505010000_add_group_archive/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN "archivedAt" DATETIME;
+
+-- CreateIndex
+CREATE INDEX "Group_archivedAt_idx" ON "Group"("archivedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,20 +48,22 @@ model User {
 }
 
 model Group {
-  id          String   @id @default(cuid())
-  slug        String   @unique
+  id          String    @id @default(cuid())
+  slug        String    @unique
   name        String
   description String?
-  autoApprove Boolean  @default(false)
+  autoApprove Boolean   @default(false)
   createdById String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  archivedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   createdBy   User         @relation("GroupCreator", fields: [createdById], references: [id])
   memberships Membership[]
   questions   Question[]
 
   @@index([createdById])
+  @@index([archivedAt])
 }
 
 model Membership {

--- a/src/app/api/groups/[slug]/questions/route.ts
+++ b/src/app/api/groups/[slug]/questions/route.ts
@@ -1,6 +1,6 @@
 import { getSession } from "@/lib/auth";
 import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
-import { getGroupBySlugOrThrow } from "@/lib/groups";
+import { assertGroupNotArchived, getGroupBySlugOrThrow } from "@/lib/groups";
 import { assertApprovedMember } from "@/lib/memberships";
 import { createQuestion, listQuestionsForGroup } from "@/lib/questions";
 import { notifyQuestionCreated } from "@/lib/notifications";
@@ -32,6 +32,7 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
   try {
     const group = await getGroupBySlugOrThrow(slug);
     await assertApprovedMember(group.id, session.user.id);
+    await assertGroupNotArchived(group.id);
     const question = await createQuestion(parsed.data, group.id, session.user.id);
     try {
       await notifyQuestionCreated(question, group, session.user.name);

--- a/src/app/api/groups/[slug]/route.test.ts
+++ b/src/app/api/groups/[slug]/route.test.ts
@@ -36,7 +36,7 @@ vi.mock("next/navigation", () => ({
 const auth = await import("@/lib/auth");
 const { db } = await import("@/lib/db");
 const { createGroup } = await import("@/lib/groups");
-const { GET, PATCH } = await import("./route");
+const { DELETE, GET, PATCH } = await import("./route");
 
 beforeAll(async () => {
   const root = path.resolve(import.meta.dirname, "../../../../..");
@@ -172,5 +172,77 @@ describe("PATCH /api/groups/[slug]", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.group.description).toBeNull();
+  });
+});
+
+describe("DELETE /api/groups/[slug]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await DELETE(jsonReq("http://x/api/groups/anything", "DELETE"), ctx("anything"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when slug doesn't exist", async () => {
+    await auth.signIn(`del-nf-${Date.now()}@example.com`);
+    const res = await DELETE(
+      jsonReq("http://x/api/groups/missing-del", "DELETE"),
+      ctx("missing-del"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when actor is not the owner", async () => {
+    const ownerEmail = `del-owner-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `del-forbid-${Date.now()}`;
+    await createGroup({ name: "F", slug }, ownerSess.user.id);
+    cookieStore.clear();
+    await auth.signIn(`del-stranger-${Date.now()}@example.com`);
+    const res = await DELETE(jsonReq(`http://x/api/groups/${slug}`, "DELETE"), ctx(slug));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 and sets archivedAt when actor is owner", async () => {
+    const ownerEmail = `del-ok-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `del-ok-${Date.now()}`;
+    await createGroup({ name: "Ok", slug }, ownerSess.user.id);
+    const res = await DELETE(jsonReq(`http://x/api/groups/${slug}`, "DELETE"), ctx(slug));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.group.archivedAt).not.toBeNull();
+    const fresh = await db.group.findUnique({ where: { slug } });
+    expect(fresh?.archivedAt).not.toBeNull();
+  });
+
+  it("returns 409 when the group is already archived", async () => {
+    const ownerEmail = `del-twice-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `del-twice-${Date.now()}`;
+    await createGroup({ name: "Twice", slug }, ownerSess.user.id);
+    const first = await DELETE(jsonReq(`http://x/api/groups/${slug}`, "DELETE"), ctx(slug));
+    expect(first.status).toBe(200);
+    const second = await DELETE(jsonReq(`http://x/api/groups/${slug}`, "DELETE"), ctx(slug));
+    expect(second.status).toBe(409);
+  });
+
+  it("blocks PATCH after archive (409)", async () => {
+    const ownerEmail = `del-then-patch-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `del-then-patch-${Date.now()}`;
+    await createGroup({ name: "P", slug }, ownerSess.user.id);
+    const archiveRes = await DELETE(
+      jsonReq(`http://x/api/groups/${slug}`, "DELETE"),
+      ctx(slug),
+    );
+    expect(archiveRes.status).toBe(200);
+    const patchRes = await PATCH(
+      jsonReq(`http://x/api/groups/${slug}`, "PATCH", { name: "Whoops" }),
+      ctx(slug),
+    );
+    expect(patchRes.status).toBe(409);
   });
 });

--- a/src/app/api/groups/[slug]/route.ts
+++ b/src/app/api/groups/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { getSession } from "@/lib/auth";
-import { getGroupBySlug, updateGroup } from "@/lib/groups";
+import { archiveGroup, getGroupBySlug, updateGroup } from "@/lib/groups";
 import { updateGroupSchema } from "@/lib/validation/groups";
 import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
 
@@ -32,6 +32,19 @@ export async function PATCH(req: Request, ctx: Ctx): Promise<Response> {
 
   try {
     const group = await updateGroup(slug, parsed.data, session.user.id);
+    return Response.json({ group });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}
+
+export async function DELETE(_req: Request, ctx: Ctx): Promise<Response> {
+  const { slug } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const group = await archiveGroup(slug, session.user.id);
     return Response.json({ group });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/api/groups/[slug]/unarchive/route.test.ts
+++ b/src/app/api/groups/[slug]/unarchive/route.test.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/groups/[slug]/unarchive route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-group-unarchive-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { archiveGroup, createGroup } = await import("@/lib/groups");
+const { POST } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function ctx(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+function req(slug: string): Request {
+  return new Request(`http://x/api/groups/${slug}/unarchive`, { method: "POST" });
+}
+
+describe("POST /api/groups/[slug]/unarchive", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await POST(req("anything"), ctx("anything"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for unknown slug", async () => {
+    await auth.signIn(`un-nf-${Date.now()}@example.com`);
+    const res = await POST(req("missing"), ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when actor is not the owner", async () => {
+    const ownerEmail = `un-owner-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `un-forbid-${Date.now()}`;
+    await createGroup({ name: "F", slug }, ownerSess.user.id);
+    await archiveGroup(slug, ownerSess.user.id);
+    cookieStore.clear();
+    await auth.signIn(`un-stranger-${Date.now()}@example.com`);
+    const res = await POST(req(slug), ctx(slug));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when group is not archived", async () => {
+    const ownerEmail = `un-noop-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `un-noop-${Date.now()}`;
+    await createGroup({ name: "Noop", slug }, ownerSess.user.id);
+    const res = await POST(req(slug), ctx(slug));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 200 and clears archivedAt when actor is owner", async () => {
+    const ownerEmail = `un-ok-${Date.now()}@example.com`;
+    await auth.signIn(ownerEmail);
+    const ownerSess = (await auth.getSession())!;
+    const slug = `un-ok-${Date.now()}`;
+    await createGroup({ name: "Ok", slug }, ownerSess.user.id);
+    await archiveGroup(slug, ownerSess.user.id);
+    const res = await POST(req(slug), ctx(slug));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.group.archivedAt).toBeNull();
+    const fresh = await db.group.findUnique({ where: { slug } });
+    expect(fresh?.archivedAt).toBeNull();
+  });
+});

--- a/src/app/api/groups/[slug]/unarchive/route.ts
+++ b/src/app/api/groups/[slug]/unarchive/route.ts
@@ -1,0 +1,18 @@
+import { getSession } from "@/lib/auth";
+import { unarchiveGroup } from "@/lib/groups";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+
+type Ctx = { params: Promise<{ slug: string }> };
+
+export async function POST(_req: Request, ctx: Ctx): Promise<Response> {
+  const { slug } = await ctx.params;
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const group = await unarchiveGroup(slug, session.user.id);
+    return Response.json({ group });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/questions/[id]/answers/route.ts
+++ b/src/app/api/questions/[id]/answers/route.ts
@@ -1,6 +1,7 @@
 import { getSession } from "@/lib/auth";
 import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
 import { db } from "@/lib/db";
+import { assertGroupNotArchived } from "@/lib/groups";
 import { NotFoundError, assertApprovedMember } from "@/lib/memberships";
 import { createAnswer } from "@/lib/answers";
 import { createAnswerSchema } from "@/lib/validation/answers";
@@ -34,6 +35,7 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
       throw new NotFoundError("Question not found.");
     }
     await assertApprovedMember(question.groupId, session.user.id);
+    await assertGroupNotArchived(question.groupId);
     const answer = await createAnswer(parsed.data, question.id, session.user.id);
     return Response.json({ answer }, { status: 201 });
   } catch (err) {

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -50,15 +50,32 @@ export default async function GroupDetailPage({ params }: Props) {
 
   const isOwner = membership?.role === "owner" && membership.status === "approved";
   const isApproved = membership?.status === "approved";
+  const isArchived = group.archivedAt != null;
   const memberLabel = memberCount === 1 ? "1 member" : `${memberCount} members`;
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
+      {isArchived ? (
+        <Card className="border-amber-300 bg-amber-50 dark:border-amber-700/60 dark:bg-amber-900/20">
+          <CardContent className="py-3 text-sm">
+            <strong>This group is archived.</strong>{" "}
+            It is read-only — no new questions, answers, votes, or applications. Existing
+            content remains visible.
+          </CardContent>
+        </Card>
+      ) : null}
       <Card>
         <CardHeader className="border-b">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="space-y-1">
-              <CardTitle className="text-xl">{group.name}</CardTitle>
+              <CardTitle className="text-xl">
+                {group.name}
+                {isArchived ? (
+                  <span className="ml-2 rounded-md border border-border px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    Archived
+                  </span>
+                ) : null}
+              </CardTitle>
               <CardDescription>
                 <span className="font-mono text-xs">{group.slug}</span>
                 {" · "}
@@ -91,13 +108,17 @@ export default async function GroupDetailPage({ params }: Props) {
           <p className="text-xs text-muted-foreground">
             Owner: {group.createdBy.name ?? group.createdBy.email}
           </p>
-          <MembershipActions
-            slug={group.slug}
-            isAuthenticated={Boolean(session)}
-            currentUserId={session?.user.id ?? null}
-            membership={membership ? { role: membership.role, status: membership.status } : null}
-          />
-          {isApproved ? (
+          {isArchived ? null : (
+            <MembershipActions
+              slug={group.slug}
+              isAuthenticated={Boolean(session)}
+              currentUserId={session?.user.id ?? null}
+              membership={
+                membership ? { role: membership.role, status: membership.status } : null
+              }
+            />
+          )}
+          {isApproved && !isArchived ? (
             <Button
               variant="default"
               size="sm"

--- a/src/app/groups/[slug]/settings/actions.ts
+++ b/src/app/groups/[slug]/settings/actions.ts
@@ -2,8 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
-import { updateGroup } from "@/lib/groups";
-import { AuthorizationError, NotFoundError } from "@/lib/memberships";
+import { archiveGroup, unarchiveGroup, updateGroup } from "@/lib/groups";
+import { AuthorizationError, ConflictError, NotFoundError } from "@/lib/memberships";
 
 export type ToggleAutoApproveState = {
   error?: string;
@@ -32,8 +32,65 @@ export async function toggleAutoApproveAction(
     if (err instanceof NotFoundError) {
       return { error: "Group not found." };
     }
+    if (err instanceof ConflictError) {
+      return { error: err.message };
+    }
     return {
       error: err instanceof Error ? err.message : "Could not update settings.",
+    };
+  }
+}
+
+export type ArchiveActionResult = { error?: string; ok?: true };
+
+export async function archiveGroupAction(slug: string): Promise<ArchiveActionResult> {
+  const session = await getSession();
+  if (!session) return { error: "You must be signed in." };
+
+  try {
+    await archiveGroup(slug, session.user.id);
+    revalidatePath("/groups");
+    revalidatePath(`/groups/${slug}`);
+    revalidatePath(`/groups/${slug}/settings`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only the owner can archive this group." };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: "Group not found." };
+    }
+    if (err instanceof ConflictError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not archive group.",
+    };
+  }
+}
+
+export async function unarchiveGroupAction(slug: string): Promise<ArchiveActionResult> {
+  const session = await getSession();
+  if (!session) return { error: "You must be signed in." };
+
+  try {
+    await unarchiveGroup(slug, session.user.id);
+    revalidatePath("/groups");
+    revalidatePath(`/groups/${slug}`);
+    revalidatePath(`/groups/${slug}/settings`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only the owner can restore this group." };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: "Group not found." };
+    }
+    if (err instanceof ConflictError) {
+      return { error: err.message };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not restore group.",
     };
   }
 }

--- a/src/app/groups/[slug]/settings/archive-controls.tsx
+++ b/src/app/groups/[slug]/settings/archive-controls.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { archiveGroupAction, unarchiveGroupAction } from "./actions";
+
+type Props = {
+  slug: string;
+  archived: boolean;
+};
+
+export function ArchiveControls({ slug, archived }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onArchive = () => {
+    if (
+      !confirm(
+        "Archive this group? It becomes read-only — no new questions, answers, votes, or applications. The group is hidden from the default list and search; existing content stays browsable. You can restore it later.",
+      )
+    ) {
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await archiveGroupAction(slug);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  const onUnarchive = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await unarchiveGroupAction(slug);
+      if (result.error) setError(result.error);
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {archived ? (
+        <button
+          type="button"
+          onClick={onUnarchive}
+          disabled={pending}
+          className="rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-60"
+        >
+          {pending ? "Restoring…" : "Restore group"}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onArchive}
+          disabled={pending}
+          className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-60 dark:border-red-700/60 dark:text-red-300 dark:hover:bg-red-900/20"
+        >
+          {pending ? "Archiving…" : "Archive group"}
+        </button>
+      )}
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/groups/[slug]/settings/page.tsx
+++ b/src/app/groups/[slug]/settings/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { requireAuth } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
 import { isOwner, listPendingApplications } from "@/lib/memberships";
+import { ArchiveControls } from "./archive-controls";
 import { AutoApproveToggle } from "./auto-approve-toggle";
 import { PendingApplicationsList, type PendingApplicationView } from "./pending-applications-list";
 
@@ -17,13 +18,17 @@ export default async function GroupSettingsPage({ params }: Props) {
   if (!group) notFound();
   if (!(await isOwner(group.id, session.user.id))) notFound();
 
-  const pending = await listPendingApplications(group.id);
+  const pending = group.archivedAt
+    ? []
+    : await listPendingApplications(group.id);
   const applications: PendingApplicationView[] = pending.map((m) => ({
     userId: m.userId,
     email: m.user.email,
     name: m.user.name,
     appliedAt: m.createdAt.toISOString(),
   }));
+
+  const isArchived = group.archivedAt != null;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-8">
@@ -34,6 +39,11 @@ export default async function GroupSettingsPage({ params }: Props) {
             <span className="font-mono text-xs">{group.slug}</span>
             {" · "}
             {group.name}
+            {isArchived ? (
+              <span className="ml-2 rounded-md border border-border px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Archived
+              </span>
+            ) : null}
           </p>
         </div>
         <Button variant="outline" size="sm" render={<Link href={`/groups/${group.slug}`} />}>
@@ -44,24 +54,50 @@ export default async function GroupSettingsPage({ params }: Props) {
       <Card>
         <CardHeader>
           <CardTitle>Membership</CardTitle>
-          <CardDescription>Control how new members join this group.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <AutoApproveToggle slug={group.slug} initial={group.autoApprove} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Pending applications</CardTitle>
           <CardDescription>
-            {applications.length === 0
-              ? "Nothing waiting for review."
-              : `${applications.length} ${applications.length === 1 ? "person is" : "people are"} waiting to join.`}
+            {isArchived
+              ? "Archived groups are read-only. Restore the group to manage membership."
+              : "Control how new members join this group."}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <PendingApplicationsList slug={group.slug} applications={applications} />
+          {isArchived ? (
+            <p className="text-sm text-muted-foreground">
+              Auto-approve is currently {group.autoApprove ? "on" : "off"}.
+            </p>
+          ) : (
+            <AutoApproveToggle slug={group.slug} initial={group.autoApprove} />
+          )}
+        </CardContent>
+      </Card>
+
+      {isArchived ? null : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pending applications</CardTitle>
+            <CardDescription>
+              {applications.length === 0
+                ? "Nothing waiting for review."
+                : `${applications.length} ${applications.length === 1 ? "person is" : "people are"} waiting to join.`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <PendingApplicationsList slug={group.slug} applications={applications} />
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{isArchived ? "Restore" : "Danger zone"}</CardTitle>
+          <CardDescription>
+            {isArchived
+              ? "Restore this group to make it read-write again. It will reappear in the default group list and search."
+              : "Archive this group to make it read-only. The page stays browsable so existing links keep working."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ArchiveControls slug={group.slug} archived={isArchived} />
         </CardContent>
       </Card>
     </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -5,16 +5,30 @@ import { Button } from "@/components/ui/button";
 import { getSession } from "@/lib/auth";
 import { listGroups, type ListGroupsSort } from "@/lib/groups";
 
-type Props = { searchParams: Promise<{ sort?: string }> };
+type Props = {
+  searchParams: Promise<{ sort?: string; includeArchived?: string }>;
+};
 
 function parseSort(value: string | undefined): ListGroupsSort {
   return value === "members" ? "members" : "newest";
 }
 
+function buildToggleHref(sort: ListGroupsSort, includeArchived: boolean): string {
+  const params = new URLSearchParams();
+  if (sort === "members") params.set("sort", "members");
+  if (!includeArchived) params.set("includeArchived", "1");
+  const qs = params.toString();
+  return qs ? `/groups?${qs}` : "/groups";
+}
+
 export default async function GroupsPage({ searchParams }: Props) {
   const sp = await searchParams;
   const sort = parseSort(sp.sort);
-  const [session, groups] = await Promise.all([getSession(), listGroups({ sort })]);
+  const includeArchived = sp.includeArchived === "1";
+  const [session, groups] = await Promise.all([
+    getSession(),
+    listGroups({ sort, includeArchived }),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -27,7 +41,15 @@ export default async function GroupsPage({ searchParams }: Props) {
         </div>
         {session ? <Button render={<Link href="/groups/new" />}>Create group</Button> : null}
       </div>
-      <SortTabs active={sort} />
+      <div className="flex flex-wrap items-center gap-3">
+        <SortTabs active={sort} includeArchived={includeArchived} />
+        <Link
+          href={buildToggleHref(sort, includeArchived)}
+          className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+        >
+          {includeArchived ? "Hide archived" : "Show archived"}
+        </Link>
+      </div>
       {groups.length === 0 ? (
         <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
           No groups yet.{" "}

--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -10,14 +10,24 @@ import type { GroupListItem } from "@/lib/groups";
 
 export function GroupCard({ group }: { group: GroupListItem }) {
   const memberLabel = group.memberCount === 1 ? "member" : "members";
+  const isArchived = group.archivedAt != null;
   return (
     <Link
       href={`/groups/${group.slug}`}
       className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-xl"
     >
-      <Card className="h-full transition-shadow hover:shadow-md">
+      <Card
+        className={`h-full transition-shadow hover:shadow-md ${isArchived ? "opacity-70" : ""}`}
+      >
         <CardHeader>
-          <CardTitle className="text-base">{group.name}</CardTitle>
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-base">{group.name}</CardTitle>
+            {isArchived ? (
+              <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Archived
+              </span>
+            ) : null}
+          </div>
           <CardDescription>
             <span className="font-mono text-xs">{group.slug}</span>
             {" · "}

--- a/src/components/groups/sort-tabs.tsx
+++ b/src/components/groups/sort-tabs.tsx
@@ -2,18 +2,32 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { ListGroupsSort } from "@/lib/groups";
 
-const TABS: ReadonlyArray<{ value: ListGroupsSort; label: string; href: string }> = [
-  { value: "newest", label: "Newest", href: "/groups" },
-  { value: "members", label: "Most members", href: "/groups?sort=members" },
+const TABS: ReadonlyArray<{ value: ListGroupsSort; label: string }> = [
+  { value: "newest", label: "Newest" },
+  { value: "members", label: "Most members" },
 ];
 
-export function SortTabs({ active }: { active: ListGroupsSort }) {
+function buildHref(sort: ListGroupsSort, includeArchived: boolean): string {
+  const params = new URLSearchParams();
+  if (sort === "members") params.set("sort", "members");
+  if (includeArchived) params.set("includeArchived", "1");
+  const qs = params.toString();
+  return qs ? `/groups?${qs}` : "/groups";
+}
+
+export function SortTabs({
+  active,
+  includeArchived,
+}: {
+  active: ListGroupsSort;
+  includeArchived: boolean;
+}) {
   return (
     <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-background p-1">
       {TABS.map((t) => (
         <Link
           key={t.value}
-          href={t.href}
+          href={buildHref(t.value, includeArchived)}
           aria-current={t.value === active ? "page" : undefined}
           className={cn(
             "rounded-md px-3 py-1 text-sm transition-colors",

--- a/src/lib/answers.ts
+++ b/src/lib/answers.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { Answer } from "@prisma/client";
 import { db } from "@/lib/db";
+import { assertGroupNotArchived } from "@/lib/groups";
 import {
   AuthorizationError,
   NotFoundError,
@@ -51,6 +52,7 @@ export async function updateAnswer(
   if (existing.authorId !== userId) {
     throw new AuthorizationError("Only the answer's author can edit it.");
   }
+  await assertGroupNotArchived(existing.question.groupId);
   return db.answer.update({
     where: { id: answerId },
     data: { body: input.body },

--- a/src/lib/groups.test.ts
+++ b/src/lib/groups.test.ts
@@ -16,14 +16,17 @@ process.env["DATABASE_URL"] = `file:${testDbPath}`;
 
 const { db } = await import("./db");
 const {
+  archiveGroup,
+  assertGroupNotArchived,
   createGroup,
   getGroupBySlug,
   getGroupBySlugOrThrow,
   listGroups,
+  unarchiveGroup,
   updateGroup,
   SlugConflictError,
 } = await import("./groups");
-const { AuthorizationError, NotFoundError } = await import("./memberships");
+const { AuthorizationError, ConflictError, NotFoundError } = await import("./memberships");
 
 beforeAll(async () => {
   const root = path.resolve(import.meta.dirname, "../..");
@@ -203,5 +206,75 @@ describe("listGroups", () => {
     expect(indexBig).toBeGreaterThanOrEqual(0);
     expect(indexSmall).toBeGreaterThanOrEqual(0);
     expect(indexBig).toBeLessThan(indexSmall);
+  });
+
+  it("excludes archived groups by default but includes them when includeArchived is set", async () => {
+    const owner = await makeUser("ls-arch");
+    const slug = `ls-arch-${Date.now()}`;
+    const group = await createGroup({ name: "Archy", slug }, owner.id);
+    await archiveGroup(slug, owner.id);
+
+    const defaultList = await listGroups({ sort: "newest" });
+    expect(defaultList.find((g) => g.id === group.id)).toBeUndefined();
+
+    const fullList = await listGroups({ sort: "newest", includeArchived: true });
+    const found = fullList.find((g) => g.id === group.id);
+    expect(found).toBeDefined();
+    expect(found!.archivedAt).not.toBeNull();
+  });
+});
+
+describe("archiveGroup / unarchiveGroup", () => {
+  it("owner can archive then unarchive", async () => {
+    const owner = await makeUser("arch-owner");
+    const slug = `arch-${Date.now()}`;
+    await createGroup({ name: "A", slug }, owner.id);
+    const archived = await archiveGroup(slug, owner.id);
+    expect(archived.archivedAt).not.toBeNull();
+
+    const restored = await unarchiveGroup(slug, owner.id);
+    expect(restored.archivedAt).toBeNull();
+  });
+
+  it("non-owner cannot archive (AuthorizationError)", async () => {
+    const owner = await makeUser("arch-owner2");
+    const stranger = await makeUser("arch-strange");
+    const slug = `arch2-${Date.now()}`;
+    await createGroup({ name: "A", slug }, owner.id);
+    await expect(archiveGroup(slug, stranger.id)).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("archiveGroup throws ConflictError when already archived", async () => {
+    const owner = await makeUser("arch-double");
+    const slug = `arch-double-${Date.now()}`;
+    await createGroup({ name: "A", slug }, owner.id);
+    await archiveGroup(slug, owner.id);
+    await expect(archiveGroup(slug, owner.id)).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("unarchiveGroup throws ConflictError when not archived", async () => {
+    const owner = await makeUser("arch-noop");
+    const slug = `arch-noop-${Date.now()}`;
+    await createGroup({ name: "A", slug }, owner.id);
+    await expect(unarchiveGroup(slug, owner.id)).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("updateGroup is blocked on archived groups (ConflictError)", async () => {
+    const owner = await makeUser("arch-update");
+    const slug = `arch-update-${Date.now()}`;
+    await createGroup({ name: "A", slug }, owner.id);
+    await archiveGroup(slug, owner.id);
+    await expect(
+      updateGroup(slug, { name: "Renamed" }, owner.id),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("assertGroupNotArchived throws when archived, no-op otherwise", async () => {
+    const owner = await makeUser("arch-assert");
+    const slug = `arch-assert-${Date.now()}`;
+    const group = await createGroup({ name: "A", slug }, owner.id);
+    await expect(assertGroupNotArchived(group.id)).resolves.toBeUndefined();
+    await archiveGroup(slug, owner.id);
+    await expect(assertGroupNotArchived(group.id)).rejects.toBeInstanceOf(ConflictError);
   });
 });

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { Group, User } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import { db } from "@/lib/db";
-import { assertOwner, NotFoundError } from "@/lib/memberships";
+import { assertOwner, ConflictError, NotFoundError } from "@/lib/memberships";
 import type { CreateGroupInput, UpdateGroupInput } from "@/lib/validation/groups";
 
 export class SlugConflictError extends Error {
@@ -60,19 +60,26 @@ export type GroupListItem = {
   description: string | null;
   memberCount: number;
   createdAt: Date;
+  archivedAt: Date | null;
 };
 
 export type ListGroupsSort = "newest" | "members";
 
-export async function listGroups(opts: { sort: ListGroupsSort }): Promise<GroupListItem[]> {
+export async function listGroups(opts: {
+  sort: ListGroupsSort;
+  includeArchived?: boolean;
+}): Promise<GroupListItem[]> {
+  const where = opts.includeArchived ? {} : { archivedAt: null };
   const [groups, counts] = await Promise.all([
     db.group.findMany({
+      where,
       select: {
         id: true,
         slug: true,
         name: true,
         description: true,
         createdAt: true,
+        archivedAt: true,
       },
     }),
     db.membership.groupBy({
@@ -90,6 +97,7 @@ export async function listGroups(opts: { sort: ListGroupsSort }): Promise<GroupL
     name: g.name,
     description: g.description,
     createdAt: g.createdAt,
+    archivedAt: g.archivedAt,
     memberCount: countByGroupId.get(g.id) ?? 0,
   }));
 
@@ -127,9 +135,47 @@ export async function updateGroup(
 ): Promise<Group> {
   const group = await getGroupBySlugOrThrow(slug);
   await assertOwner(group.id, actorUserId);
+  if (group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
+  }
   const data: Prisma.GroupUpdateInput = {};
   if (input.name !== undefined) data.name = input.name;
   if (input.description !== undefined) data.description = input.description;
   if (input.autoApprove !== undefined) data.autoApprove = input.autoApprove;
   return db.group.update({ where: { id: group.id }, data });
+}
+
+export async function assertGroupNotArchived(groupId: string): Promise<void> {
+  const group = await db.group.findUnique({
+    where: { id: groupId },
+    select: { archivedAt: true },
+  });
+  if (!group) throw new NotFoundError("Group not found.");
+  if (group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
+  }
+}
+
+export async function archiveGroup(slug: string, actorUserId: string): Promise<Group> {
+  const group = await getGroupBySlugOrThrow(slug);
+  await assertOwner(group.id, actorUserId);
+  if (group.archivedAt) {
+    throw new ConflictError("Group is already archived.");
+  }
+  return db.group.update({
+    where: { id: group.id },
+    data: { archivedAt: new Date() },
+  });
+}
+
+export async function unarchiveGroup(slug: string, actorUserId: string): Promise<Group> {
+  const group = await getGroupBySlugOrThrow(slug);
+  await assertOwner(group.id, actorUserId);
+  if (!group.archivedAt) {
+    throw new ConflictError("Group is not archived.");
+  }
+  return db.group.update({
+    where: { id: group.id },
+    data: { archivedAt: null },
+  });
 }

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -95,9 +95,12 @@ export async function assertApprovedMember(groupId: string, userId: string): Pro
 export async function applyToGroup(groupId: string, userId: string): Promise<Membership> {
   const group = await db.group.findUnique({
     where: { id: groupId },
-    select: { autoApprove: true },
+    select: { autoApprove: true, archivedAt: true },
   });
   if (!group) throw new NotFoundError("Group not found.");
+  if (group.archivedAt) {
+    throw new ConflictError("This group is archived and is not accepting new applications.");
+  }
 
   const existing = await getMembership(groupId, userId);
   if (existing) {
@@ -127,6 +130,14 @@ export async function setMembershipStatus(
   actorUserId: string,
 ): Promise<Membership> {
   await assertOwnerOrModerator(groupId, actorUserId);
+  const group = await db.group.findUnique({
+    where: { id: groupId },
+    select: { archivedAt: true },
+  });
+  if (!group) throw new NotFoundError("Group not found.");
+  if (group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
+  }
   const target = await getMembership(groupId, targetUserId);
   if (!target) throw new NotFoundError("Membership not found.");
   if (target.role === "owner") {

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -3,6 +3,7 @@ import type { Answer, Question, User } from "@prisma/client";
 import { db } from "@/lib/db";
 import {
   AuthorizationError,
+  ConflictError,
   NotFoundError,
   isOwnerOrModerator,
 } from "@/lib/memberships";
@@ -69,11 +70,19 @@ export async function updateQuestion(
 ): Promise<Question> {
   const existing = await db.question.findUnique({
     where: { id: questionId },
-    select: { id: true, authorId: true },
+    select: {
+      id: true,
+      authorId: true,
+      deletedAt: true,
+      group: { select: { archivedAt: true } },
+    },
   });
-  if (!existing) throw new NotFoundError("Question not found.");
+  if (!existing || existing.deletedAt) throw new NotFoundError("Question not found.");
   if (existing.authorId !== userId) {
     throw new AuthorizationError("Only the question's author can edit it.");
+  }
+  if (existing.group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
   }
   return db.question.update({
     where: { id: questionId },
@@ -222,10 +231,19 @@ export async function acceptAnswer(
 ): Promise<Question> {
   const question = await db.question.findUnique({
     where: { id: questionId },
-    select: { id: true, authorId: true, groupId: true, deletedAt: true },
+    select: {
+      id: true,
+      authorId: true,
+      groupId: true,
+      deletedAt: true,
+      group: { select: { archivedAt: true } },
+    },
   });
   if (!question || question.deletedAt) {
     throw new NotFoundError("Question not found.");
+  }
+  if (question.group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
   }
 
   await assertCanResolveQuestion(question, userId);
@@ -252,10 +270,19 @@ export async function reopenQuestion(
 ): Promise<Question> {
   const question = await db.question.findUnique({
     where: { id: questionId },
-    select: { id: true, authorId: true, groupId: true, deletedAt: true },
+    select: {
+      id: true,
+      authorId: true,
+      groupId: true,
+      deletedAt: true,
+      group: { select: { archivedAt: true } },
+    },
   });
   if (!question || question.deletedAt) {
     throw new NotFoundError("Question not found.");
+  }
+  if (question.group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
   }
 
   await assertCanResolveQuestion(question, userId);

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -369,4 +369,47 @@ describe("searchContent", () => {
     expect(after.items.some((i) => i.questionId === q.id)).toBe(false);
     expect(after.total).toBeLessThan(beforeTotal);
   });
+
+  it("excludes content from archived groups", async () => {
+    const author = await makeUser("archSearch");
+    const group = await createGroup(
+      { name: "Arch", slug: uniq("arch"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Numbat sightings on the trail", body: "Spotted a numbat at dawn." },
+      group.id,
+      author.id,
+    );
+    const answer = await db.answer.create({
+      data: { questionId: q.id, authorId: author.id, body: "Numbat populations vary widely." },
+    });
+
+    const before = await searchContent({
+      q: "numbat",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 5,
+    });
+    expect(before.items.some((i) => i.questionId === q.id)).toBe(true);
+    expect(
+      before.items.some((i) => i.type === "answer" && i.answerId === answer.id),
+    ).toBe(true);
+
+    await db.group.update({
+      where: { id: group.id },
+      data: { archivedAt: new Date() },
+    });
+
+    const after = await searchContent({
+      q: "numbat",
+      scope: "all",
+      groupIds: [],
+      page: 1,
+      per: 5,
+    });
+    expect(after.items.some((i) => i.questionId === q.id)).toBe(false);
+    expect(after.items.some((i) => i.answerId === answer.id)).toBe(false);
+  });
 });

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -121,8 +121,10 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
           bm25(question_fts) AS score
         FROM question_fts
         JOIN "Question" q ON q.id = question_fts.id
+        JOIN "Group" g ON g.id = q."groupId"
         WHERE question_fts MATCH ${expr}
           AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
         ${groupFilterQuestion}
         ORDER BY score ASC, created_at DESC
         LIMIT ${fetchLimit}
@@ -140,8 +142,10 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         FROM answer_fts
         JOIN "Answer" a ON a.id = answer_fts.id
         JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
         WHERE answer_fts MATCH ${expr}
           AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
         ${groupFilterQuestion}
         ORDER BY score ASC, created_at DESC
         LIMIT ${fetchLimit}
@@ -150,8 +154,10 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         SELECT COUNT(*) AS n
         FROM question_fts
         JOIN "Question" q ON q.id = question_fts.id
+        JOIN "Group" g ON g.id = q."groupId"
         WHERE question_fts MATCH ${expr}
           AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
         ${groupFilterQuestion}
       `),
       db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
@@ -159,8 +165,10 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
         FROM answer_fts
         JOIN "Answer" a ON a.id = answer_fts.id
         JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
         WHERE answer_fts MATCH ${expr}
           AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
         ${groupFilterQuestion}
       `),
     ]);

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { Prisma, type TargetType } from "@prisma/client";
 import { db } from "@/lib/db";
+import { assertGroupNotArchived } from "@/lib/groups";
 import {
   AuthorizationError,
   NotFoundError,
@@ -78,6 +79,7 @@ export async function castVote(
     throw new AuthorizationError("You cannot vote on your own content.");
   }
   await assertApprovedMember(groupId, userId);
+  await assertGroupNotArchived(groupId);
 
   const existing = await db.vote.findUnique({
     where: {


### PR DESCRIPTION
## Summary
- Adds `Group.archivedAt` (nullable) + migration; `DELETE /api/groups/:slug` archives and `POST /api/groups/:slug/unarchive` restores, owner-only.
- Archived groups are read-only across the app: question/answer creation, edits, votes, applications, and PATCH all return 409 via a centralized `assertGroupNotArchived` helper.
- Group list and FTS search exclude archived groups by default; `/groups?includeArchived=1` reveals them with an "Archived" pill, and existing detail/permalinks still load with a banner so inbound links don't 404.
- Settings page gains a danger-zone card with confirm-on-archive and a one-click restore.

## Test plan
- [x] \`npx prisma validate\`, \`npm run typecheck\`, \`npm run lint\` — clean
- [x] \`npm run test\` — 325/325 (new coverage: lib archive/unarchive + assertion helper, DELETE route incl. write-block, unarchive route, search exclusion)
- [ ] Manual smoke: owner archive from Settings hides group from \`/groups\` and search; detail page shows banner; restore reverses; non-owner DELETE returns 403; \`?includeArchived=1\` shows archived groups with pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)