### PR TITLE
feat(profile): edit name and bio (closes #42)

### DIFF
--- a/prisma/migrations/20260506000000_add_user_bio/migration.sql
+++ b/prisma/migrations/20260506000000_add_user_bio/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "bio" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   emailVerified DateTime?
   name          String?
   image         String?
+  bio           String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 

--- a/src/app/api/me/route.test.ts
+++ b/src/app/api/me/route.test.ts
@@ -1,0 +1,190 @@
+/**
+ * PATCH /api/me route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-me-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { PATCH } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function jsonReq(body?: unknown): Request {
+  return new Request("http://x/api/me", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function rawReq(body: string): Request {
+  return new Request("http://x/api/me", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+async function signInFresh(email: string): Promise<string> {
+  cookieStore.clear();
+  await auth.signIn(email);
+  const sess = (await auth.getSession())!;
+  return sess.user.id;
+}
+
+describe("PATCH /api/me", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await PATCH(jsonReq({ name: "Alice" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when JSON body is malformed", async () => {
+    await signInFresh(`bad-json-${Date.now()}@example.com`);
+    const res = await PATCH(rawReq("{ not json"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("ValidationError");
+  });
+
+  it("returns 400 when name is empty", async () => {
+    await signInFresh(`empty-name-${Date.now()}@example.com`);
+    const res = await PATCH(jsonReq({ name: "   ", bio: "hi" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(
+      json.issues?.some((i: { path: string[] }) => i.path.includes("name")),
+    ).toBe(true);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    await signInFresh(`missing-name-${Date.now()}@example.com`);
+    const res = await PATCH(jsonReq({ bio: "hi" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when bio exceeds 1000 chars", async () => {
+    await signInFresh(`long-bio-${Date.now()}@example.com`);
+    const res = await PATCH(
+      jsonReq({ name: "Alice", bio: "x".repeat(1001) }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(
+      json.issues?.some((i: { path: string[] }) => i.path.includes("bio")),
+    ).toBe(true);
+  });
+
+  it("returns 200 and updates name + bio for the authed user", async () => {
+    const userId = await signInFresh(`happy-${Date.now()}@example.com`);
+    const res = await PATCH(
+      jsonReq({ name: "Alice Example", bio: "Hello **world**." }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.user.id).toBe(userId);
+    expect(json.user.name).toBe("Alice Example");
+    expect(json.user.bio).toBe("Hello **world**.");
+
+    const row = await db.user.findUnique({ where: { id: userId } });
+    expect(row!.name).toBe("Alice Example");
+    expect(row!.bio).toBe("Hello **world**.");
+  });
+
+  it("clears bio when omitted", async () => {
+    const userId = await signInFresh(`clear-bio-${Date.now()}@example.com`);
+    await db.user.update({
+      where: { id: userId },
+      data: { bio: "starting bio" },
+    });
+
+    const res = await PATCH(jsonReq({ name: "Bob" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.user.bio).toBeNull();
+
+    const row = await db.user.findUnique({ where: { id: userId } });
+    expect(row!.bio).toBeNull();
+  });
+
+  it("clears bio when empty string", async () => {
+    const userId = await signInFresh(`empty-bio-${Date.now()}@example.com`);
+    await db.user.update({
+      where: { id: userId },
+      data: { bio: "starting bio" },
+    });
+
+    const res = await PATCH(jsonReq({ name: "Bob", bio: "   " }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.user.bio).toBeNull();
+  });
+
+  it("trims whitespace around name and bio", async () => {
+    const userId = await signInFresh(`trim-${Date.now()}@example.com`);
+    const res = await PATCH(
+      jsonReq({ name: "  Carol  ", bio: "  short bio  " }),
+    );
+    expect(res.status).toBe(200);
+
+    const row = await db.user.findUnique({ where: { id: userId } });
+    expect(row!.name).toBe("Carol");
+    expect(row!.bio).toBe("short bio");
+  });
+});

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,0 +1,33 @@
+import { getSession } from "@/lib/auth";
+import {
+  errorToResponse,
+  unauthorized,
+  validationFailed,
+} from "@/lib/api/errors";
+import { updateUserProfile } from "@/lib/profile";
+import { updateMeSchema } from "@/lib/validation/users";
+
+export async function PATCH(req: Request): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json(
+      { error: "ValidationError", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateMeSchema.safeParse(raw);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const user = await updateUserProfile(session.user.id, parsed.data);
+    return Response.json({ user }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/me/actions.ts
+++ b/src/app/me/actions.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import { updateUserProfile } from "@/lib/profile";
+import { updateMeSchema } from "@/lib/validation/users";
+
+export type FieldError = { path: string; message: string };
+
+export type MeFormState = {
+  ok?: boolean;
+  error?: string;
+  fieldErrors?: FieldError[];
+  values?: { name?: string; bio?: string };
+};
+
+export async function updateMeAction(
+  _prev: MeFormState,
+  formData: FormData,
+): Promise<MeFormState> {
+  const session = await getSession();
+  if (!session) {
+    return { error: "You must be signed in to edit your profile." };
+  }
+
+  const raw = {
+    name: String(formData.get("name") ?? ""),
+    bio: String(formData.get("bio") ?? ""),
+  };
+  const parsed = updateMeSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+      values: raw,
+    };
+  }
+
+  try {
+    await updateUserProfile(session.user.id, parsed.data);
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err.message : "Could not update profile.",
+      values: raw,
+    };
+  }
+
+  revalidatePath("/me");
+  revalidatePath(`/u/${session.user.id}`);
+  return { ok: true };
+}

--- a/src/app/me/edit-profile-form.tsx
+++ b/src/app/me/edit-profile-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { MarkdownBody } from "@/components/markdown-body";
+import { updateMeAction, type MeFormState } from "./actions";
+
+const initialState: MeFormState = {};
+
+function fieldError(state: MeFormState, path: string): string | undefined {
+  return state.fieldErrors?.find((e) => e.path === path)?.message;
+}
+
+type Props = {
+  name: string | null;
+  bio: string | null;
+};
+
+export function EditProfileForm({ name, bio }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [state, formAction, isPending] = useActionState(updateMeAction, initialState);
+
+  useEffect(() => {
+    if (state.ok) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEditing(false);
+    }
+  }, [state.ok]);
+
+  if (editing) {
+    return (
+      <form action={formAction} className="space-y-3">
+        <div className="space-y-1">
+          <label htmlFor="edit-profile-name" className="block text-sm font-medium">
+            Name
+          </label>
+          <input
+            id="edit-profile-name"
+            name="name"
+            type="text"
+            required
+            minLength={1}
+            maxLength={100}
+            defaultValue={state.values?.name ?? name ?? ""}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+          />
+          {fieldError(state, "name") ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {fieldError(state, "name")}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="edit-profile-bio" className="block text-sm font-medium">
+            Bio <span className="text-zinc-500">(Markdown supported, optional)</span>
+          </label>
+          <textarea
+            id="edit-profile-bio"
+            name="bio"
+            rows={6}
+            maxLength={1000}
+            defaultValue={state.values?.bio ?? bio ?? ""}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+          />
+          {fieldError(state, "bio") ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {fieldError(state, "bio")}
+            </p>
+          ) : null}
+        </div>
+
+        {state.error ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {state.error}
+          </p>
+        ) : null}
+
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="rounded bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {isPending ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="rounded border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {bio ? <MarkdownBody source={bio} /> : null}
+      <div>
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="text-xs text-zinc-600 underline hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          Edit profile
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -12,11 +12,13 @@ import { ProfileGroupList } from "@/components/profile/profile-group-list";
 import { ProfileQuestionList } from "@/components/profile/profile-question-list";
 import { requireAuth } from "@/lib/auth";
 import {
+  getOwnProfile,
   listAnswersByAuthor,
   listFavoritesByUser,
   listGroupsForUser,
   listQuestionsByAuthor,
 } from "@/lib/profile";
+import { EditProfileForm } from "./edit-profile-form";
 
 const PAGE_SIZE = 20;
 
@@ -24,14 +26,17 @@ export default async function MePage() {
   const session = await requireAuth();
   const userId = session.user.id;
 
-  const [questions, answers, groups, favorites] = await Promise.all([
+  const [profile, questions, answers, groups, favorites] = await Promise.all([
+    getOwnProfile(userId),
     listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
     listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
     listGroupsForUser(userId, { includePending: true }),
     listFavoritesByUser(userId),
   ]);
 
-  const display = session.user.name?.trim() || session.user.email;
+  const name = profile?.name ?? session.user.name;
+  const bio = profile?.bio ?? null;
+  const display = name?.trim() || session.user.email;
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -44,6 +49,9 @@ export default async function MePage() {
             <span className="font-mono text-xs">{session.user.id}</span>
           </CardDescription>
         </CardHeader>
+        <CardContent className="pt-4">
+          <EditProfileForm name={name} bio={bio} />
+        </CardContent>
       </Card>
 
       <Card>

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { MarkdownBody } from "@/components/markdown-body";
 import { ProfileAnswerList } from "@/components/profile/profile-answer-list";
 import { ProfileGroupList } from "@/components/profile/profile-group-list";
 import { ProfileQuestionList } from "@/components/profile/profile-question-list";
@@ -52,6 +53,11 @@ export default async function PublicProfilePage({ params }: Props) {
             </span>
           </CardDescription>
         </CardHeader>
+        {profile.bio ? (
+          <CardContent className="pt-4">
+            <MarkdownBody source={profile.bio} />
+          </CardContent>
+        ) : null}
       </Card>
 
       <Card>

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -287,10 +287,34 @@ export async function listFavoritesByUser(
 
 export async function getPublicUserProfile(
   userId: string,
-): Promise<{ id: string; name: string | null } | null> {
+): Promise<{ id: string; name: string | null; bio: string | null } | null> {
   const user = await db.user.findUnique({
     where: { id: userId },
-    select: { id: true, name: true },
+    select: { id: true, name: true, bio: true },
   });
   return user;
+}
+
+export type UserProfile = {
+  id: string;
+  name: string | null;
+  bio: string | null;
+};
+
+export async function getOwnProfile(userId: string): Promise<UserProfile | null> {
+  return db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, bio: true },
+  });
+}
+
+export async function updateUserProfile(
+  userId: string,
+  input: { name: string; bio?: string },
+): Promise<UserProfile> {
+  return db.user.update({
+    where: { id: userId },
+    data: { name: input.name, bio: input.bio ?? null },
+    select: { id: true, name: true, bio: true },
+  });
 }

--- a/src/lib/validation/users.ts
+++ b/src/lib/validation/users.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const userNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required.")
+  .max(100, "Name must be at most 100 characters.");
+
+export const userBioSchema = z
+  .string()
+  .trim()
+  .max(1000, "Bio must be at most 1000 characters.")
+  .transform((v) => (v.length === 0 ? undefined : v))
+  .optional();
+
+export const updateMeSchema = z.object({
+  name: userNameSchema,
+  bio: userBioSchema,
+});
+
+export type UpdateMeInput = z.infer<typeof updateMeSchema>;


### PR DESCRIPTION
## Summary
- Adds optional `bio` column to `User` (migration + Prisma schema) and exposes `PATCH /api/me` so the authed user can update their name and bio.
- Edit form on `/me` (using `useActionState` + a server action), with `name` required (≤100), `bio` optional (≤1000) — both trimmed; empty bio clears the column.
- `/u/:userId` renders the bio via the existing `MarkdownBody` component when present; `/me` reads `name`/`bio` fresh from the DB so the owner's view is not stale relative to the JWT cookie.

## Test plan
- [x] `npx vitest run src/app/api/me/route.test.ts` — 9 cases (401 unauth, 400 bad JSON, name required/missing, bio length cap, happy path, bio cleared via omit + empty string, trimming)
- [x] Full suite: `npx vitest run` — 334/334
- [x] `npm run lint` and `npx tsc --noEmit` clean
- [ ] Manual: sign in, edit name + bio on `/me`, confirm display updates and `/u/:id` renders the new bio