### PR TITLE
feat(notifications): answer and membership events (closes #44)

### DIFF
--- a/src/app/api/groups/[slug]/membership/[userId]/route.ts
+++ b/src/app/api/groups/[slug]/membership/[userId]/route.ts
@@ -1,7 +1,13 @@
 import { getSession } from "@/lib/auth";
 import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { db } from "@/lib/db";
 import { getGroupBySlugOrThrow } from "@/lib/groups";
-import { removeMembership, setMembershipStatus } from "@/lib/memberships";
+import {
+  getMembership,
+  removeMembership,
+  setMembershipStatus,
+} from "@/lib/memberships";
+import { notifyMembershipDecision } from "@/lib/notifications";
 import { updateMembershipStatusSchema } from "@/lib/validation/memberships";
 
 type Ctx = { params: Promise<{ slug: string; userId: string }> };
@@ -23,12 +29,30 @@ export async function PATCH(req: Request, ctx: Ctx): Promise<Response> {
 
   try {
     const group = await getGroupBySlugOrThrow(slug);
+    const previous = await getMembership(group.id, userId);
     const membership = await setMembershipStatus(
       group.id,
       userId,
       parsed.data.status,
       session.user.id,
     );
+    const statusChanged = previous?.status !== membership.status;
+    if (statusChanged) {
+      try {
+        const actor = await db.user.findUnique({
+          where: { id: session.user.id },
+          select: { name: true },
+        });
+        await notifyMembershipDecision(
+          parsed.data.status,
+          userId,
+          { slug: group.slug, name: group.name },
+          { id: session.user.id, name: actor?.name ?? session.user.name },
+        );
+      } catch (notifyErr) {
+        console.error("notifyMembershipDecision failed:", notifyErr);
+      }
+    }
     return Response.json({ membership });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/api/questions/[id]/accept/route.ts
+++ b/src/app/api/questions/[id]/accept/route.ts
@@ -1,6 +1,8 @@
 import { getSession } from "@/lib/auth";
 import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { db } from "@/lib/db";
 import { acceptAnswer } from "@/lib/questions";
+import { notifyAnswerAccepted } from "@/lib/notifications";
 import { acceptQuestionSchema } from "@/lib/validation/questions";
 
 type Ctx = { params: Promise<{ id: string }> };
@@ -32,6 +34,35 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
       parsed.data.answerId ?? null,
       session.user.id,
     );
+    if (parsed.data.answerId) {
+      try {
+        const acceptedAnswerId = parsed.data.answerId;
+        const ctx = await db.answer.findUnique({
+          where: { id: acceptedAnswerId },
+          select: {
+            id: true,
+            authorId: true,
+            question: {
+              select: {
+                id: true,
+                title: true,
+                group: { select: { slug: true, name: true } },
+              },
+            },
+          },
+        });
+        if (ctx) {
+          await notifyAnswerAccepted(
+            { id: ctx.id, authorId: ctx.authorId },
+            { id: ctx.question.id, title: ctx.question.title },
+            ctx.question.group,
+            { id: session.user.id, name: session.user.name },
+          );
+        }
+      } catch (notifyErr) {
+        console.error("notifyAnswerAccepted failed:", notifyErr);
+      }
+    }
     return Response.json({ question }, { status: 200 });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/api/questions/[id]/answers/route.ts
+++ b/src/app/api/questions/[id]/answers/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { assertGroupNotArchived } from "@/lib/groups";
 import { NotFoundError, assertApprovedMember } from "@/lib/memberships";
 import { createAnswer } from "@/lib/answers";
+import { notifyAnswerPosted } from "@/lib/notifications";
 import { createAnswerSchema } from "@/lib/validation/answers";
 
 type Ctx = { params: Promise<{ id: string }> };
@@ -29,7 +30,14 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
   try {
     const question = await db.question.findUnique({
       where: { id },
-      select: { id: true, groupId: true, deletedAt: true },
+      select: {
+        id: true,
+        title: true,
+        authorId: true,
+        groupId: true,
+        deletedAt: true,
+        group: { select: { slug: true, name: true } },
+      },
     });
     if (!question || question.deletedAt) {
       throw new NotFoundError("Question not found.");
@@ -37,6 +45,16 @@ export async function POST(req: Request, ctx: Ctx): Promise<Response> {
     await assertApprovedMember(question.groupId, session.user.id);
     await assertGroupNotArchived(question.groupId);
     const answer = await createAnswer(parsed.data, question.id, session.user.id);
+    try {
+      await notifyAnswerPosted(
+        { id: answer.id, authorId: answer.authorId },
+        { id: question.id, title: question.title, authorId: question.authorId },
+        question.group,
+        session.user.name,
+      );
+    } catch (notifyErr) {
+      console.error("notifyAnswerPosted failed:", notifyErr);
+    }
     return Response.json({ answer }, { status: 201 });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/me/applications/page.tsx
+++ b/src/app/me/applications/page.tsx
@@ -1,0 +1,39 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ProfileGroupList } from "@/components/profile/profile-group-list";
+import { requireAuth } from "@/lib/auth";
+import { listGroupsForUser } from "@/lib/profile";
+
+export default async function ApplicationsPage() {
+  const session = await requireAuth();
+  const groups = await listGroupsForUser(session.user.id, {
+    includePending: true,
+  });
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">
+            Your applications {groups.length > 0 ? `(${groups.length})` : ""}
+          </CardTitle>
+          <CardDescription>
+            Groups you&rsquo;ve joined or applied to, with current status.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ProfileGroupList
+            items={groups}
+            viewer="self"
+            emptyState="You haven't applied to any groups yet."
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -18,10 +18,58 @@ import type {
 
 const POLL_INTERVAL_MS = 30_000;
 
-type ClientNotification = Omit<ParsedNotification, "createdAt" | "readAt"> & {
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+type ClientNotification = DistributiveOmit<
+  ParsedNotification,
+  "createdAt" | "readAt"
+> & {
   createdAt: string;
   readAt: string | null;
 };
+
+type RenderedNotification = {
+  href: string;
+  title: string;
+  subtitle: string;
+};
+
+function renderNotification(n: ClientNotification): RenderedNotification {
+  switch (n.type) {
+    case "question.created":
+      return {
+        href: `/q/${n.payload.questionId}`,
+        title: n.payload.questionTitle,
+        subtitle: `${n.payload.authorName ?? "Someone"} in ${n.payload.groupName}`,
+      };
+    case "answer.posted":
+      return {
+        href: `/q/${n.payload.questionId}`,
+        title: `New answer: ${n.payload.questionTitle}`,
+        subtitle: `${n.payload.answererName ?? "Someone"} answered in ${n.payload.groupName}`,
+      };
+    case "answer.accepted":
+      return {
+        href: `/q/${n.payload.questionId}`,
+        title: "Your answer was accepted",
+        subtitle: `${n.payload.actorName ?? "Someone"} on ${n.payload.questionTitle}`,
+      };
+    case "membership.approved":
+      return {
+        href: "/me/applications",
+        title: `Approved to join ${n.payload.groupName}`,
+        subtitle: `${n.payload.actorName ?? "A moderator"} approved your application`,
+      };
+    case "membership.rejected":
+      return {
+        href: "/me/applications",
+        title: `Application to ${n.payload.groupName} declined`,
+        subtitle: `${n.payload.actorName ?? "A moderator"} declined your application`,
+      };
+  }
+}
 
 function relativeTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -165,10 +213,11 @@ export function NotificationBell() {
           ) : (
             items.map((n) => {
               const unread = !n.readAt;
+              const rendered = renderNotification(n);
               return (
                 <Link
                   key={n.id}
-                  href={`/q/${n.payload.questionId}`}
+                  href={rendered.href}
                   onClick={() => handleItemClick(n.id)}
                   className="flex items-start gap-2 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
                 >
@@ -181,10 +230,10 @@ export function NotificationBell() {
                   />
                   <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                     <span className="truncate font-medium">
-                      {n.payload.questionTitle}
+                      {rendered.title}
                     </span>
                     <span className="truncate text-xs text-muted-foreground">
-                      {n.payload.authorName ?? "Someone"} in {n.payload.groupName}
+                      {rendered.subtitle}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {relativeTime(n.createdAt)}

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -17,12 +17,20 @@ const { db } = await import("./db");
 const { createGroup } = await import("./groups");
 const { applyToGroup, NotFoundError } = await import("./memberships");
 const { createQuestion } = await import("./questions");
+const { createAnswer } = await import("./answers");
 const {
   notifyQuestionCreated,
+  notifyAnswerPosted,
+  notifyAnswerAccepted,
+  notifyMembershipDecision,
   listForUser,
   markRead,
   markAllRead,
   QUESTION_CREATED,
+  ANSWER_POSTED,
+  ANSWER_ACCEPTED,
+  MEMBERSHIP_APPROVED,
+  MEMBERSHIP_REJECTED,
 } = await import("./notifications");
 
 beforeAll(async () => {
@@ -156,8 +164,10 @@ describe("listForUser", () => {
 
     const result = await listForUser(u.id);
     expect(result.items).toHaveLength(2);
-    expect(result.items[0]!.payload.questionTitle).toBe("New");
-    expect(result.items[1]!.payload.questionTitle).toBe("Old");
+    const titles = result.items.map((i) =>
+      i.type === QUESTION_CREATED ? i.payload.questionTitle : null,
+    );
+    expect(titles).toEqual(["New", "Old"]);
     expect(result.unreadCount).toBe(1);
   });
 
@@ -210,7 +220,9 @@ describe("listForUser", () => {
     });
 
     const result = await listForUser(u.id);
-    const ids = result.items.map((i) => i.payload.questionId);
+    const ids = result.items.map((i) =>
+      i.type === QUESTION_CREATED ? i.payload.questionId : null,
+    );
     expect(ids).toContain(visible.id);
     expect(ids).not.toContain(hidden.id);
   });
@@ -356,5 +368,239 @@ describe("markAllRead", () => {
     expect(await db.notification.count({ where: { userId: u.id, readAt: null } })).toBe(0);
     const otherStill = await db.notification.findUnique({ where: { id: otherUnread.id } });
     expect(otherStill?.readAt).toBeNull();
+  });
+});
+
+describe("notifyAnswerPosted", () => {
+  it("notifies the question author with deep-link payload", async () => {
+    const author = await makeUser("qAuthor");
+    const answerer = await makeUser("answerer");
+    const group = await createGroup(
+      { name: "AP", slug: uniq("ap"), autoApprove: true },
+      author.id,
+    );
+    await applyToGroup(group.id, answerer.id);
+    const question = await createQuestion(
+      { title: "Help?", body: "body" },
+      group.id,
+      author.id,
+    );
+    const answer = await createAnswer(
+      { body: "answer body" },
+      question.id,
+      answerer.id,
+    );
+
+    const count = await notifyAnswerPosted(
+      { id: answer.id, authorId: answer.authorId },
+      { id: question.id, title: question.title, authorId: question.authorId },
+      { slug: group.slug, name: group.name },
+      "Answerer Name",
+    );
+    expect(count).toBe(1);
+
+    const rows = await db.notification.findMany({ where: { userId: author.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.type).toBe(ANSWER_POSTED);
+    const payload = JSON.parse(rows[0]!.payload);
+    expect(payload.questionId).toBe(question.id);
+    expect(payload.questionTitle).toBe("Help?");
+    expect(payload.groupSlug).toBe(group.slug);
+    expect(payload.groupName).toBe(group.name);
+    expect(payload.answerId).toBe(answer.id);
+    expect(payload.answererName).toBe("Answerer Name");
+  });
+
+  it("returns 0 when the answerer is the question author", async () => {
+    const author = await makeUser("selfAns");
+    const group = await createGroup(
+      { name: "SA", slug: uniq("sa"), autoApprove: true },
+      author.id,
+    );
+    const question = await createQuestion(
+      { title: "Self", body: "body" },
+      group.id,
+      author.id,
+    );
+    const answer = await createAnswer(
+      { body: "self answer" },
+      question.id,
+      author.id,
+    );
+
+    const count = await notifyAnswerPosted(
+      { id: answer.id, authorId: answer.authorId },
+      { id: question.id, title: question.title, authorId: question.authorId },
+      { slug: group.slug, name: group.name },
+      "Author",
+    );
+    expect(count).toBe(0);
+    const rows = await db.notification.findMany({ where: { userId: author.id } });
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("notifyAnswerAccepted", () => {
+  it("notifies the answer author with deep-link payload", async () => {
+    const author = await makeUser("aaAuthor");
+    const answerer = await makeUser("aaAnswerer");
+    const group = await createGroup(
+      { name: "AA", slug: uniq("aa"), autoApprove: true },
+      author.id,
+    );
+    await applyToGroup(group.id, answerer.id);
+    const question = await createQuestion(
+      { title: "Q", body: "body" },
+      group.id,
+      author.id,
+    );
+    const answer = await createAnswer(
+      { body: "ans" },
+      question.id,
+      answerer.id,
+    );
+
+    const count = await notifyAnswerAccepted(
+      { id: answer.id, authorId: answer.authorId },
+      { id: question.id, title: question.title },
+      { slug: group.slug, name: group.name },
+      { id: author.id, name: "Question Author" },
+    );
+    expect(count).toBe(1);
+
+    const rows = await db.notification.findMany({ where: { userId: answerer.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.type).toBe(ANSWER_ACCEPTED);
+    const payload = JSON.parse(rows[0]!.payload);
+    expect(payload.questionId).toBe(question.id);
+    expect(payload.questionTitle).toBe("Q");
+    expect(payload.groupSlug).toBe(group.slug);
+    expect(payload.groupName).toBe(group.name);
+    expect(payload.answerId).toBe(answer.id);
+    expect(payload.actorName).toBe("Question Author");
+  });
+
+  it("returns 0 when the actor is the answer author (accepting own answer)", async () => {
+    const author = await makeUser("selfAccept");
+    const group = await createGroup(
+      { name: "SC", slug: uniq("sc"), autoApprove: true },
+      author.id,
+    );
+    const question = await createQuestion(
+      { title: "Q", body: "body" },
+      group.id,
+      author.id,
+    );
+    const answer = await createAnswer(
+      { body: "ans" },
+      question.id,
+      author.id,
+    );
+
+    const count = await notifyAnswerAccepted(
+      { id: answer.id, authorId: answer.authorId },
+      { id: question.id, title: question.title },
+      { slug: group.slug, name: group.name },
+      { id: author.id, name: "Author" },
+    );
+    expect(count).toBe(0);
+    const rows = await db.notification.findMany({ where: { userId: author.id } });
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("notifyMembershipDecision", () => {
+  it("notifies the target user on approval", async () => {
+    const owner = await makeUser("mdOwner");
+    const applicant = await makeUser("mdApplicant");
+    const group = await createGroup(
+      { name: "MD", slug: uniq("md"), autoApprove: false },
+      owner.id,
+    );
+
+    const count = await notifyMembershipDecision(
+      "approved",
+      applicant.id,
+      { slug: group.slug, name: group.name },
+      { id: owner.id, name: "Owner Name" },
+    );
+    expect(count).toBe(1);
+
+    const rows = await db.notification.findMany({ where: { userId: applicant.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.type).toBe(MEMBERSHIP_APPROVED);
+    const payload = JSON.parse(rows[0]!.payload);
+    expect(payload.groupSlug).toBe(group.slug);
+    expect(payload.groupName).toBe(group.name);
+    expect(payload.actorName).toBe("Owner Name");
+  });
+
+  it("notifies the target user on rejection", async () => {
+    const owner = await makeUser("mdrOwner");
+    const applicant = await makeUser("mdrApplicant");
+    const group = await createGroup(
+      { name: "MDR", slug: uniq("mdr"), autoApprove: false },
+      owner.id,
+    );
+
+    const count = await notifyMembershipDecision(
+      "rejected",
+      applicant.id,
+      { slug: group.slug, name: group.name },
+      { id: owner.id, name: null },
+    );
+    expect(count).toBe(1);
+
+    const rows = await db.notification.findMany({ where: { userId: applicant.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.type).toBe(MEMBERSHIP_REJECTED);
+    const payload = JSON.parse(rows[0]!.payload);
+    expect(payload.actorName).toBeNull();
+  });
+
+  it("returns 0 when the actor is the target", async () => {
+    const u = await makeUser("mdSelf");
+    const count = await notifyMembershipDecision(
+      "approved",
+      u.id,
+      { slug: "g", name: "G" },
+      { id: u.id, name: "Self" },
+    );
+    expect(count).toBe(0);
+    const rows = await db.notification.findMany({ where: { userId: u.id } });
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("listForUser membership pass-through", () => {
+  it("returns membership notifications even though their payload has no questionId", async () => {
+    const u = await makeUser("memPass");
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: MEMBERSHIP_APPROVED,
+        payload: JSON.stringify({
+          groupSlug: "g",
+          groupName: "G",
+          actorName: "Mod",
+        }),
+      },
+    });
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: MEMBERSHIP_REJECTED,
+        payload: JSON.stringify({
+          groupSlug: "g2",
+          groupName: "G2",
+          actorName: null,
+        }),
+      },
+    });
+
+    const result = await listForUser(u.id);
+    expect(result.items).toHaveLength(2);
+    const types = result.items.map((i) => i.type).sort();
+    expect(types).toEqual([MEMBERSHIP_APPROVED, MEMBERSHIP_REJECTED].sort());
   });
 });

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -4,6 +4,10 @@ import { db } from "@/lib/db";
 import { listApprovedMemberIds, NotFoundError } from "@/lib/memberships";
 
 export const QUESTION_CREATED = "question.created" as const;
+export const ANSWER_POSTED = "answer.posted" as const;
+export const ANSWER_ACCEPTED = "answer.accepted" as const;
+export const MEMBERSHIP_APPROVED = "membership.approved" as const;
+export const MEMBERSHIP_REJECTED = "membership.rejected" as const;
 
 export type QuestionCreatedPayload = {
   questionId: string;
@@ -13,17 +17,73 @@ export type QuestionCreatedPayload = {
   authorName: string | null;
 };
 
-export type ParsedNotification = Omit<Notification, "payload"> & {
-  payload: QuestionCreatedPayload;
+export type AnswerPostedPayload = {
+  questionId: string;
+  questionTitle: string;
+  groupSlug: string;
+  groupName: string;
+  answerId: string;
+  answererName: string | null;
 };
+
+export type AnswerAcceptedPayload = {
+  questionId: string;
+  questionTitle: string;
+  groupSlug: string;
+  groupName: string;
+  answerId: string;
+  actorName: string | null;
+};
+
+export type MembershipDecisionPayload = {
+  groupSlug: string;
+  groupName: string;
+  actorName: string | null;
+};
+
+type NotificationBase = Omit<Notification, "type" | "payload">;
+
+export type ParsedNotification =
+  | (NotificationBase & {
+      type: typeof QUESTION_CREATED;
+      payload: QuestionCreatedPayload;
+    })
+  | (NotificationBase & {
+      type: typeof ANSWER_POSTED;
+      payload: AnswerPostedPayload;
+    })
+  | (NotificationBase & {
+      type: typeof ANSWER_ACCEPTED;
+      payload: AnswerAcceptedPayload;
+    })
+  | (NotificationBase & {
+      type: typeof MEMBERSHIP_APPROVED;
+      payload: MembershipDecisionPayload;
+    })
+  | (NotificationBase & {
+      type: typeof MEMBERSHIP_REJECTED;
+      payload: MembershipDecisionPayload;
+    });
 
 export type NotificationListResult = {
   items: ParsedNotification[];
   unreadCount: number;
 };
 
+const QUESTION_REF_TYPES: ReadonlySet<string> = new Set([
+  QUESTION_CREATED,
+  ANSWER_POSTED,
+  ANSWER_ACCEPTED,
+]);
+
 export function parsePayload(n: Notification): ParsedNotification {
-  return { ...n, payload: JSON.parse(n.payload) as QuestionCreatedPayload };
+  const payload = JSON.parse(n.payload) as
+    | QuestionCreatedPayload
+    | AnswerPostedPayload
+    | AnswerAcceptedPayload
+    | MembershipDecisionPayload;
+  // The discriminator is the row's `type` column; the union narrows on it.
+  return { ...n, payload } as ParsedNotification;
 }
 
 export async function notifyQuestionCreated(
@@ -54,6 +114,81 @@ export async function notifyQuestionCreated(
   return result.count;
 }
 
+export async function notifyAnswerPosted(
+  answer: { id: string; authorId: string },
+  question: { id: string; title: string; authorId: string },
+  group: { slug: string; name: string },
+  answererName: string | null,
+): Promise<number> {
+  if (question.authorId === answer.authorId) return 0;
+
+  const payload: AnswerPostedPayload = {
+    questionId: question.id,
+    questionTitle: question.title,
+    groupSlug: group.slug,
+    groupName: group.name,
+    answerId: answer.id,
+    answererName,
+  };
+  await db.notification.create({
+    data: {
+      userId: question.authorId,
+      type: ANSWER_POSTED,
+      payload: JSON.stringify(payload),
+    },
+  });
+  return 1;
+}
+
+export async function notifyAnswerAccepted(
+  answer: { id: string; authorId: string },
+  question: { id: string; title: string },
+  group: { slug: string; name: string },
+  actor: { id: string; name: string | null },
+): Promise<number> {
+  if (answer.authorId === actor.id) return 0;
+
+  const payload: AnswerAcceptedPayload = {
+    questionId: question.id,
+    questionTitle: question.title,
+    groupSlug: group.slug,
+    groupName: group.name,
+    answerId: answer.id,
+    actorName: actor.name,
+  };
+  await db.notification.create({
+    data: {
+      userId: answer.authorId,
+      type: ANSWER_ACCEPTED,
+      payload: JSON.stringify(payload),
+    },
+  });
+  return 1;
+}
+
+export async function notifyMembershipDecision(
+  status: "approved" | "rejected",
+  targetUserId: string,
+  group: { slug: string; name: string },
+  actor: { id: string; name: string | null },
+): Promise<number> {
+  if (targetUserId === actor.id) return 0;
+
+  const payload: MembershipDecisionPayload = {
+    groupSlug: group.slug,
+    groupName: group.name,
+    actorName: actor.name,
+  };
+  await db.notification.create({
+    data: {
+      userId: targetUserId,
+      type: status === "approved" ? MEMBERSHIP_APPROVED : MEMBERSHIP_REJECTED,
+      payload: JSON.stringify(payload),
+    },
+  });
+  return 1;
+}
+
 export async function listForUser(
   userId: string,
   opts: { limit?: number } = {},
@@ -70,7 +205,11 @@ export async function listForUser(
 
   const parsed = rows.map(parsePayload);
   const referencedQuestionIds = Array.from(
-    new Set(parsed.map((p) => p.payload.questionId)),
+    new Set(
+      parsed
+        .filter((p) => QUESTION_REF_TYPES.has(p.type))
+        .map((p) => (p.payload as { questionId: string }).questionId),
+    ),
   );
   const deletedIds = referencedQuestionIds.length
     ? new Set(
@@ -86,7 +225,10 @@ export async function listForUser(
       )
     : new Set<string>();
 
-  const items = parsed.filter((p) => !deletedIds.has(p.payload.questionId));
+  const items = parsed.filter((p) => {
+    if (!QUESTION_REF_TYPES.has(p.type)) return true;
+    return !deletedIds.has((p.payload as { questionId: string }).questionId);
+  });
   return { items, unreadCount };
 }
 


### PR DESCRIPTION
## Summary
- Today only `question.created` fires a notification; per #44, several other write events warrant one (new answer, accept, membership decision).
- This wires fan-out for `answer.posted`, `answer.accepted`, `membership.approved`, and `membership.rejected` and updates the bell dropdown to render them with appropriate copy and deep-links.
- Closes #44.

## Changes
- **Notifications service** (`src/lib/notifications.ts`): four new type constants and payload shapes; `notifyAnswerPosted` / `notifyAnswerAccepted` / `notifyMembershipDecision` fan-out fns with actor exclusion; `ParsedNotification` is now a discriminated union; `listForUser` only applies the soft-deleted-question filter to question-referencing types so membership notifications pass through.
- **API write sites**: `notifyAnswerPosted` after `createAnswer`; `notifyAnswerAccepted` after a successful accept (skipped on un-accept); `notifyMembershipDecision` after `setMembershipStatus`, suppressed on no-op status changes. All notify calls are try/catch-wrapped — notification failure does not fail the user-facing request.
- **UI** (`src/components/notification-bell.tsx`): per-type renderer producing `{ href, title, subtitle }`; `ClientNotification` uses a distributive `Omit` so the union narrows.
- **New page** (`src/app/me/applications/page.tsx`): read-only list of the current user's group memberships, reusing `listGroupsForUser` + `ProfileGroupList`. Serves as the deep-link target for membership notifications.
- **Tests** (`src/lib/notifications.test.ts`): new describe blocks per fan-out fn (success + actor exclusion); `listForUser` test asserting membership notifications survive the soft-delete filter.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 342/342 pass
- [ ] Manual smoke (not run): post answer → question author's bell shows it; accept → answer author's bell shows it; approve/reject application → applicant's bell shows it and links to `/me/applications`; self-actor cases produce no notification.