### PR TITLE
feat(notifications): dedicated page with filters and per-group mute

### DIFF
--- a/prisma/migrations/20260506105111_add_notification_preference/migration.sql
+++ b/prisma/migrations/20260506105111_add_notification_preference/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "NotificationPreference" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "mutedTypes" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "NotificationPreference_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationPreference_userId_groupId_key" ON "NotificationPreference"("userId", "groupId");
+
+-- CreateIndex
+CREATE INDEX "NotificationPreference_groupId_idx" ON "NotificationPreference"("groupId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,13 +39,14 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  memberships   Membership[]
-  questions     Question[]
-  answers       Answer[]
-  votes         Vote[]
-  favorites     Favorite[]
-  notifications Notification[]
-  createdGroups Group[]        @relation("GroupCreator")
+  memberships             Membership[]
+  questions               Question[]
+  answers                 Answer[]
+  votes                   Vote[]
+  favorites               Favorite[]
+  notifications           Notification[]
+  notificationPreferences NotificationPreference[]
+  createdGroups           Group[]                  @relation("GroupCreator")
 }
 
 model Group {
@@ -60,9 +61,10 @@ model Group {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
-  createdBy   User         @relation("GroupCreator", fields: [createdById], references: [id])
-  memberships Membership[]
-  questions   Question[]
+  createdBy               User                     @relation("GroupCreator", fields: [createdById], references: [id])
+  memberships             Membership[]
+  questions               Question[]
+  notificationPreferences NotificationPreference[]
 
   @@index([createdById])
   @@index([archivedAt])
@@ -162,4 +164,22 @@ model Notification {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, readAt])
+}
+
+// mutedTypes is a JSON-as-string array of category prefixes (e.g. ["question","answer"])
+// for SQLite portability. Categories correspond to the first dotted segment of a
+// notification type (question.created -> "question", etc.).
+model NotificationPreference {
+  id         String   @id @default(cuid())
+  userId     String
+  groupId    String
+  mutedTypes String   @default("[]")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, groupId])
+  @@index([groupId])
 }

--- a/src/app/api/notification-preferences/[groupId]/route.test.ts
+++ b/src/app/api/notification-preferences/[groupId]/route.test.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-notif-prefs-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { createGroup } = await import("@/lib/groups");
+const { applyToGroup } = await import("@/lib/memberships");
+const { GET, PUT } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+let counter = 0;
+function uniqEmail() {
+  counter += 1;
+  return `prefs-${Date.now()}-${counter}@example.com`;
+}
+
+function ctx(groupId: string) {
+  return { params: Promise.resolve({ groupId }) };
+}
+
+describe("PUT /api/notification-preferences/[groupId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await PUT(
+      new Request("http://localhost/api/notification-preferences/x", {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["question"] }),
+      }),
+      ctx("x"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("upserts preferences for an approved member", async () => {
+    await auth.signIn(uniqEmail());
+    const sess = (await auth.getSession())!;
+    const group = await createGroup(
+      { name: "G", slug: `g-${Date.now()}-${counter++}`, autoApprove: true },
+      sess.user.id,
+    );
+
+    const res = await PUT(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["question", "answer"] }),
+      }),
+      ctx(group.id),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.groupId).toBe(group.id);
+    expect(json.mutedTypes).toEqual(["question", "answer"]);
+
+    const stored = await db.notificationPreference.findUnique({
+      where: { userId_groupId: { userId: sess.user.id, groupId: group.id } },
+    });
+    expect(stored).not.toBeNull();
+  });
+
+  it("returns 403 when caller is not an approved member", async () => {
+    // Owner creates group; stranger tries to set prefs.
+    await auth.signIn(uniqEmail());
+    const ownerSess = (await auth.getSession())!;
+    const group = await createGroup(
+      { name: "G", slug: `gs-${Date.now()}-${counter++}`, autoApprove: false },
+      ownerSess.user.id,
+    );
+
+    cookieStore.clear();
+    await auth.signIn(uniqEmail());
+
+    const res = await PUT(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["question"] }),
+      }),
+      ctx(group.id),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for pending applicants", async () => {
+    await auth.signIn(uniqEmail());
+    const ownerSess = (await auth.getSession())!;
+    const group = await createGroup(
+      { name: "G", slug: `gp-${Date.now()}-${counter++}`, autoApprove: false },
+      ownerSess.user.id,
+    );
+
+    cookieStore.clear();
+    await auth.signIn(uniqEmail());
+    const applicant = (await auth.getSession())!;
+    await applyToGroup(group.id, applicant.user.id);
+
+    const res = await PUT(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["question"] }),
+      }),
+      ctx(group.id),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid body", async () => {
+    await auth.signIn(uniqEmail());
+    const sess = (await auth.getSession())!;
+    const group = await createGroup(
+      { name: "G", slug: `gv-${Date.now()}-${counter++}`, autoApprove: true },
+      sess.user.id,
+    );
+    const res = await PUT(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["bogus"] }),
+      }),
+      ctx(group.id),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("GET returns the current preference for the user", async () => {
+    await auth.signIn(uniqEmail());
+    const sess = (await auth.getSession())!;
+    const group = await createGroup(
+      { name: "G", slug: `gg-${Date.now()}-${counter++}`, autoApprove: true },
+      sess.user.id,
+    );
+    await PUT(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ mutedTypes: ["membership"] }),
+      }),
+      ctx(group.id),
+    );
+    const res = await GET(
+      new Request(`http://localhost/api/notification-preferences/${group.id}`),
+      ctx(group.id),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.mutedTypes).toEqual(["membership"]);
+  });
+});

--- a/src/app/api/notification-preferences/[groupId]/route.ts
+++ b/src/app/api/notification-preferences/[groupId]/route.ts
@@ -1,0 +1,48 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import {
+  getPreferenceForGroup,
+  setPreferenceForGroup,
+} from "@/lib/notification-preferences";
+import { updateNotificationPreferenceSchema } from "@/lib/validation/notification-preferences";
+
+type Ctx = { params: Promise<{ groupId: string }> };
+
+export async function GET(_req: Request, ctx: Ctx): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+  const { groupId } = await ctx.params;
+  try {
+    const mutedTypes = await getPreferenceForGroup(session.user.id, groupId);
+    return Response.json({ groupId, mutedTypes }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}
+
+export async function PUT(req: Request, ctx: Ctx): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+  const { groupId } = await ctx.params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "InvalidJson" }, { status: 400 });
+  }
+
+  const parsed = updateNotificationPreferenceSchema.safeParse(body);
+  if (!parsed.success) return validationFailed(parsed.error);
+
+  try {
+    const mutedTypes = await setPreferenceForGroup(
+      session.user.id,
+      groupId,
+      parsed.data.mutedTypes,
+    );
+    return Response.json({ groupId, mutedTypes }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -1,0 +1,15 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { listPreferencesForUser } from "@/lib/notification-preferences";
+
+export async function GET(): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const preferences = await listPreferencesForUser(session.user.id);
+    return Response.json({ preferences }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
 
 describe("GET /api/notifications", () => {
   it("returns 401 when unauthenticated", async () => {
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/notifications"));
     expect(res.status).toBe(401);
   });
 
@@ -87,11 +87,57 @@ describe("GET /api/notifications", () => {
       },
     });
 
-    const res = await GET();
+    const res = await GET(new Request("http://localhost/api/notifications"));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.items).toHaveLength(1);
     expect(json.items[0].payload.questionTitle).toBe("Hello");
     expect(json.unreadCount).toBe(1);
+  });
+
+  it("paginates and filters when query params are passed", async () => {
+    const email = `nq-${Date.now()}-${Math.random()}@example.com`;
+    await auth.signIn(email);
+    const sess = (await auth.getSession())!;
+    for (let i = 0; i < 4; i += 1) {
+      await db.notification.create({
+        data: {
+          userId: sess.user.id,
+          type: QUESTION_CREATED,
+          payload: JSON.stringify({
+            questionId: `qq${i}`,
+            questionTitle: `Q${i}`,
+            groupSlug: "g",
+            groupName: "G",
+            authorName: null,
+          }),
+        },
+      });
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    // Add a noise notification of a different type that the filter should exclude.
+    await db.notification.create({
+      data: {
+        userId: sess.user.id,
+        type: "answer.posted",
+        payload: JSON.stringify({
+          questionId: "qx",
+          questionTitle: "X",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+
+    const res = await GET(
+      new Request("http://localhost/api/notifications?page=1&per=2&types=question"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(2);
+    expect(json.total).toBe(4);
+    expect(json.page).toBe(1);
+    expect(json.per).toBe(2);
   });
 });

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,13 +1,48 @@
 import { getSession } from "@/lib/auth";
 import { errorToResponse, unauthorized } from "@/lib/api/errors";
-import { listForUser } from "@/lib/notifications";
+import { DEFAULT_PER, MAX_PER, listForUser } from "@/lib/notifications";
+import { isCategory, type NotificationCategory } from "@/lib/notification-preferences";
 
-export async function GET(): Promise<Response> {
+function parsePositiveInt(raw: string | null, fallback: number, max?: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return max !== undefined ? Math.min(n, max) : n;
+}
+
+export async function GET(req: Request): Promise<Response> {
   const session = await getSession();
   if (!session) return unauthorized();
 
   try {
-    const result = await listForUser(session.user.id, { limit: 20 });
+    const url = new URL(req.url);
+    const sp = url.searchParams;
+    const hasFilters = sp.has("page") || sp.has("per") || sp.has("types") || sp.has("unread");
+
+    if (!hasFilters) {
+      // Bell-dropdown default: most recent 20.
+      const result = await listForUser(session.user.id, { limit: 20 });
+      return Response.json(result, { status: 200 });
+    }
+
+    const page = parsePositiveInt(sp.get("page"), 1);
+    const per = parsePositiveInt(sp.get("per"), DEFAULT_PER, MAX_PER);
+    const typesRaw = sp.get("types");
+    const types: NotificationCategory[] = typesRaw
+      ? typesRaw
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+          .filter(isCategory)
+      : [];
+    const unreadOnly = sp.get("unread") === "1" || sp.get("unread") === "true";
+
+    const result = await listForUser(session.user.id, {
+      page,
+      per,
+      types,
+      unreadOnly,
+    });
     return Response.json(result, { status: 200 });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { GroupAvatar } from "@/components/ui/group-avatar";
+import { NotificationPreferencesControl } from "@/components/notification-preferences-control";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { getSession } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
@@ -17,6 +18,7 @@ import {
   getMembership,
   listApprovedMembers,
 } from "@/lib/memberships";
+import { getPreferenceForGroup } from "@/lib/notification-preferences";
 import { listQuestionsForGroup } from "@/lib/questions";
 import { MembershipActions } from "./membership-actions";
 
@@ -43,6 +45,8 @@ export default async function GroupDetailPage({ params }: Props) {
 
   const isOwner = membership?.role === "owner" && membership.status === "approved";
   const isApproved = membership?.status === "approved";
+  const mutedTypes =
+    isApproved && session ? await getPreferenceForGroup(session.user.id, group.id) : [];
   const isArchived = group.archivedAt != null;
   const memberLabel = memberCount === 1 ? "1 member" : `${memberCount} members`;
 
@@ -157,6 +161,24 @@ export default async function GroupDetailPage({ params }: Props) {
           )}
         </CardContent>
       </Card>
+
+      {isApproved ? (
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle className="text-base">Notification settings</CardTitle>
+            <CardDescription>
+              Control which {group.name} activity sends you notifications.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-4">
+            <NotificationPreferencesControl
+              groupId={group.id}
+              groupName={group.name}
+              initialMutedTypes={mutedTypes}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card>
         <CardHeader className="border-b">

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -13,6 +13,7 @@ import { ProfileFavoriteList } from "@/components/profile/profile-favorite-list"
 import { ProfileGroupList } from "@/components/profile/profile-group-list";
 import { ProfileQuestionList } from "@/components/profile/profile-question-list";
 import { requireAuth } from "@/lib/auth";
+import { listPreferencesForUser } from "@/lib/notification-preferences";
 import {
   getOwnProfile,
   listAnswersByAuthor,
@@ -28,13 +29,18 @@ export default async function MePage() {
   const session = await requireAuth();
   const userId = session.user.id;
 
-  const [profile, questions, answers, groups, favorites] = await Promise.all([
+  const [profile, questions, answers, groups, favorites, preferences] = await Promise.all([
     getOwnProfile(userId),
     listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
     listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
     listGroupsForUser(userId, { includePending: true }),
     listFavoritesByUser(userId),
+    listPreferencesForUser(userId),
   ]);
+
+  const mutedTypesByGroupId = Object.fromEntries(
+    preferences.map((p) => [p.groupId, p.mutedTypes]),
+  );
 
   const name = profile?.name ?? session.user.name;
   const bio = profile?.bio ?? null;
@@ -126,6 +132,7 @@ export default async function MePage() {
           <ProfileGroupList
             items={groups}
             viewer="self"
+            mutedTypesByGroupId={mutedTypesByGroupId}
             emptyState={
               <>
                 You&rsquo;re not in any groups yet.{" "}

--- a/src/app/notifications/notifications-controls.tsx
+++ b/src/app/notifications/notifications-controls.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { NOTIFICATION_CATEGORIES, type NotificationCategory } from "@/lib/notification-categories";
+
+type Props = {
+  selectedTypes: NotificationCategory[];
+  unreadOnly: boolean;
+  per: number;
+  hasUnread: boolean;
+};
+
+const TYPE_LABELS: Record<NotificationCategory, string> = {
+  question: "Questions",
+  answer: "Answers",
+  membership: "Memberships",
+};
+
+function buildQuery(params: {
+  types?: NotificationCategory[];
+  unread?: boolean;
+  per: number;
+}): string {
+  const sp = new URLSearchParams();
+  sp.set("page", "1");
+  sp.set("per", String(params.per));
+  if (params.types && params.types.length > 0) sp.set("types", params.types.join(","));
+  if (params.unread) sp.set("unread", "1");
+  return sp.toString();
+}
+
+export function NotificationsControls({ selectedTypes, unreadOnly, per, hasUnread }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function navigate(qs: string) {
+    startTransition(() => {
+      router.replace(`/notifications?${qs}`, { scroll: false });
+    });
+  }
+
+  function toggleType(t: NotificationCategory) {
+    const next = selectedTypes.includes(t)
+      ? selectedTypes.filter((x) => x !== t)
+      : [...selectedTypes, t];
+    navigate(buildQuery({ types: next, unread: unreadOnly, per }));
+  }
+
+  function setAllTypes() {
+    navigate(buildQuery({ types: [], unread: unreadOnly, per }));
+  }
+
+  function setUnread(value: boolean) {
+    navigate(buildQuery({ types: selectedTypes, unread: value, per }));
+  }
+
+  async function markAllRead() {
+    try {
+      const res = await fetch("/api/notifications/read-all", { method: "POST" });
+      if (!res.ok) return;
+      router.refresh();
+    } catch {
+      // surface no error UI for now; page will reload manually if needed
+    }
+  }
+
+  const allSelected = selectedTypes.length === 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Type</span>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by type">
+          <Button
+            type="button"
+            variant={allSelected ? "secondary" : "outline"}
+            size="sm"
+            onClick={setAllTypes}
+            aria-pressed={allSelected}
+          >
+            All
+          </Button>
+          {NOTIFICATION_CATEGORIES.map((t) => {
+            const pressed = selectedTypes.includes(t);
+            return (
+              <Button
+                key={t}
+                type="button"
+                variant={pressed ? "secondary" : "outline"}
+                size="sm"
+                onClick={() => toggleType(t)}
+                aria-pressed={pressed}
+              >
+                {TYPE_LABELS[t]}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Read state</span>
+        <div className="flex gap-1" role="group" aria-label="Filter by read state">
+          <Button
+            type="button"
+            variant={!unreadOnly ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setUnread(false)}
+            aria-pressed={!unreadOnly}
+          >
+            All
+          </Button>
+          <Button
+            type="button"
+            variant={unreadOnly ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setUnread(true)}
+            aria-pressed={unreadOnly}
+          >
+            Unread only
+          </Button>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {isPending ? (
+            <span className="text-xs text-muted-foreground" aria-live="polite">
+              Updating…
+            </span>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={markAllRead}
+            disabled={!hasUnread}
+          >
+            Mark all read
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function MarkRowReadButton({
+  id,
+  alreadyRead,
+}: {
+  id: string;
+  alreadyRead: boolean;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  if (alreadyRead) {
+    return (
+      <span className="text-xs text-muted-foreground" aria-label="Already read">
+        Read
+      </span>
+    );
+  }
+
+  async function onClick() {
+    try {
+      const res = await fetch(`/api/notifications/${id}/read`, { method: "POST" });
+      if (!res.ok) return;
+      startTransition(() => router.refresh());
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      disabled={isPending}
+      aria-label="Mark as read"
+    >
+      Mark read
+    </Button>
+  );
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,242 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { requireAuth } from "@/lib/auth";
+import {
+  DEFAULT_PER,
+  MAX_PER,
+  listForUser,
+  type ParsedNotification,
+} from "@/lib/notifications";
+import {
+  isCategory,
+  type NotificationCategory,
+} from "@/lib/notification-categories";
+
+import { MarkRowReadButton, NotificationsControls } from "./notifications-controls";
+
+type Props = {
+  searchParams: Promise<{
+    page?: string;
+    per?: string;
+    types?: string;
+    unread?: string;
+  }>;
+};
+
+function parseTypes(raw: string | undefined): NotificationCategory[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter(isCategory);
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number, max?: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return max !== undefined ? Math.min(n, max) : n;
+}
+
+function relativeTime(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  if (ms < 60_000) return "just now";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} d ago`;
+  return date.toLocaleDateString();
+}
+
+function descriptionFor(n: ParsedNotification): { headline: string; subline: string; href: string } {
+  switch (n.type) {
+    case "question.created":
+      return {
+        headline: n.payload.questionTitle,
+        subline: `New question · ${n.payload.authorName ?? "Someone"} in ${n.payload.groupName}`,
+        href: `/q/${n.payload.questionId}`,
+      };
+    case "answer.posted":
+      return {
+        headline: `New answer: ${n.payload.questionTitle}`,
+        subline: `${n.payload.answererName ?? "Someone"} answered in ${n.payload.groupName}`,
+        href: `/q/${n.payload.questionId}`,
+      };
+    case "answer.accepted":
+      return {
+        headline: "Your answer was accepted",
+        subline: `${n.payload.actorName ?? "Someone"} on ${n.payload.questionTitle}`,
+        href: `/q/${n.payload.questionId}`,
+      };
+    case "membership.approved":
+      return {
+        headline: `Approved to join ${n.payload.groupName}`,
+        subline: `${n.payload.actorName ?? "A moderator"} approved your application`,
+        href: "/me/applications",
+      };
+    case "membership.rejected":
+      return {
+        headline: `Application to ${n.payload.groupName} declined`,
+        subline: `${n.payload.actorName ?? "A moderator"} declined your application`,
+        href: "/me/applications",
+      };
+  }
+}
+
+function PageButton({
+  to,
+  per,
+  types,
+  unread,
+  disabled,
+  children,
+}: {
+  to: number;
+  per: number;
+  types: NotificationCategory[];
+  unread: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  if (disabled) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        {children}
+      </Button>
+    );
+  }
+  const sp = new URLSearchParams();
+  sp.set("page", String(to));
+  sp.set("per", String(per));
+  if (types.length > 0) sp.set("types", types.join(","));
+  if (unread) sp.set("unread", "1");
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      render={<Link href={`/notifications?${sp.toString()}`} />}
+    >
+      {children}
+    </Button>
+  );
+}
+
+export default async function NotificationsPage({ searchParams }: Props) {
+  const session = await requireAuth();
+  const sp = await searchParams;
+  const page = parsePositiveInt(sp.page, 1);
+  const per = parsePositiveInt(sp.per, DEFAULT_PER, MAX_PER);
+  const types = parseTypes(sp.types);
+  const unreadOnly = sp.unread === "1" || sp.unread === "true";
+
+  const result = await listForUser(session.user.id, { page, per, types, unreadOnly });
+  const totalPages = Math.max(Math.ceil(result.total / per), 1);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
+        <p className="text-sm text-muted-foreground">
+          Full history. Filter by type or read state, and mute groups from{" "}
+          <Link href="/me" className="underline">
+            your profile
+          </Link>
+          .
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <NotificationsControls
+            selectedTypes={types}
+            unreadOnly={unreadOnly}
+            per={per}
+            hasUnread={result.unreadCount > 0}
+          />
+        </CardContent>
+      </Card>
+
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground" aria-live="polite">
+          {result.total === 0
+            ? "No notifications match these filters."
+            : `${result.total} ${result.total === 1 ? "notification" : "notifications"} · page ${result.page} of ${totalPages} · ${result.unreadCount} unread`}
+        </p>
+
+        {result.items.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+            Nothing here yet.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {result.items.map((n) => {
+              const desc = descriptionFor(n);
+              const unread = !n.readAt;
+              return (
+                <li
+                  key={n.id}
+                  className="flex items-start gap-3 rounded-lg border border-border p-3"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={
+                      "mt-1.5 size-2 shrink-0 rounded-full " +
+                      (unread ? "bg-primary" : "bg-transparent")
+                    }
+                  />
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <Link
+                      href={desc.href}
+                      className="block truncate text-sm font-medium hover:underline"
+                    >
+                      {desc.headline}
+                    </Link>
+                    <p className="truncate text-xs text-muted-foreground">{desc.subline}</p>
+                    <p className="text-xs text-muted-foreground">{relativeTime(n.createdAt)}</p>
+                  </div>
+                  <MarkRowReadButton id={n.id} alreadyRead={!unread} />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {result.total > per ? (
+          <div className="flex items-center justify-between pt-2">
+            <PageButton
+              to={page - 1}
+              per={per}
+              types={types}
+              unread={unreadOnly}
+              disabled={page <= 1}
+            >
+              Previous
+            </PageButton>
+            <PageButton
+              to={page + 1}
+              per={per}
+              types={types}
+              unread={unreadOnly}
+              disabled={page >= totalPages}
+            >
+              Next
+            </PageButton>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -244,6 +244,14 @@ export function NotificationBell() {
             })
           )}
         </div>
+        <div className="border-t border-border px-3 py-2 text-center">
+          <Link
+            href="/notifications"
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            View all notifications
+          </Link>
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/notification-preferences-control.tsx
+++ b/src/components/notification-preferences-control.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import {
+  NOTIFICATION_CATEGORIES,
+  type NotificationCategory,
+} from "@/lib/notification-categories";
+
+const TYPE_LABELS: Record<NotificationCategory, string> = {
+  question: "New questions",
+  answer: "New answers",
+  membership: "Membership updates",
+};
+
+type Props = {
+  groupId: string;
+  groupName: string;
+  initialMutedTypes: NotificationCategory[];
+};
+
+export function NotificationPreferencesControl({
+  groupId,
+  groupName,
+  initialMutedTypes,
+}: Props) {
+  const [mutedTypes, setMutedTypes] = useState<NotificationCategory[]>(initialMutedTypes);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  async function persist(next: NotificationCategory[]) {
+    setError(null);
+    try {
+      const res = await fetch(`/api/notification-preferences/${groupId}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mutedTypes: next }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        setError(body?.message ?? "Failed to update preferences.");
+      }
+    } catch {
+      setError("Network error. Try again.");
+    }
+  }
+
+  function toggle(category: NotificationCategory, muted: boolean) {
+    const next = muted
+      ? Array.from(new Set([...mutedTypes, category]))
+      : mutedTypes.filter((t) => t !== category);
+    // Keep canonical order so the server-rendered HTML matches across reloads.
+    const ordered = NOTIFICATION_CATEGORIES.filter((c) => next.includes(c));
+    setMutedTypes(ordered);
+    startTransition(() => {
+      void persist(ordered);
+    });
+  }
+
+  return (
+    <fieldset className="space-y-2">
+      <legend className="sr-only">Mute notifications for {groupName}</legend>
+      <p className="text-xs text-muted-foreground">
+        Pick which kinds of activity in {groupName} should not generate notifications.
+      </p>
+      <ul className="space-y-1">
+        {NOTIFICATION_CATEGORIES.map((category) => {
+          const muted = mutedTypes.includes(category);
+          const inputId = `mute-${groupId}-${category}`;
+          return (
+            <li key={category} className="flex items-center gap-2 text-sm">
+              <input
+                id={inputId}
+                type="checkbox"
+                className="size-4 rounded border-input"
+                checked={muted}
+                disabled={isPending}
+                onChange={(e) => toggle(category, e.target.checked)}
+              />
+              <label htmlFor={inputId} className="cursor-pointer">
+                Mute {TYPE_LABELS[category].toLowerCase()}
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </fieldset>
+  );
+}

--- a/src/components/profile/profile-group-list.tsx
+++ b/src/components/profile/profile-group-list.tsx
@@ -1,41 +1,70 @@
 import Link from "next/link";
+import { NotificationPreferencesControl } from "@/components/notification-preferences-control";
+import type { NotificationCategory } from "@/lib/notification-categories";
 import type { ProfileGroupItem } from "@/lib/profile";
 
 type Props = {
   items: ProfileGroupItem[];
   viewer: "self" | "public";
   emptyState: React.ReactNode;
+  /** Map of groupId -> muted category list. Only honored when viewer === "self". */
+  mutedTypesByGroupId?: Record<string, NotificationCategory[]>;
 };
 
-export function ProfileGroupList({ items, viewer, emptyState }: Props) {
+export function ProfileGroupList({
+  items,
+  viewer,
+  emptyState,
+  mutedTypesByGroupId,
+}: Props) {
   if (items.length === 0) {
     return <p className="text-sm text-muted-foreground">{emptyState}</p>;
   }
   return (
-    <ul className="space-y-2">
-      {items.map((g) => (
-        <li key={g.id} className="flex items-center gap-2 text-sm">
-          <Link
-            href={`/groups/${g.slug}`}
-            className="font-medium hover:underline"
-          >
-            {g.name}
-          </Link>
-          <span className="font-mono text-xs text-muted-foreground">
-            {g.slug}
-          </span>
-          {g.role !== "member" ? (
-            <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {g.role}
-            </span>
-          ) : null}
-          {viewer === "self" && g.status !== "approved" ? (
-            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
-              {g.status}
-            </span>
-          ) : null}
-        </li>
-      ))}
+    <ul className="space-y-3">
+      {items.map((g) => {
+        const showMutes = viewer === "self" && g.status === "approved";
+        const muted = mutedTypesByGroupId?.[g.id] ?? [];
+        return (
+          <li key={g.id} className="space-y-2 rounded-md border border-border p-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <Link
+                href={`/groups/${g.slug}`}
+                className="font-medium hover:underline"
+              >
+                {g.name}
+              </Link>
+              <span className="font-mono text-xs text-muted-foreground">
+                {g.slug}
+              </span>
+              {g.role !== "member" ? (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {g.role}
+                </span>
+              ) : null}
+              {viewer === "self" && g.status !== "approved" ? (
+                <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                  {g.status}
+                </span>
+              ) : null}
+            </div>
+            {showMutes ? (
+              <details className="text-xs">
+                <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                  Notification settings
+                </summary>
+                <div className="pt-2">
+                  <NotificationPreferencesControl
+                    groupId={g.id}
+                    groupName={g.name}
+                    initialMutedTypes={muted}
+                  />
+                </div>
+              </details>
+            ) : null}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/lib/notification-categories.ts
+++ b/src/lib/notification-categories.ts
@@ -1,0 +1,11 @@
+export const NOTIFICATION_CATEGORIES = ["question", "answer", "membership"] as const;
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
+
+export function isCategory(value: string): value is NotificationCategory {
+  return (NOTIFICATION_CATEGORIES as readonly string[]).includes(value);
+}
+
+export function categoryFor(type: string): NotificationCategory | null {
+  const head = type.split(".")[0] ?? "";
+  return isCategory(head) ? head : null;
+}

--- a/src/lib/notification-preferences.test.ts
+++ b/src/lib/notification-preferences.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-notif-prefs-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { createGroup } = await import("./groups");
+const { applyToGroup, AuthorizationError, NotFoundError } = await import("./memberships");
+const {
+  categoryFor,
+  filterMuted,
+  getPreferenceForGroup,
+  listPreferencesForUser,
+  setPreferenceForGroup,
+} = await import("./notification-preferences");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+async function makeUser(label: string) {
+  return db.user.create({ data: { email: `${uniq(label)}@example.com`, name: label } });
+}
+async function approve(userId: string, groupId: string) {
+  await applyToGroup(groupId, userId);
+  await db.membership.update({
+    where: { userId_groupId: { userId, groupId } },
+    data: { status: "approved" },
+  });
+}
+
+describe("categoryFor", () => {
+  it("maps known prefixes", () => {
+    expect(categoryFor("question.created")).toBe("question");
+    expect(categoryFor("answer.posted")).toBe("answer");
+    expect(categoryFor("membership.approved")).toBe("membership");
+  });
+  it("returns null for unknown types", () => {
+    expect(categoryFor("totally.weird")).toBeNull();
+    expect(categoryFor("")).toBeNull();
+  });
+});
+
+describe("setPreferenceForGroup / getPreferenceForGroup", () => {
+  it("upserts preferences and returns the normalized list", async () => {
+    const owner = await makeUser("po");
+    const g = await createGroup({ name: "P", slug: uniq("p"), autoApprove: true }, owner.id);
+
+    const stored = await setPreferenceForGroup(owner.id, g.id, ["question", "membership"]);
+    expect(stored).toEqual(["question", "membership"]);
+    expect(await getPreferenceForGroup(owner.id, g.id)).toEqual(["question", "membership"]);
+
+    // Update — replaces
+    const updated = await setPreferenceForGroup(owner.id, g.id, ["answer"]);
+    expect(updated).toEqual(["answer"]);
+    expect(await getPreferenceForGroup(owner.id, g.id)).toEqual(["answer"]);
+  });
+
+  it("rejects unknown categories silently and dedupes", async () => {
+    const u = await makeUser("pu");
+    const g = await createGroup({ name: "P", slug: uniq("p"), autoApprove: true }, u.id);
+    const stored = await setPreferenceForGroup(u.id, g.id, [
+      "question",
+      "question",
+      "totally-bogus",
+    ]);
+    expect(stored).toEqual(["question"]);
+  });
+
+  it("throws AuthorizationError when caller is not an approved member", async () => {
+    const owner = await makeUser("ao");
+    const stranger = await makeUser("st");
+    const g = await createGroup({ name: "G", slug: uniq("auth"), autoApprove: false }, owner.id);
+    await expect(
+      setPreferenceForGroup(stranger.id, g.id, ["question"]),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws AuthorizationError for pending applicants", async () => {
+    const owner = await makeUser("po2");
+    const pending = await makeUser("pp");
+    const g = await createGroup({ name: "G", slug: uniq("auth2"), autoApprove: false }, owner.id);
+    await applyToGroup(g.id, pending.id);
+    await expect(
+      setPreferenceForGroup(pending.id, g.id, ["question"]),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws NotFoundError for unknown group", async () => {
+    const u = await makeUser("nf");
+    await expect(
+      setPreferenceForGroup(u.id, "does-not-exist", ["question"]),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns [] for users with no row", async () => {
+    const u = await makeUser("nopref");
+    const owner = await makeUser("nopref-o");
+    const g = await createGroup({ name: "G", slug: uniq("nop"), autoApprove: true }, owner.id);
+    expect(await getPreferenceForGroup(u.id, g.id)).toEqual([]);
+  });
+});
+
+describe("listPreferencesForUser", () => {
+  it("returns all preferences with group metadata", async () => {
+    const u = await makeUser("lu");
+    const g1 = await createGroup({ name: "L1", slug: uniq("l1"), autoApprove: true }, u.id);
+    const g2 = await createGroup({ name: "L2", slug: uniq("l2"), autoApprove: true }, u.id);
+    await setPreferenceForGroup(u.id, g1.id, ["question"]);
+    await setPreferenceForGroup(u.id, g2.id, ["answer", "membership"]);
+
+    const list = await listPreferencesForUser(u.id);
+    expect(list).toHaveLength(2);
+    const byId = new Map(list.map((p) => [p.groupId, p]));
+    expect(byId.get(g1.id)?.mutedTypes).toEqual(["question"]);
+    expect(byId.get(g2.id)?.mutedTypes).toEqual(["answer", "membership"]);
+    expect(byId.get(g1.id)?.groupName).toBe("L1");
+  });
+});
+
+describe("filterMuted", () => {
+  it("excludes users who muted the given category for the given group", async () => {
+    const owner = await makeUser("fmo");
+    const g = await createGroup({ name: "F", slug: uniq("f"), autoApprove: true }, owner.id);
+    const a = await makeUser("fmA");
+    const b = await makeUser("fmB");
+    const c = await makeUser("fmC");
+    await approve(a.id, g.id);
+    await approve(b.id, g.id);
+    await approve(c.id, g.id);
+    await setPreferenceForGroup(a.id, g.id, ["question"]);
+    await setPreferenceForGroup(b.id, g.id, ["answer"]); // muted other category, should pass
+
+    const result = await filterMuted([a.id, b.id, c.id], g.id, "question");
+    expect(result).toEqual([b.id, c.id]);
+  });
+
+  it("returns input unchanged when no users have prefs", async () => {
+    const owner = await makeUser("fme");
+    const g = await createGroup({ name: "E", slug: uniq("e"), autoApprove: true }, owner.id);
+    const a = await makeUser("a2");
+    const b = await makeUser("b2");
+    await approve(a.id, g.id);
+    await approve(b.id, g.id);
+    expect(await filterMuted([a.id, b.id], g.id, "question")).toEqual([a.id, b.id]);
+  });
+
+  it("returns [] for empty input without DB query", async () => {
+    expect(await filterMuted([], "some-group", "question")).toEqual([]);
+  });
+
+  it("ignores prefs scoped to a different group", async () => {
+    const owner = await makeUser("fxo");
+    const g1 = await createGroup({ name: "X1", slug: uniq("x1"), autoApprove: true }, owner.id);
+    const g2 = await createGroup({ name: "X2", slug: uniq("x2"), autoApprove: true }, owner.id);
+    const a = await makeUser("xa");
+    await approve(a.id, g1.id);
+    await approve(a.id, g2.id);
+    await setPreferenceForGroup(a.id, g2.id, ["question"]); // muted in g2, not g1
+
+    expect(await filterMuted([a.id], g1.id, "question")).toEqual([a.id]);
+    expect(await filterMuted([a.id], g2.id, "question")).toEqual([]);
+  });
+});

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -1,0 +1,105 @@
+import "server-only";
+import { db } from "@/lib/db";
+import { AuthorizationError, NotFoundError, isApprovedMember } from "@/lib/memberships";
+import {
+  NOTIFICATION_CATEGORIES,
+  type NotificationCategory,
+  isCategory,
+} from "@/lib/notification-categories";
+
+export {
+  NOTIFICATION_CATEGORIES,
+  isCategory,
+  categoryFor,
+} from "@/lib/notification-categories";
+export type { NotificationCategory } from "@/lib/notification-categories";
+
+function parseMutedTypes(raw: string): NotificationCategory[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is NotificationCategory => typeof v === "string" && isCategory(v));
+  } catch {
+    return [];
+  }
+}
+
+function normalizeMutedTypes(input: readonly string[]): NotificationCategory[] {
+  const seen = new Set<NotificationCategory>();
+  for (const v of input) {
+    if (isCategory(v)) seen.add(v);
+  }
+  return NOTIFICATION_CATEGORIES.filter((c) => seen.has(c));
+}
+
+export type GroupPreference = {
+  groupId: string;
+  groupSlug: string;
+  groupName: string;
+  mutedTypes: NotificationCategory[];
+};
+
+export async function getPreferenceForGroup(
+  userId: string,
+  groupId: string,
+): Promise<NotificationCategory[]> {
+  const row = await db.notificationPreference.findUnique({
+    where: { userId_groupId: { userId, groupId } },
+  });
+  return row ? parseMutedTypes(row.mutedTypes) : [];
+}
+
+export async function listPreferencesForUser(userId: string): Promise<GroupPreference[]> {
+  const rows = await db.notificationPreference.findMany({
+    where: { userId },
+    include: { group: { select: { id: true, slug: true, name: true } } },
+  });
+  return rows.map((r) => ({
+    groupId: r.group.id,
+    groupSlug: r.group.slug,
+    groupName: r.group.name,
+    mutedTypes: parseMutedTypes(r.mutedTypes),
+  }));
+}
+
+export async function setPreferenceForGroup(
+  userId: string,
+  groupId: string,
+  mutedTypes: readonly string[],
+): Promise<NotificationCategory[]> {
+  const group = await db.group.findUnique({ where: { id: groupId }, select: { id: true } });
+  if (!group) throw new NotFoundError("Group not found.");
+  if (!(await isApprovedMember(groupId, userId))) {
+    throw new AuthorizationError("You must be an approved member to set notification preferences.");
+  }
+
+  const normalized = normalizeMutedTypes(mutedTypes);
+  const json = JSON.stringify(normalized);
+  await db.notificationPreference.upsert({
+    where: { userId_groupId: { userId, groupId } },
+    create: { userId, groupId, mutedTypes: json },
+    update: { mutedTypes: json },
+  });
+  return normalized;
+}
+
+/**
+ * Given candidate recipient userIds for a single group + category, return
+ * those who have NOT muted the category. One query, in-memory filter.
+ */
+export async function filterMuted(
+  userIds: readonly string[],
+  groupId: string,
+  category: NotificationCategory,
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const rows = await db.notificationPreference.findMany({
+    where: { groupId, userId: { in: [...userIds] } },
+    select: { userId: true, mutedTypes: true },
+  });
+  const muted = new Set<string>();
+  for (const r of rows) {
+    if (parseMutedTypes(r.mutedTypes).includes(category)) muted.add(r.userId);
+  }
+  return userIds.filter((id) => !muted.has(id));
+}

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -18,6 +18,7 @@ const { createGroup } = await import("./groups");
 const { applyToGroup, NotFoundError } = await import("./memberships");
 const { createQuestion } = await import("./questions");
 const { createAnswer } = await import("./answers");
+const { setPreferenceForGroup } = await import("./notification-preferences");
 const {
   notifyQuestionCreated,
   notifyAnswerPosted,
@@ -112,6 +113,75 @@ describe("notifyQuestionCreated", () => {
 
     const pendingRows = await db.notification.findMany({ where: { userId: pending.id } });
     expect(pendingRows).toHaveLength(0);
+  });
+
+  it("skips users who muted the question category for this group", async () => {
+    const owner = await makeUser("muteOwner");
+    const group = await createGroup(
+      { name: "M", slug: uniq("mute"), autoApprove: true },
+      owner.id,
+    );
+    const muted = await makeUser("muted");
+    const noisy = await makeUser("noisy");
+    const otherMute = await makeUser("otherMute");
+    await applyToGroup(group.id, muted.id);
+    await applyToGroup(group.id, noisy.id);
+    await applyToGroup(group.id, otherMute.id);
+    await db.membership.update({
+      where: { userId_groupId: { userId: muted.id, groupId: group.id } },
+      data: { status: "approved" },
+    });
+    await db.membership.update({
+      where: { userId_groupId: { userId: noisy.id, groupId: group.id } },
+      data: { status: "approved" },
+    });
+    await db.membership.update({
+      where: { userId_groupId: { userId: otherMute.id, groupId: group.id } },
+      data: { status: "approved" },
+    });
+
+    await setPreferenceForGroup(muted.id, group.id, ["question"]);
+    await setPreferenceForGroup(otherMute.id, group.id, ["answer"]); // muted other category
+
+    const question = await createQuestion(
+      { title: "Hi", body: "body" },
+      group.id,
+      owner.id,
+    );
+    const count = await notifyQuestionCreated(question, group, "Owner");
+
+    // Recipients are: noisy + otherMute (muted excluded; owner is the author).
+    expect(count).toBe(2);
+    expect(await db.notification.count({ where: { userId: muted.id } })).toBe(0);
+    expect(await db.notification.count({ where: { userId: noisy.id } })).toBe(1);
+    expect(await db.notification.count({ where: { userId: otherMute.id } })).toBe(1);
+  });
+
+  it("ignores mutes scoped to a different group", async () => {
+    const owner = await makeUser("crossOwner");
+    const g1 = await createGroup(
+      { name: "X1", slug: uniq("cx1"), autoApprove: true },
+      owner.id,
+    );
+    const g2 = await createGroup(
+      { name: "X2", slug: uniq("cx2"), autoApprove: true },
+      owner.id,
+    );
+    const member = await makeUser("crossMember");
+    await applyToGroup(g1.id, member.id);
+    await applyToGroup(g2.id, member.id);
+
+    // Muted in g2 only — should still receive g1 notifications.
+    await setPreferenceForGroup(member.id, g2.id, ["question"]);
+
+    const question = await createQuestion(
+      { title: "X", body: "body" },
+      g1.id,
+      owner.id,
+    );
+    const count = await notifyQuestionCreated(question, g1, "Owner");
+    expect(count).toBe(1);
+    expect(await db.notification.count({ where: { userId: member.id } })).toBe(1);
   });
 
   it("returns 0 when there are no other approved members", async () => {
@@ -225,6 +295,118 @@ describe("listForUser", () => {
     );
     expect(ids).toContain(visible.id);
     expect(ids).not.toContain(hidden.id);
+  });
+
+  it("paginates with page/per and reports total", async () => {
+    const u = await makeUser("pagU");
+    for (let i = 0; i < 5; i += 1) {
+      await db.notification.create({
+        data: {
+          userId: u.id,
+          type: QUESTION_CREATED,
+          payload: JSON.stringify({
+            questionId: `q${i}`,
+            questionTitle: `T${i}`,
+            groupSlug: "g",
+            groupName: "G",
+            authorName: null,
+          }),
+        },
+      });
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    const p1 = await listForUser(u.id, { page: 1, per: 2 });
+    expect(p1.items).toHaveLength(2);
+    expect(p1.total).toBe(5);
+    expect(p1.page).toBe(1);
+    expect(p1.per).toBe(2);
+    const p3 = await listForUser(u.id, { page: 3, per: 2 });
+    expect(p3.items).toHaveLength(1);
+    expect(p3.total).toBe(5);
+  });
+
+  it("filters by type prefix", async () => {
+    const u = await makeUser("typU");
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: "question.created",
+        payload: JSON.stringify({
+          questionId: "qa",
+          questionTitle: "A",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: "answer.posted",
+        payload: JSON.stringify({
+          questionId: "qb",
+          questionTitle: "B",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+
+    const onlyQuestions = await listForUser(u.id, { types: ["question"] });
+    expect(onlyQuestions.items).toHaveLength(1);
+    expect(onlyQuestions.items[0]!.type).toBe("question.created");
+
+    const onlyAnswers = await listForUser(u.id, { types: ["answer"] });
+    expect(onlyAnswers.items).toHaveLength(1);
+    expect(onlyAnswers.items[0]!.type).toBe("answer.posted");
+
+    const both = await listForUser(u.id, { types: ["question", "answer"] });
+    expect(both.items).toHaveLength(2);
+
+    const none = await listForUser(u.id, { types: [] });
+    expect(none.items).toHaveLength(2); // empty types means no filter
+  });
+
+  it("filters to unread when unreadOnly is set", async () => {
+    const u = await makeUser("unrU");
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "qx",
+          questionTitle: "X",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+        readAt: new Date(),
+      },
+    });
+    await db.notification.create({
+      data: {
+        userId: u.id,
+        type: QUESTION_CREATED,
+        payload: JSON.stringify({
+          questionId: "qy",
+          questionTitle: "Y",
+          groupSlug: "g",
+          groupName: "G",
+          authorName: null,
+        }),
+      },
+    });
+    const all = await listForUser(u.id);
+    expect(all.items).toHaveLength(2);
+    const unread = await listForUser(u.id, { unreadOnly: true });
+    expect(unread.items).toHaveLength(1);
+    const unreadItem = unread.items[0]!;
+    if (unreadItem.type !== QUESTION_CREATED) throw new Error("expected question.created");
+    expect(unreadItem.payload.questionId).toBe("qy");
+    expect(unread.total).toBe(1);
+    expect(unread.unreadCount).toBe(1);
   });
 
   it("respects the limit option", async () => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -2,6 +2,12 @@ import "server-only";
 import type { Notification, Question } from "@prisma/client";
 import { db } from "@/lib/db";
 import { listApprovedMemberIds, NotFoundError } from "@/lib/memberships";
+import {
+  type NotificationCategory,
+  categoryFor,
+  filterMuted,
+  isCategory,
+} from "@/lib/notification-preferences";
 
 export const QUESTION_CREATED = "question.created" as const;
 export const ANSWER_POSTED = "answer.posted" as const;
@@ -67,8 +73,23 @@ export type ParsedNotification =
 
 export type NotificationListResult = {
   items: ParsedNotification[];
+  total: number;
+  page: number;
+  per: number;
   unreadCount: number;
 };
+
+export type ListForUserOptions = {
+  page?: number;
+  per?: number;
+  types?: readonly NotificationCategory[];
+  unreadOnly?: boolean;
+  /** Legacy single-page cap (used by the bell dropdown). When provided, overrides page/per. */
+  limit?: number;
+};
+
+export const DEFAULT_PER = 20;
+export const MAX_PER = 50;
 
 const QUESTION_REF_TYPES: ReadonlySet<string> = new Set([
   QUESTION_CREATED,
@@ -92,7 +113,8 @@ export async function notifyQuestionCreated(
   authorName: string | null,
 ): Promise<number> {
   const memberIds = await listApprovedMemberIds(group.id);
-  const recipients = memberIds.filter((id) => id !== question.authorId);
+  const candidates = memberIds.filter((id) => id !== question.authorId);
+  const recipients = await filterMuted(candidates, group.id, "question");
   if (recipients.length === 0) return 0;
 
   const payload: QuestionCreatedPayload = {
@@ -189,17 +211,45 @@ export async function notifyMembershipDecision(
   return 1;
 }
 
+function typeFilterToPrismaWhere(
+  types: readonly NotificationCategory[],
+): { OR: { type: { startsWith: string } }[] } | undefined {
+  if (types.length === 0) return undefined;
+  return { OR: types.map((t) => ({ type: { startsWith: `${t}.` } })) };
+}
+
 export async function listForUser(
   userId: string,
-  opts: { limit?: number } = {},
+  opts: ListForUserOptions = {},
 ): Promise<NotificationListResult> {
-  const limit = opts.limit ?? 20;
-  const [rows, unreadCount] = await Promise.all([
+  const types = (opts.types ?? []).filter((t): t is NotificationCategory => isCategory(t));
+  const unreadOnly = opts.unreadOnly === true;
+
+  const where: {
+    userId: string;
+    readAt?: null;
+    OR?: { type: { startsWith: string } }[];
+  } = { userId };
+  const typeWhere = typeFilterToPrismaWhere(types);
+  if (typeWhere) where.OR = typeWhere.OR;
+  if (unreadOnly) where.readAt = null;
+
+  const legacyLimit = opts.limit;
+  const per =
+    legacyLimit !== undefined
+      ? Math.max(1, Math.min(MAX_PER, legacyLimit))
+      : Math.max(1, Math.min(MAX_PER, opts.per ?? DEFAULT_PER));
+  const page = legacyLimit !== undefined ? 1 : Math.max(1, opts.page ?? 1);
+  const skip = (page - 1) * per;
+
+  const [rows, total, unreadCount] = await Promise.all([
     db.notification.findMany({
-      where: { userId },
+      where,
       orderBy: { createdAt: "desc" },
-      take: limit,
+      skip,
+      take: per,
     }),
+    db.notification.count({ where }),
     db.notification.count({ where: { userId, readAt: null } }),
   ]);
 
@@ -229,7 +279,7 @@ export async function listForUser(
     if (!QUESTION_REF_TYPES.has(p.type)) return true;
     return !deletedIds.has((p.payload as { questionId: string }).questionId);
   });
-  return { items, unreadCount };
+  return { items, total, page, per, unreadCount };
 }
 
 export async function markRead(
@@ -255,3 +305,5 @@ export async function markAllRead(userId: string): Promise<number> {
   });
   return result.count;
 }
+
+export { categoryFor };

--- a/src/lib/validation/notification-preferences.ts
+++ b/src/lib/validation/notification-preferences.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { NOTIFICATION_CATEGORIES } from "@/lib/notification-preferences";
+
+const categoryEnum = z.enum(
+  NOTIFICATION_CATEGORIES as unknown as [string, ...string[]],
+);
+
+export const updateNotificationPreferenceSchema = z.object({
+  mutedTypes: z.array(categoryEnum).max(NOTIFICATION_CATEGORIES.length),
+});
+
+export type UpdateNotificationPreferenceInput = z.infer<typeof updateNotificationPreferenceSchema>;


### PR DESCRIPTION
## Summary
- Closes #45.
- Bell dropdown's 20-item window made history hard to review and gave no way to suppress noisy groups; this introduces a full `/notifications` page and a `NotificationPreference` model.
- Mutes are honored at fan-out (no row created) rather than at render, so muted users genuinely don't accumulate notifications.
- Filter UI is keyed on category prefixes (`question.*`, `answer.*`, `membership.*`) so issue #44's new types light up automatically when that fan-out lands.

## Changes
- **Schema**: new `NotificationPreference` model with `(userId, groupId)` unique and a JSON-array `mutedTypes` TEXT column; migration written by hand to coexist with the FTS5 virtual tables.
- **Server libs**: `notification-categories.ts` (client-safe constants), `notification-preferences.ts` (CRUD + `filterMuted`), and an extended `notifications.ts` whose `listForUser` now supports `{ page, per, types?, unreadOnly? }` and whose `notifyQuestionCreated` filters muted users.
- **API**: `GET /api/notifications` now accepts `page`/`per`/`types`/`unread`; new `GET/PUT /api/notification-preferences/[groupId]` and `GET /api/notification-preferences`.
- **UI**: `/notifications` page with filter chips, unread toggle, pagination, per-row + bulk mark-read; shared `NotificationPreferencesControl` mounted on the group page (members) and inline in `/me`'s group list; bell footer link to `/notifications`.
- **Tests**: new `notification-preferences.test.ts` and `[groupId]/route.test.ts`; `notifications.test.ts` and `notifications/route.test.ts` extended for mute fan-out, cross-group isolation, pagination, type filter, and `unreadOnly`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] `npx vitest run` — 376 tests passing
- [x] `npx next build` — succeeds
- [ ] Manual: post a question; mute Questions for that group on `/me`; post another question and verify the muted user has no new row in `NotificationPreference`/`Notification`.
- [ ] Manual: visit `/notifications`, exercise type filters, unread toggle, pagination, per-row + bulk mark-read; confirm bell still polls and the new footer link routes correctly.

## Notes
- Issue #44 (M3) — `answer.*` and `membership.*` fan-out — is intentionally out of scope; this PR only ensures the model and filter UI are ready for those categories.
- `listForUser`'s return shape gained `total`/`page`/`per`; existing bell client ignores the extra keys, but downstream consumers should update if they rely on the old shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)