### PR TITLE
feat(search): filters and sort (closes #47)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -10,6 +10,10 @@ export async function GET(req: Request): Promise<Response> {
     groupIds: url.searchParams.get("groupIds") ?? undefined,
     page: url.searchParams.get("page") ?? undefined,
     per: url.searchParams.get("per") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+    range: url.searchParams.get("range") ?? undefined,
+    authorId: url.searchParams.get("authorId") ?? undefined,
+    sort: url.searchParams.get("sort") ?? undefined,
   });
   if (!parsed.success) return validationFailed(parsed.error);
 

--- a/src/app/api/users/search/route.test.ts
+++ b/src/app/api/users/search/route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/users/search route handler tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-users-search-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { GET } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+describe("GET /api/users/search", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET(new Request("http://x/api/users/search?q=jane"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns matching users for an authenticated request", async () => {
+    const sessionEmail = `requester-${Date.now()}@example.com`;
+    await auth.signIn(sessionEmail);
+
+    const target = `quokkahunter-${Date.now()}@example.com`;
+    await db.user.create({ data: { email: target, name: "Quokka Hunter" } });
+
+    const res = await GET(new Request("http://x/api/users/search?q=quokkahunter&limit=5"));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: { id: string; email: string }[] };
+    expect(json.items.some((u) => u.email === target)).toBe(true);
+  });
+
+  it("returns empty items for blank query", async () => {
+    await auth.signIn(`r2-${Date.now()}@example.com`);
+    const res = await GET(new Request("http://x/api/users/search?q="));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: unknown[] };
+    expect(json.items).toEqual([]);
+  });
+});

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -1,0 +1,21 @@
+import { getSession } from "@/lib/auth";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { searchUsersByNameOrEmail } from "@/lib/users";
+
+export async function GET(req: Request): Promise<Response> {
+  const session = await getSession();
+  if (!session) return unauthorized();
+
+  try {
+    const url = new URL(req.url);
+    const q = url.searchParams.get("q") ?? "";
+    const limitRaw = url.searchParams.get("limit");
+    const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : 10;
+    const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
+
+    const items = await searchUsersByNameOrEmail(q, limit);
+    return Response.json({ items }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -5,11 +5,18 @@ import { Button } from "@/components/ui/button";
 import { getSession } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
 import { listGroupsForUser } from "@/lib/profile";
-import { searchContent, type SearchHit } from "@/lib/search";
+import {
+  searchContent,
+  type SearchHit,
+  type SearchRange,
+  type SearchSort,
+  type SearchStatus,
+} from "@/lib/search";
+import { getUserSummaryById } from "@/lib/users";
 import { searchQuerySchema } from "@/lib/validation/search";
 
 import { applyGroupSlugDefault } from "./normalize";
-import { SearchControls, type MyGroup } from "./search-controls";
+import { SearchControls, type AuthorOption, type MyGroup } from "./search-controls";
 
 type Props = {
   searchParams: Promise<{
@@ -19,6 +26,10 @@ type Props = {
     groupSlug?: string;
     page?: string;
     per?: string;
+    status?: string;
+    range?: string;
+    authorId?: string;
+    sort?: string;
   }>;
 };
 
@@ -55,7 +66,41 @@ function authorLabel(a: { name: string | null; email: string | null }): string {
   return a.name ?? a.email ?? "unknown";
 }
 
-function HitCard({ hit }: { hit: SearchHit }) {
+type CommonUrlState = {
+  q: string;
+  scope: string;
+  groupIds: string | undefined;
+  groupSlug: string | undefined;
+  status: SearchStatus;
+  range: SearchRange;
+  authorId: string | undefined;
+  sort: SearchSort;
+  per: number;
+};
+
+function buildSearchUrl(state: CommonUrlState, overrides: Partial<CommonUrlState & { page: number }>): string {
+  const merged: CommonUrlState & { page?: number } = { ...state, ...overrides };
+  const params = new URLSearchParams();
+  if (merged.q) params.set("q", merged.q);
+  params.set("scope", merged.scope);
+  if (merged.groupIds) params.set("groupIds", merged.groupIds);
+  if (merged.groupSlug) params.set("groupSlug", merged.groupSlug);
+  if (merged.status !== "all") params.set("status", merged.status);
+  if (merged.range !== "all") params.set("range", merged.range);
+  if (merged.sort !== "relevance") params.set("sort", merged.sort);
+  if (merged.authorId) params.set("authorId", merged.authorId);
+  if (merged.page && merged.page > 1) params.set("page", String(merged.page));
+  if (merged.per !== 20) params.set("per", String(merged.per));
+  return `/search?${params.toString()}`;
+}
+
+function HitCard({
+  hit,
+  authorFilterUrl,
+}: {
+  hit: SearchHit;
+  authorFilterUrl: string;
+}) {
   const titleNode = hit.titleSnippet ? renderSnippet(hit.titleSnippet) : hit.title;
   return (
     <li className="rounded-lg border border-border p-4">
@@ -67,7 +112,13 @@ function HitCard({ hit }: { hit: SearchHit }) {
           {hit.group.name}
         </Link>
         <span aria-hidden>·</span>
-        <span>{authorLabel(hit.author)}</span>
+        <Link
+          href={authorFilterUrl}
+          className="hover:underline"
+          title="Filter by this author"
+        >
+          {authorLabel(hit.author)}
+        </Link>
       </div>
       <h2 className="mt-1 text-lg font-semibold leading-snug">
         <Link
@@ -82,39 +133,96 @@ function HitCard({ hit }: { hit: SearchHit }) {
   );
 }
 
-function PageLink({
-  to,
-  q,
-  scope,
-  groupIds,
-  groupSlug,
-  per,
-  children,
-  disabled,
+const STATUS_LABEL: Record<SearchStatus, string> = {
+  all: "All",
+  answered: "Answered",
+  unanswered: "Unanswered",
+};
+
+const RANGE_LABEL: Record<SearchRange, string> = {
+  all: "Any time",
+  week: "Past week",
+  month: "Past month",
+  year: "Past year",
+};
+
+const SORT_LABEL: Record<SearchSort, string> = {
+  relevance: "Relevance",
+  newest: "Newest",
+};
+
+function ActiveFilters({
+  state,
+  authorLabelText,
 }: {
-  to: number;
-  q: string;
-  scope: string;
-  groupIds: string | undefined;
-  groupSlug: string | undefined;
-  per: number;
-  children: ReactNode;
-  disabled?: boolean;
+  state: CommonUrlState;
+  authorLabelText: string | null;
 }) {
-  if (disabled) {
-    return (
-      <Button variant="outline" size="sm" disabled>
-        {children}
-      </Button>
-    );
+  const chips: { key: string; label: string; clearUrl: string }[] = [];
+  if (state.status !== "all") {
+    chips.push({
+      key: "status",
+      label: `Status: ${STATUS_LABEL[state.status]}`,
+      clearUrl: buildSearchUrl(state, { status: "all", page: 1 }),
+    });
   }
-  const params = new URLSearchParams({ q, scope, page: String(to), per: String(per) });
-  if (groupIds) params.set("groupIds", groupIds);
-  if (groupSlug) params.set("groupSlug", groupSlug);
+  if (state.range !== "all") {
+    chips.push({
+      key: "range",
+      label: `Date: ${RANGE_LABEL[state.range]}`,
+      clearUrl: buildSearchUrl(state, { range: "all", page: 1 }),
+    });
+  }
+  if (state.authorId && authorLabelText) {
+    chips.push({
+      key: "author",
+      label: `Author: ${authorLabelText}`,
+      clearUrl: buildSearchUrl(state, { authorId: undefined, page: 1 }),
+    });
+  }
+  if (state.sort !== "relevance") {
+    chips.push({
+      key: "sort",
+      label: `Sort: ${SORT_LABEL[state.sort]}`,
+      clearUrl: buildSearchUrl(state, { sort: "relevance", page: 1 }),
+    });
+  }
+
+  if (chips.length === 0) return null;
+
+  const clearAllUrl = buildSearchUrl(state, {
+    status: "all",
+    range: "all",
+    authorId: undefined,
+    sort: "relevance",
+    page: 1,
+  });
+
   return (
-    <Button variant="outline" size="sm" render={<Link href={`/search?${params.toString()}`} />}>
-      {children}
-    </Button>
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-md border border-dashed border-border bg-muted/30 px-3 py-2"
+      role="region"
+      aria-label="Active filters"
+    >
+      <span className="text-xs font-medium text-muted-foreground">Active:</span>
+      {chips.map((c) => (
+        <Link
+          key={c.key}
+          href={c.clearUrl}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-xs hover:bg-muted"
+          aria-label={`Clear ${c.label}`}
+        >
+          <span>{c.label}</span>
+          <span aria-hidden>×</span>
+        </Link>
+      ))}
+      <Link
+        href={clearAllUrl}
+        className="ml-auto text-xs text-muted-foreground underline-offset-2 hover:underline"
+      >
+        Clear all
+      </Link>
+    </div>
   );
 }
 
@@ -149,6 +257,13 @@ export default async function SearchPage({ searchParams }: Props) {
   let results: { items: SearchHit[]; total: number; page: number; per: number } | null = null;
   let validationMessage: string | null = null;
 
+  // Default the parsed filters so the page always has well-typed state, even
+  // before the user has typed a query.
+  let parsedStatus: SearchStatus = "all";
+  let parsedRange: SearchRange = "all";
+  let parsedSort: SearchSort = "relevance";
+  let parsedAuthorId: string | undefined = sp.authorId?.trim() || undefined;
+
   if (rawQ.length > 0) {
     const parsed = searchQuerySchema.safeParse({
       q: rawQ,
@@ -156,16 +271,63 @@ export default async function SearchPage({ searchParams }: Props) {
       groupIds: groupIdsCsv,
       page: String(requestedPage),
       per: String(per),
+      status: sp.status,
+      range: sp.range,
+      authorId: parsedAuthorId,
+      sort: sp.sort,
     });
     if (parsed.success) {
+      parsedStatus = parsed.data.status;
+      parsedRange = parsed.data.range;
+      parsedSort = parsed.data.sort;
+      parsedAuthorId = parsed.data.authorId;
       results = await searchContent(parsed.data);
     } else {
       validationMessage = parsed.error.issues[0]?.message ?? "Invalid query.";
     }
+  } else {
+    // Validate filter shape even with no query so the controls stay in sync.
+    const parsed = searchQuerySchema.safeParse({
+      q: "x",
+      scope: normalized.scope,
+      groupIds: groupIdsCsv,
+      page: String(requestedPage),
+      per: String(per),
+      status: sp.status,
+      range: sp.range,
+      authorId: parsedAuthorId,
+      sort: sp.sort,
+    });
+    if (parsed.success) {
+      parsedStatus = parsed.data.status;
+      parsedRange = parsed.data.range;
+      parsedSort = parsed.data.sort;
+      parsedAuthorId = parsed.data.authorId;
+    }
   }
+
+  const selectedAuthor = parsedAuthorId ? await getUserSummaryById(parsedAuthorId) : null;
+  const initialAuthor: AuthorOption | null = selectedAuthor
+    ? { id: selectedAuthor.id, name: selectedAuthor.name, email: selectedAuthor.email }
+    : null;
+  const authorLabelText = selectedAuthor
+    ? (selectedAuthor.name ?? selectedAuthor.email)
+    : null;
 
   const totalPages = results ? Math.max(Math.ceil(results.total / per), 1) : 1;
   const currentPage = results?.page ?? requestedPage;
+
+  const urlState: CommonUrlState = {
+    q: rawQ,
+    scope: normalized.scope,
+    groupIds: groupIdsCsv,
+    groupSlug: normalized.groupSlugForUrl ?? undefined,
+    status: parsedStatus,
+    range: parsedRange,
+    authorId: parsedAuthorId,
+    sort: parsedSort,
+    per,
+  };
 
   return (
     <div className="space-y-6">
@@ -187,7 +349,13 @@ export default async function SearchPage({ searchParams }: Props) {
         initialScope={normalized.scope}
         initialGroupIds={normalized.groupIds}
         myGroups={myGroups}
+        initialStatus={parsedStatus}
+        initialRange={parsedRange}
+        initialSort={parsedSort}
+        initialAuthor={initialAuthor}
       />
+
+      <ActiveFilters state={urlState} authorLabelText={authorLabelText} />
 
       {validationMessage ? (
         <p className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
@@ -212,28 +380,27 @@ export default async function SearchPage({ searchParams }: Props) {
             </p>
             <ul className="space-y-3">
               {results.items.map((hit) => (
-                <HitCard key={`${hit.type}-${hit.answerId ?? hit.questionId}`} hit={hit} />
+                <HitCard
+                  key={`${hit.type}-${hit.answerId ?? hit.questionId}`}
+                  hit={hit}
+                  authorFilterUrl={buildSearchUrl(urlState, {
+                    authorId: hit.author.id,
+                    page: 1,
+                  })}
+                />
               ))}
             </ul>
             <div className="flex items-center justify-between">
               <PageLink
                 to={currentPage - 1}
-                q={rawQ}
-                scope={normalized.scope}
-                groupIds={groupIdsCsv}
-                groupSlug={normalized.groupSlugForUrl ?? undefined}
-                per={per}
+                state={urlState}
                 disabled={currentPage <= 1}
               >
                 Previous
               </PageLink>
               <PageLink
                 to={currentPage + 1}
-                q={rawQ}
-                scope={normalized.scope}
-                groupIds={groupIdsCsv}
-                groupSlug={normalized.groupSlugForUrl ?? undefined}
-                per={per}
+                state={urlState}
                 disabled={currentPage >= totalPages}
               >
                 Next
@@ -243,5 +410,34 @@ export default async function SearchPage({ searchParams }: Props) {
         )
       ) : null}
     </div>
+  );
+}
+
+function PageLink({
+  to,
+  state,
+  children,
+  disabled,
+}: {
+  to: number;
+  state: CommonUrlState;
+  children: ReactNode;
+  disabled?: boolean;
+}) {
+  if (disabled) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        {children}
+      </Button>
+    );
+  }
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      render={<Link href={buildSearchUrl(state, { page: to })} />}
+    >
+      {children}
+    </Button>
   );
 }

--- a/src/app/search/search-controls.tsx
+++ b/src/app/search/search-controls.tsx
@@ -5,19 +5,31 @@ import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import type { SearchRange, SearchSort, SearchStatus } from "@/lib/search";
 
 const DEBOUNCE_MS = 250;
+const AUTHOR_DEBOUNCE_MS = 200;
 const MAX_GROUP_IDS = 50;
 
 export type ScopeOption = "all" | "my" | "pick";
 
 export type MyGroup = { id: string; slug: string; name: string };
 
+export type AuthorOption = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
 type Props = {
   initialQ: string;
   initialScope: "all" | "selected" | "current";
   initialGroupIds: string[];
   myGroups: MyGroup[];
+  initialStatus: SearchStatus;
+  initialRange: SearchRange;
+  initialSort: SearchSort;
+  initialAuthor: AuthorOption | null;
 };
 
 function arraysEqualSet(a: string[], b: string[]): boolean {
@@ -39,7 +51,20 @@ function deriveSurfaceScope(
   return "pick";
 }
 
-export function SearchControls({ initialQ, initialScope, initialGroupIds, myGroups }: Props) {
+function authorLabel(a: AuthorOption): string {
+  return a.name ?? a.email ?? "unknown";
+}
+
+export function SearchControls({
+  initialQ,
+  initialScope,
+  initialGroupIds,
+  myGroups,
+  initialStatus,
+  initialRange,
+  initialSort,
+  initialAuthor,
+}: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -53,6 +78,10 @@ export function SearchControls({ initialQ, initialScope, initialGroupIds, myGrou
     if (initialScope === "selected" || initialScope === "current") return initialGroupIds;
     return [];
   });
+  const [status, setStatus] = useState<SearchStatus>(initialStatus);
+  const [range, setRange] = useState<SearchRange>(initialRange);
+  const [sort, setSort] = useState<SearchSort>(initialSort);
+  const [author, setAuthor] = useState<AuthorOption | null>(initialAuthor);
 
   // When the URL's q changes from outside (header submit, back button), reset
   // the local typing buffer. Uses React's "adjust state during render" pattern.
@@ -60,6 +89,28 @@ export function SearchControls({ initialQ, initialScope, initialGroupIds, myGrou
   if (prevInitialQ !== initialQ) {
     setPrevInitialQ(initialQ);
     setQ(initialQ);
+  }
+
+  // Sync filter state when the URL changes from outside (e.g. clear-all link).
+  const [prevAuthorId, setPrevAuthorId] = useState(initialAuthor?.id ?? null);
+  if ((initialAuthor?.id ?? null) !== prevAuthorId) {
+    setPrevAuthorId(initialAuthor?.id ?? null);
+    setAuthor(initialAuthor);
+  }
+  const [prevStatus, setPrevStatus] = useState(initialStatus);
+  if (initialStatus !== prevStatus) {
+    setPrevStatus(initialStatus);
+    setStatus(initialStatus);
+  }
+  const [prevRange, setPrevRange] = useState(initialRange);
+  if (initialRange !== prevRange) {
+    setPrevRange(initialRange);
+    setRange(initialRange);
+  }
+  const [prevSort, setPrevSort] = useState(initialSort);
+  if (initialSort !== prevSort) {
+    setPrevSort(initialSort);
+    setSort(initialSort);
   }
 
   const firstRender = useRef(true);
@@ -90,13 +141,18 @@ export function SearchControls({ initialQ, initialScope, initialGroupIds, myGrou
         }
       }
 
+      if (status !== "all") params.set("status", status);
+      if (range !== "all") params.set("range", range);
+      if (sort !== "relevance") params.set("sort", sort);
+      if (author?.id) params.set("authorId", author.id);
+
       const qs = params.toString();
       startTransition(() => {
         router.replace(qs ? `/search?${qs}` : "/search", { scroll: false });
       });
     }, DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [q, surfaceScope, pickedGroupIds, myGroupIds, router]);
+  }, [q, surfaceScope, pickedGroupIds, myGroupIds, status, range, sort, author, router]);
 
   const myDisabled = myGroups.length === 0;
   const noPicked = surfaceScope === "pick" && pickedGroupIds.length === 0;
@@ -133,20 +189,20 @@ export function SearchControls({ initialQ, initialScope, initialGroupIds, myGrou
         role="radiogroup"
         aria-label="Search scope"
       >
-        <ScopeButton pressed={surfaceScope === "all"} onClick={() => setSurfaceScope("all")}>
+        <ToggleButton pressed={surfaceScope === "all"} onClick={() => setSurfaceScope("all")}>
           All groups
-        </ScopeButton>
-        <ScopeButton
+        </ToggleButton>
+        <ToggleButton
           pressed={surfaceScope === "my"}
           onClick={() => setSurfaceScope("my")}
           disabled={myDisabled}
           title={myDisabled ? "Join a group to use this scope." : undefined}
         >
           My groups
-        </ScopeButton>
-        <ScopeButton pressed={surfaceScope === "pick"} onClick={() => setSurfaceScope("pick")}>
+        </ToggleButton>
+        <ToggleButton pressed={surfaceScope === "pick"} onClick={() => setSurfaceScope("pick")}>
           Pick groups
-        </ScopeButton>
+        </ToggleButton>
       </div>
 
       {surfaceScope === "pick" ? (
@@ -185,11 +241,183 @@ export function SearchControls({ initialQ, initialScope, initialGroupIds, myGrou
           </fieldset>
         )
       ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Status</span>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by question status">
+          <ToggleButton pressed={status === "all"} onClick={() => setStatus("all")}>
+            All
+          </ToggleButton>
+          <ToggleButton pressed={status === "answered"} onClick={() => setStatus("answered")}>
+            Answered
+          </ToggleButton>
+          <ToggleButton pressed={status === "unanswered"} onClick={() => setStatus("unanswered")}>
+            Unanswered
+          </ToggleButton>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Date</span>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by date range">
+          <ToggleButton pressed={range === "all"} onClick={() => setRange("all")}>
+            Any time
+          </ToggleButton>
+          <ToggleButton pressed={range === "week"} onClick={() => setRange("week")}>
+            Past week
+          </ToggleButton>
+          <ToggleButton pressed={range === "month"} onClick={() => setRange("month")}>
+            Past month
+          </ToggleButton>
+          <ToggleButton pressed={range === "year"} onClick={() => setRange("year")}>
+            Past year
+          </ToggleButton>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Sort</span>
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Sort results">
+          <ToggleButton pressed={sort === "relevance"} onClick={() => setSort("relevance")}>
+            Relevance
+          </ToggleButton>
+          <ToggleButton pressed={sort === "newest"} onClick={() => setSort("newest")}>
+            Newest
+          </ToggleButton>
+        </div>
+      </div>
+
+      <AuthorPicker
+        author={author}
+        onChange={setAuthor}
+      />
     </div>
   );
 }
 
-function ScopeButton({
+function AuthorPicker({
+  author,
+  onChange,
+}: {
+  author: AuthorOption | null;
+  onChange: (a: AuthorOption | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<AuthorOption[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (author) return; // hide picker when one is selected
+    const term = query.trim();
+    if (!term) return;
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/users/search?q=${encodeURIComponent(term)}&limit=8`,
+          { credentials: "same-origin" },
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as { items: AuthorOption[] };
+        if (!cancelled) setResults(data.items ?? []);
+      } catch {
+        // swallow — typeahead is best-effort
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, AUTHOR_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, author]);
+
+  if (author) {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Author</span>
+        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs">
+          {authorLabel(author)}
+          <button
+            type="button"
+            onClick={() => {
+              onChange(null);
+              setQuery("");
+              setResults([]);
+            }}
+            aria-label={`Remove author filter ${authorLabel(author)}`}
+            className="ml-1 rounded-full text-muted-foreground hover:text-foreground"
+          >
+            ×
+          </button>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs font-medium text-muted-foreground">Author</span>
+      <div className="relative">
+        <Input
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            // delay so click on a result fires before close
+            setTimeout(() => setOpen(false), 120);
+          }}
+          placeholder="Filter by author…"
+          aria-label="Filter by author"
+          aria-autocomplete="list"
+          className="w-64"
+        />
+        {open && query.trim() ? (
+          <ul
+            role="listbox"
+            className="absolute z-10 mt-1 max-h-64 w-full overflow-auto rounded-md border border-border bg-popover p-1 text-sm shadow-md"
+          >
+            {loading ? (
+              <li className="px-2 py-1 text-xs text-muted-foreground">Searching…</li>
+            ) : results.length === 0 ? (
+              <li className="px-2 py-1 text-xs text-muted-foreground">No matches.</li>
+            ) : (
+              results.map((u) => (
+                <li key={u.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected="false"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => {
+                      onChange(u);
+                      setQuery("");
+                      setResults([]);
+                      setOpen(false);
+                    }}
+                    className="flex w-full flex-col items-start rounded-sm px-2 py-1 text-left hover:bg-muted"
+                  >
+                    <span>{u.name ?? u.email ?? "unknown"}</span>
+                    {u.name && u.email ? (
+                      <span className="text-xs text-muted-foreground">{u.email}</span>
+                    ) : null}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ToggleButton({
   pressed,
   onClick,
   disabled,

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -370,6 +370,310 @@ describe("searchContent", () => {
     expect(after.total).toBeLessThan(beforeTotal);
   });
 
+  it("filters by question status (answered)", async () => {
+    const author = await makeUser("statusAns");
+    const group = await createGroup(
+      { name: "SAns", slug: uniq("sans"), autoApprove: true },
+      author.id,
+    );
+    const open = await createQuestion(
+      { title: "Wallaby tracking open", body: "open question body" },
+      group.id,
+      author.id,
+    );
+    const answered = await createQuestion(
+      { title: "Wallaby tracking answered", body: "answered question body" },
+      group.id,
+      author.id,
+    );
+    const ans = await db.answer.create({
+      data: { questionId: answered.id, authorId: author.id, body: "Use radio collars wallaby." },
+    });
+    await db.question.update({
+      where: { id: answered.id },
+      data: { status: "answered", acceptedAnswerId: ans.id },
+    });
+
+    const onlyAnswered = await searchContent({
+      q: "wallaby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 10,
+      status: "answered",
+    });
+    const ansIds = new Set(onlyAnswered.items.map((i) => i.questionId));
+    expect(ansIds.has(answered.id)).toBe(true);
+    expect(ansIds.has(open.id)).toBe(false);
+
+    const onlyUnanswered = await searchContent({
+      q: "wallaby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 10,
+      status: "unanswered",
+    });
+    const unIds = new Set(onlyUnanswered.items.map((i) => i.questionId));
+    expect(unIds.has(open.id)).toBe(true);
+    expect(unIds.has(answered.id)).toBe(false);
+  });
+
+  it("status filter applies to answer hits via parent question status", async () => {
+    const author = await makeUser("statusAnsHits");
+    const group = await createGroup(
+      { name: "SAH", slug: uniq("sah"), autoApprove: true },
+      author.id,
+    );
+    const open = await createQuestion(
+      { title: "Tasmanian devil open Q", body: "topic body" },
+      group.id,
+      author.id,
+    );
+    const answered = await createQuestion(
+      { title: "Tasmanian devil answered Q", body: "topic body" },
+      group.id,
+      author.id,
+    );
+    const ansOpen = await db.answer.create({
+      data: { questionId: open.id, authorId: author.id, body: "tasdevil note open" },
+    });
+    const ansAnswered = await db.answer.create({
+      data: { questionId: answered.id, authorId: author.id, body: "tasdevil note answered" },
+    });
+    await db.question.update({
+      where: { id: answered.id },
+      data: { status: "answered", acceptedAnswerId: ansAnswered.id },
+    });
+
+    const res = await searchContent({
+      q: "tasdevil",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 10,
+      status: "answered",
+    });
+    const answerHits = res.items.filter((i) => i.type === "answer");
+    expect(answerHits.some((h) => h.answerId === ansAnswered.id)).toBe(true);
+    expect(answerHits.some((h) => h.answerId === ansOpen.id)).toBe(false);
+  });
+
+  it("filters by date range using each hit's createdAt", async () => {
+    const author = await makeUser("dateR");
+    const group = await createGroup(
+      { name: "DR", slug: uniq("dr"), autoApprove: true },
+      author.id,
+    );
+    const now = Date.now();
+    const ages = [
+      { label: "1d", offset: 1 * 24 * 60 * 60 * 1000 },
+      { label: "10d", offset: 10 * 24 * 60 * 60 * 1000 },
+      { label: "100d", offset: 100 * 24 * 60 * 60 * 1000 },
+      { label: "400d", offset: 400 * 24 * 60 * 60 * 1000 },
+    ];
+    const ids: Record<string, string> = {};
+    for (const a of ages) {
+      const q = await createQuestion(
+        { title: `Bilby age ${a.label}`, body: "marsupial body" },
+        group.id,
+        author.id,
+      );
+      await db.question.update({
+        where: { id: q.id },
+        data: { createdAt: new Date(now - a.offset) },
+      });
+      ids[a.label] = q.id;
+    }
+
+    const week = await searchContent({
+      q: "bilby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      range: "week",
+    });
+    const weekIds = new Set(week.items.map((i) => i.questionId));
+    expect(weekIds.has(ids["1d"]!)).toBe(true);
+    expect(weekIds.has(ids["10d"]!)).toBe(false);
+
+    const month = await searchContent({
+      q: "bilby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      range: "month",
+    });
+    const monthIds = new Set(month.items.map((i) => i.questionId));
+    expect(monthIds.has(ids["1d"]!)).toBe(true);
+    expect(monthIds.has(ids["10d"]!)).toBe(true);
+    expect(monthIds.has(ids["100d"]!)).toBe(false);
+
+    const year = await searchContent({
+      q: "bilby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      range: "year",
+    });
+    const yearIds = new Set(year.items.map((i) => i.questionId));
+    expect(yearIds.has(ids["100d"]!)).toBe(true);
+    expect(yearIds.has(ids["400d"]!)).toBe(false);
+
+    const all = await searchContent({
+      q: "bilby",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      range: "all",
+    });
+    const allIds = new Set(all.items.map((i) => i.questionId));
+    for (const v of Object.values(ids)) expect(allIds.has(v)).toBe(true);
+  });
+
+  it("filters by authorId across questions and answers", async () => {
+    const a1 = await makeUser("authA");
+    const a2 = await makeUser("authB");
+    const group = await createGroup(
+      { name: "AU", slug: uniq("au"), autoApprove: true },
+      a1.id,
+    );
+    // a2 needs membership to post — ensure via createGroup auto-add for a1.
+    // For a2 to post answers, the schema doesn't require membership here.
+    const qA = await createQuestion(
+      { title: "Possum count A", body: "discuss possum" },
+      group.id,
+      a1.id,
+    );
+    const qB = await createQuestion(
+      { title: "Possum count B", body: "discuss possum" },
+      group.id,
+      a1.id,
+    );
+    const ansA1 = await db.answer.create({
+      data: { questionId: qA.id, authorId: a1.id, body: "possum sighting note A1" },
+    });
+    const ansB2 = await db.answer.create({
+      data: { questionId: qB.id, authorId: a2.id, body: "possum sighting note B2" },
+    });
+
+    const onlyA1 = await searchContent({
+      q: "possum",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      authorId: a1.id,
+    });
+    expect(onlyA1.items.some((i) => i.questionId === qA.id && i.type === "question")).toBe(true);
+    expect(onlyA1.items.some((i) => i.answerId === ansA1.id)).toBe(true);
+    expect(onlyA1.items.some((i) => i.answerId === ansB2.id)).toBe(false);
+    for (const item of onlyA1.items) {
+      expect(item.author.id).toBe(a1.id);
+    }
+  });
+
+  it("sorts by newest when sort=newest", async () => {
+    const author = await makeUser("sortN");
+    const group = await createGroup(
+      { name: "SN", slug: uniq("sn"), autoApprove: true },
+      author.id,
+    );
+    const q1 = await createQuestion(
+      { title: "Koala first", body: "koala" },
+      group.id,
+      author.id,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    const q2 = await createQuestion(
+      { title: "Koala second", body: "koala" },
+      group.id,
+      author.id,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    const q3 = await createQuestion(
+      { title: "Koala third", body: "koala" },
+      group.id,
+      author.id,
+    );
+
+    const res = await searchContent({
+      q: "koala",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      sort: "newest",
+    });
+    const order = res.items
+      .filter((i) => i.type === "question")
+      .map((i) => i.questionId);
+    const idx1 = order.indexOf(q1.id);
+    const idx2 = order.indexOf(q2.id);
+    const idx3 = order.indexOf(q3.id);
+    expect(idx3).toBeLessThan(idx2);
+    expect(idx2).toBeLessThan(idx1);
+  });
+
+  it("supports combined filters: status + range + author + newest sort", async () => {
+    const author = await makeUser("combo");
+    const other = await makeUser("comboOther");
+    const group = await createGroup(
+      { name: "CO", slug: uniq("co"), autoApprove: true },
+      author.id,
+    );
+    const recent = await createQuestion(
+      { title: "Echidna sighting recent", body: "echidna match" },
+      group.id,
+      author.id,
+    );
+    const old = await createQuestion(
+      { title: "Echidna sighting old", body: "echidna match" },
+      group.id,
+      author.id,
+    );
+    const otherQ = await createQuestion(
+      { title: "Echidna sighting from other", body: "echidna match" },
+      group.id,
+      other.id,
+    );
+    // mark all answered
+    for (const q of [recent, old, otherQ]) {
+      const ans = await db.answer.create({
+        data: { questionId: q.id, authorId: author.id, body: "answer" },
+      });
+      await db.question.update({
+        where: { id: q.id },
+        data: { status: "answered", acceptedAnswerId: ans.id },
+      });
+    }
+    // backdate "old"
+    await db.question.update({
+      where: { id: old.id },
+      data: { createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000) },
+    });
+
+    const res = await searchContent({
+      q: "echidna",
+      scope: "selected",
+      groupIds: [group.id],
+      page: 1,
+      per: 50,
+      status: "answered",
+      range: "week",
+      authorId: author.id,
+      sort: "newest",
+    });
+    const ids = new Set(res.items.map((i) => i.questionId));
+    expect(ids.has(recent.id)).toBe(true);
+    expect(ids.has(old.id)).toBe(false);
+    expect(ids.has(otherQ.id)).toBe(false);
+  });
+
   it("excludes content from archived groups", async () => {
     const author = await makeUser("archSearch");
     const group = await createGroup(

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -38,13 +38,39 @@ export type SearchResultsPage = {
   per: number;
 };
 
+export type SearchStatus = "all" | "answered" | "unanswered";
+export type SearchRange = "all" | "week" | "month" | "year";
+export type SearchSort = "relevance" | "newest";
+
 export type SearchOptions = {
   q: string;
   scope: "current" | "selected" | "all";
   groupIds: string[];
   page: number;
   per: number;
+  status?: SearchStatus;
+  range?: SearchRange;
+  authorId?: string | undefined;
+  sort?: SearchSort;
 };
+
+type ResolvedOptions = Required<Omit<SearchOptions, "authorId">> & {
+  authorId: string | undefined;
+};
+
+function resolveOptions(opts: SearchOptions): ResolvedOptions {
+  return {
+    q: opts.q,
+    scope: opts.scope,
+    groupIds: opts.groupIds,
+    page: opts.page,
+    per: opts.per,
+    status: opts.status ?? "all",
+    range: opts.range ?? "all",
+    sort: opts.sort ?? "relevance",
+    authorId: opts.authorId,
+  };
+}
 
 /**
  * Convert a free-form user query into a safe FTS5 MATCH expression.
@@ -91,92 +117,53 @@ type RawAnswerHit = {
   score: number;
 };
 
+type DriverResult = {
+  questionRows: RawQuestionHit[];
+  answerRows: RawAnswerHit[];
+  questionTotal: number;
+  answerTotal: number;
+  toPublicScore: (raw: number) => number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function rangeToSince(range: SearchRange): Date | null {
+  switch (range) {
+    case "week":
+      return new Date(Date.now() - 7 * DAY_MS);
+    case "month":
+      return new Date(Date.now() - 30 * DAY_MS);
+    case "year":
+      return new Date(Date.now() - 365 * DAY_MS);
+    case "all":
+    default:
+      return null;
+  }
+}
+
+function questionStatusClause(status: SearchStatus): Prisma.Sql {
+  if (status === "answered") return Prisma.sql`AND q.status = 'answered'`;
+  if (status === "unanswered") return Prisma.sql`AND q.status = 'open'`;
+  return Prisma.empty;
+}
+
 export async function searchContent(opts: SearchOptions): Promise<SearchResultsPage> {
-  const { q, scope, groupIds, page, per } = opts;
+  const resolved = resolveOptions(opts);
+  const { q, page, per, sort } = resolved;
   const expr = toFtsMatchExpr(q);
 
   if (expr === null) {
     return { items: [], total: 0, page, per };
   }
 
-  const useGroupFilter =
-    (scope === "current" || scope === "selected") && groupIds.length > 0;
+  const provider = (process.env["DATABASE_PROVIDER"] ?? "sqlite").toLowerCase();
+  const driver: DriverResult =
+    provider === "postgres"
+      ? await runTsvector(resolved, expr)
+      : await runFts5(resolved, expr);
 
-  const groupFilterQuestion = useGroupFilter
-    ? Prisma.sql`AND q."groupId" IN (${Prisma.join(groupIds)})`
-    : Prisma.empty;
-
-  // Fetch enough rows from each side to cover the requested page after merge.
-  const fetchLimit = page * per;
-
-  const [questionRows, answerRows, questionTotalRows, answerTotalRows] =
-    await Promise.all([
-      db.$queryRaw<RawQuestionHit[]>(Prisma.sql`
-        SELECT
-          q.id AS question_id,
-          q.title AS title,
-          snippet(question_fts, 1, '<mark>', '</mark>', '…', 12) AS title_snippet,
-          snippet(question_fts, 2, '<mark>', '</mark>', '…', 24) AS body_excerpt,
-          q."createdAt" AS created_at,
-          q."groupId" AS group_id,
-          q."authorId" AS author_id,
-          bm25(question_fts) AS score
-        FROM question_fts
-        JOIN "Question" q ON q.id = question_fts.id
-        JOIN "Group" g ON g.id = q."groupId"
-        WHERE question_fts MATCH ${expr}
-          AND q."deletedAt" IS NULL
-          AND g."archivedAt" IS NULL
-        ${groupFilterQuestion}
-        ORDER BY score ASC, created_at DESC
-        LIMIT ${fetchLimit}
-      `),
-      db.$queryRaw<RawAnswerHit[]>(Prisma.sql`
-        SELECT
-          a.id AS answer_id,
-          a."questionId" AS question_id,
-          q.title AS title,
-          snippet(answer_fts, 1, '<mark>', '</mark>', '…', 24) AS body_excerpt,
-          a."createdAt" AS created_at,
-          q."groupId" AS group_id,
-          a."authorId" AS author_id,
-          bm25(answer_fts) AS score
-        FROM answer_fts
-        JOIN "Answer" a ON a.id = answer_fts.id
-        JOIN "Question" q ON q.id = a."questionId"
-        JOIN "Group" g ON g.id = q."groupId"
-        WHERE answer_fts MATCH ${expr}
-          AND q."deletedAt" IS NULL
-          AND g."archivedAt" IS NULL
-        ${groupFilterQuestion}
-        ORDER BY score ASC, created_at DESC
-        LIMIT ${fetchLimit}
-      `),
-      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
-        SELECT COUNT(*) AS n
-        FROM question_fts
-        JOIN "Question" q ON q.id = question_fts.id
-        JOIN "Group" g ON g.id = q."groupId"
-        WHERE question_fts MATCH ${expr}
-          AND q."deletedAt" IS NULL
-          AND g."archivedAt" IS NULL
-        ${groupFilterQuestion}
-      `),
-      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
-        SELECT COUNT(*) AS n
-        FROM answer_fts
-        JOIN "Answer" a ON a.id = answer_fts.id
-        JOIN "Question" q ON q.id = a."questionId"
-        JOIN "Group" g ON g.id = q."groupId"
-        WHERE answer_fts MATCH ${expr}
-          AND q."deletedAt" IS NULL
-          AND g."archivedAt" IS NULL
-        ${groupFilterQuestion}
-      `),
-    ]);
-
-  const total =
-    Number(questionTotalRows[0]?.n ?? 0) + Number(answerTotalRows[0]?.n ?? 0);
+  const { questionRows, answerRows, questionTotal, answerTotal, toPublicScore } = driver;
+  const total = questionTotal + answerTotal;
 
   if (questionRows.length === 0 && answerRows.length === 0) {
     return { items: [], total, page, per };
@@ -205,11 +192,6 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
   ]);
   const groupsById = new Map(groupRows.map((g) => [g.id, g]));
   const authorsById = new Map(authorRows.map((u) => [u.id, u]));
-
-  // Convert FTS5 BM25 (lower = better, often negative) to a positive
-  // "higher is better" score by negating. Callers can compare scores within a
-  // single response, but the absolute magnitude is opaque.
-  const toPublicScore = (bm25: number) => -bm25;
 
   const questionHits: SearchHit[] = questionRows.flatMap((r) => {
     const group = groupsById.get(r.group_id);
@@ -252,6 +234,9 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
   });
 
   const merged = [...questionHits, ...answerHits].sort((a, b) => {
+    if (sort === "newest") {
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    }
     if (b.score !== a.score) return b.score - a.score;
     return b.createdAt.getTime() - a.createdAt.getTime();
   });
@@ -260,4 +245,252 @@ export async function searchContent(opts: SearchOptions): Promise<SearchResultsP
   const items = merged.slice(start, start + per);
 
   return { items, total, page, per };
+}
+
+async function runFts5(opts: ResolvedOptions, expr: string): Promise<DriverResult> {
+  const { scope, groupIds, page, per, status, range, authorId, sort } = opts;
+
+  const useGroupFilter =
+    (scope === "current" || scope === "selected") && groupIds.length > 0;
+  const groupFilter = useGroupFilter
+    ? Prisma.sql`AND q."groupId" IN (${Prisma.join(groupIds)})`
+    : Prisma.empty;
+
+  const since = rangeToSince(range);
+  const statusFilter = questionStatusClause(status);
+
+  const questionDateFilter = since
+    ? Prisma.sql`AND q."createdAt" > ${since}`
+    : Prisma.empty;
+  const answerDateFilter = since
+    ? Prisma.sql`AND a."createdAt" > ${since}`
+    : Prisma.empty;
+
+  const questionAuthorFilter = authorId
+    ? Prisma.sql`AND q."authorId" = ${authorId}`
+    : Prisma.empty;
+  const answerAuthorFilter = authorId
+    ? Prisma.sql`AND a."authorId" = ${authorId}`
+    : Prisma.empty;
+
+  const questionOrder =
+    sort === "newest"
+      ? Prisma.sql`ORDER BY created_at DESC`
+      : Prisma.sql`ORDER BY score ASC, created_at DESC`;
+  const answerOrder = questionOrder;
+
+  const fetchLimit = page * per;
+
+  const [questionRows, answerRows, questionTotalRows, answerTotalRows] =
+    await Promise.all([
+      db.$queryRaw<RawQuestionHit[]>(Prisma.sql`
+        SELECT
+          q.id AS question_id,
+          q.title AS title,
+          snippet(question_fts, 1, '<mark>', '</mark>', '…', 12) AS title_snippet,
+          snippet(question_fts, 2, '<mark>', '</mark>', '…', 24) AS body_excerpt,
+          q."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          q."authorId" AS author_id,
+          bm25(question_fts) AS score
+        FROM question_fts
+        JOIN "Question" q ON q.id = question_fts.id
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE question_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${questionDateFilter}
+        ${questionAuthorFilter}
+        ${questionOrder}
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<RawAnswerHit[]>(Prisma.sql`
+        SELECT
+          a.id AS answer_id,
+          a."questionId" AS question_id,
+          q.title AS title,
+          snippet(answer_fts, 1, '<mark>', '</mark>', '…', 24) AS body_excerpt,
+          a."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          a."authorId" AS author_id,
+          bm25(answer_fts) AS score
+        FROM answer_fts
+        JOIN "Answer" a ON a.id = answer_fts.id
+        JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE answer_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${answerDateFilter}
+        ${answerAuthorFilter}
+        ${answerOrder}
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*) AS n
+        FROM question_fts
+        JOIN "Question" q ON q.id = question_fts.id
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE question_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${questionDateFilter}
+        ${questionAuthorFilter}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*) AS n
+        FROM answer_fts
+        JOIN "Answer" a ON a.id = answer_fts.id
+        JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE answer_fts MATCH ${expr}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${answerDateFilter}
+        ${answerAuthorFilter}
+      `),
+    ]);
+
+  return {
+    questionRows,
+    answerRows,
+    questionTotal: Number(questionTotalRows[0]?.n ?? 0),
+    answerTotal: Number(answerTotalRows[0]?.n ?? 0),
+    // FTS5 BM25: lower = better, often negative. Negate so callers see
+    // higher = better. Magnitude is opaque outside a single response.
+    toPublicScore: (bm25) => -bm25,
+  };
+}
+
+async function runTsvector(opts: ResolvedOptions, expr: string): Promise<DriverResult> {
+  // Postgres branch — wired for the prod connector swap. SQLite tests don't
+  // exercise this path; the structure mirrors runFts5 so filters stay aligned.
+  void expr;
+  const { q, scope, groupIds, page, per, status, range, authorId, sort } = opts;
+
+  const useGroupFilter =
+    (scope === "current" || scope === "selected") && groupIds.length > 0;
+  const groupFilter = useGroupFilter
+    ? Prisma.sql`AND q."groupId" IN (${Prisma.join(groupIds)})`
+    : Prisma.empty;
+
+  const since = rangeToSince(range);
+  const statusFilter = questionStatusClause(status);
+  const questionDateFilter = since
+    ? Prisma.sql`AND q."createdAt" > ${since}`
+    : Prisma.empty;
+  const answerDateFilter = since
+    ? Prisma.sql`AND a."createdAt" > ${since}`
+    : Prisma.empty;
+  const questionAuthorFilter = authorId
+    ? Prisma.sql`AND q."authorId" = ${authorId}`
+    : Prisma.empty;
+  const answerAuthorFilter = authorId
+    ? Prisma.sql`AND a."authorId" = ${authorId}`
+    : Prisma.empty;
+
+  const questionOrder =
+    sort === "newest"
+      ? Prisma.sql`ORDER BY created_at DESC`
+      : Prisma.sql`ORDER BY score DESC, created_at DESC`;
+  const answerOrder = questionOrder;
+
+  const fetchLimit = page * per;
+
+  const tsq = Prisma.sql`plainto_tsquery('english', ${q})`;
+  const headlineOpts = "StartSel=<mark>, StopSel=</mark>, MaxWords=24, MinWords=12";
+
+  const [questionRows, answerRows, questionTotalRows, answerTotalRows] =
+    await Promise.all([
+      db.$queryRaw<RawQuestionHit[]>(Prisma.sql`
+        SELECT
+          q.id AS question_id,
+          q.title AS title,
+          ts_headline('english', q.title, ${tsq}, ${headlineOpts}) AS title_snippet,
+          ts_headline('english', q.body, ${tsq}, ${headlineOpts}) AS body_excerpt,
+          q."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          q."authorId" AS author_id,
+          ts_rank_cd(
+            to_tsvector('english', q.title || ' ' || q.body),
+            ${tsq}
+          ) AS score
+        FROM "Question" q
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE to_tsvector('english', q.title || ' ' || q.body) @@ ${tsq}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${questionDateFilter}
+        ${questionAuthorFilter}
+        ${questionOrder}
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<RawAnswerHit[]>(Prisma.sql`
+        SELECT
+          a.id AS answer_id,
+          a."questionId" AS question_id,
+          q.title AS title,
+          ts_headline('english', a.body, ${tsq}, ${headlineOpts}) AS body_excerpt,
+          a."createdAt" AS created_at,
+          q."groupId" AS group_id,
+          a."authorId" AS author_id,
+          ts_rank_cd(to_tsvector('english', a.body), ${tsq}) AS score
+        FROM "Answer" a
+        JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE to_tsvector('english', a.body) @@ ${tsq}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${answerDateFilter}
+        ${answerAuthorFilter}
+        ${answerOrder}
+        LIMIT ${fetchLimit}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*)::bigint AS n
+        FROM "Question" q
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE to_tsvector('english', q.title || ' ' || q.body) @@ ${tsq}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${questionDateFilter}
+        ${questionAuthorFilter}
+      `),
+      db.$queryRaw<{ n: number | bigint }[]>(Prisma.sql`
+        SELECT COUNT(*)::bigint AS n
+        FROM "Answer" a
+        JOIN "Question" q ON q.id = a."questionId"
+        JOIN "Group" g ON g.id = q."groupId"
+        WHERE to_tsvector('english', a.body) @@ ${tsq}
+          AND q."deletedAt" IS NULL
+          AND g."archivedAt" IS NULL
+        ${groupFilter}
+        ${statusFilter}
+        ${answerDateFilter}
+        ${answerAuthorFilter}
+      `),
+    ]);
+
+  return {
+    questionRows,
+    answerRows,
+    questionTotal: Number(questionTotalRows[0]?.n ?? 0),
+    answerTotal: Number(answerTotalRows[0]?.n ?? 0),
+    // ts_rank_cd: higher = better. Pass through unchanged.
+    toPublicScore: (rank) => rank,
+  };
 }

--- a/src/lib/users.test.ts
+++ b/src/lib/users.test.ts
@@ -1,0 +1,77 @@
+/**
+ * searchUsersByNameOrEmail tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-users-test-${Date.now()}.db`);
+process.env["DATABASE_URL"] = `file:${testDbPath}`;
+
+const { db } = await import("./db");
+const { searchUsersByNameOrEmail } = await import("./users");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+let counter = 0;
+function uniq(label: string): string {
+  counter += 1;
+  return `${label}-${Date.now()}-${counter}`;
+}
+
+describe("searchUsersByNameOrEmail", () => {
+  it("returns empty for blank query", async () => {
+    expect(await searchUsersByNameOrEmail("")).toEqual([]);
+    expect(await searchUsersByNameOrEmail("   ")).toEqual([]);
+  });
+
+  it("matches by name (case-insensitive ASCII)", async () => {
+    await db.user.create({
+      data: { email: `${uniq("nm")}@example.com`, name: "Jane Quokka" },
+    });
+    const matches = await searchUsersByNameOrEmail("quokka");
+    expect(matches.some((m) => m.name === "Jane Quokka")).toBe(true);
+  });
+
+  it("matches by email substring", async () => {
+    const target = `${uniq("specific-pgvector")}@example.com`;
+    await db.user.create({ data: { email: target, name: "Alex P" } });
+    const matches = await searchUsersByNameOrEmail("pgvector");
+    expect(matches.some((m) => m.email === target)).toBe(true);
+  });
+
+  it("caps the result count at the limit (max 20)", async () => {
+    const tag = uniq("bulk");
+    for (let i = 0; i < 5; i += 1) {
+      await db.user.create({
+        data: { email: `${tag}-${i}@example.com`, name: `${tag} user ${i}` },
+      });
+    }
+    const limited = await searchUsersByNameOrEmail(tag, 2);
+    expect(limited.length).toBeLessThanOrEqual(2);
+    const big = await searchUsersByNameOrEmail(tag, 999);
+    expect(big.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { db } from "@/lib/db";
+
+export type UserSummary = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+};
+
+export async function searchUsersByNameOrEmail(
+  q: string,
+  limit = 10,
+): Promise<UserSummary[]> {
+  const term = q.trim();
+  if (!term) return [];
+  const take = Math.min(Math.max(limit, 1), 20);
+  // SQLite `contains` is case-insensitive for ASCII without `mode: "insensitive"`,
+  // and that mode is Postgres-only. Plain `contains` works on both providers.
+  const rows = await db.user.findMany({
+    where: {
+      OR: [{ name: { contains: term } }, { email: { contains: term } }],
+    },
+    select: { id: true, name: true, email: true, image: true },
+    take,
+    orderBy: [{ name: "asc" }, { email: "asc" }],
+  });
+  return rows;
+}
+
+export async function getUserSummaryById(id: string): Promise<UserSummary | null> {
+  return db.user.findUnique({
+    where: { id },
+    select: { id: true, name: true, email: true, image: true },
+  });
+}

--- a/src/lib/validation/search.ts
+++ b/src/lib/validation/search.ts
@@ -15,6 +15,10 @@ export const searchQuerySchema = z
       .pipe(z.array(z.string().min(1)).max(50, "At most 50 groupIds.")),
     page: z.coerce.number().int().min(1).default(1),
     per: z.coerce.number().int().min(1).max(50).default(20),
+    status: z.enum(["all", "answered", "unanswered"]).default("all"),
+    range: z.enum(["all", "week", "month", "year"]).default("all"),
+    authorId: z.string().min(1).max(64).optional(),
+    sort: z.enum(["relevance", "newest"]).default("relevance"),
   })
   .superRefine((val, ctx) => {
     if ((val.scope === "current" || val.scope === "selected") && val.groupIds.length === 0) {


### PR DESCRIPTION
## Summary
- Adds answered/unanswered, date range, and author filters plus a relevance/newest sort to `/search` so power users can drill in.
- All filter and sort state lives in the URL so results stay shareable, and `searchContent` enforces filters in both the FTS5 and tsvector branches.
- Surfaces an active-filters bar with per-chip clear and a clear-all link; result-card author names are click-to-filter.
- Closes #47.

## Changes
- **Server**: extended `searchQuerySchema` with `status`/`range`/`authorId`/`sort`. Split `searchContent` into `runFts5`/`runTsvector` driver helpers gated by `DATABASE_PROVIDER`; status filters via `q.status` so answer hits inherit their parent question's state, date range applies to each hit's own `createdAt`, sort branches in SQL and merge.
- **API**: new session-gated `GET /api/users/search` endpoint backing the author typeahead; `/api/search` route passes the new params through.
- **UI**: `SearchControls` adds Status/Date/Sort segmented buttons and an author typeahead with selected-chip; `page.tsx` renders an Active-filters region with × clears and Clear-all, and pagination preserves filter state.
- **Tests**: new suites in `search.test.ts` for each filter, sort, and a combined-filters case; new `users.test.ts` and `users/search/route.test.ts` covering the helper and auth-gated endpoint.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (397 passing)
- [x] Smoke: `/search?q=foo&status=answered&range=week&sort=newest` renders the active-filter chips and Clear-all
- [x] Smoke: `/api/users/search?q=test` returns 401 unauthenticated
- [ ] Manual browser walkthrough of the author typeahead and clicking author chips on result cards — not exercised here; reviewer should sanity-check interactively.

## Notes
- The Postgres tsvector branch is wired in but exercised only by typecheck — the test harness still uses SQLite. Postgres-specific runtime coverage is deferred until a Postgres test setup lands.