### PR TITLE
feat(pagination): wire prev/next controls across group, profile, members

### DIFF
--- a/src/app/groups/[slug]/members/page.tsx
+++ b/src/app/groups/[slug]/members/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Pagination } from "@/components/ui/pagination";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { getGroupBySlug } from "@/lib/groups";
+import { listApprovedMembersPage } from "@/lib/memberships";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ page?: string }>;
+};
+
+const PER_PAGE = 20;
+
+export default async function GroupMembersPage({ params, searchParams }: Props) {
+  const [{ slug }, sp] = await Promise.all([params, searchParams]);
+  const group = await getGroupBySlug(slug);
+  if (!group) notFound();
+
+  const page = Math.max(Number(sp.page) || 1, 1);
+  const membersPage = await listApprovedMembersPage(group.id, { page, per: PER_PAGE });
+
+  const totalPages = Math.max(Math.ceil(membersPage.total / PER_PAGE), 1);
+  const memberLabel =
+    membersPage.total === 1 ? "1 member" : `${membersPage.total} members`;
+
+  const buildHref = (p: number): string =>
+    p > 1
+      ? `/groups/${group.slug}/members?page=${p}`
+      : `/groups/${group.slug}/members`;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <Link
+          href={`/groups/${group.slug}`}
+          className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+        >
+          ← Back to {group.name}
+        </Link>
+      </div>
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">Members of {group.name}</CardTitle>
+          <CardDescription>{memberLabel}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 pt-4">
+          {membersPage.items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No members yet.</p>
+          ) : (
+            <>
+              <ul className="space-y-2">
+                {membersPage.items.map((m) => (
+                  <li key={m.userId} className="flex items-center gap-3 text-sm">
+                    <UserAvatar user={m} size="sm" />
+                    <Link
+                      href={`/u/${m.userId}`}
+                      className="hover:underline"
+                    >
+                      {m.name ?? m.email ?? "Anonymous"}
+                    </Link>
+                    {m.role !== "member" ? (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {m.role}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+              <Pagination
+                currentPage={page}
+                totalPages={totalPages}
+                buildHref={buildHref}
+                label="Members pagination"
+              />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { GroupAvatar } from "@/components/ui/group-avatar";
 import { NotificationPreferencesControl } from "@/components/notification-preferences-control";
+import { Pagination } from "@/components/ui/pagination";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { getSession } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
@@ -22,26 +23,40 @@ import { getPreferenceForGroup } from "@/lib/notification-preferences";
 import { listQuestionsForGroup } from "@/lib/questions";
 import { MembershipActions } from "./membership-actions";
 
-type Props = { params: Promise<{ slug: string }> };
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ page?: string }>;
+};
 
 const MEMBER_PREVIEW_LIMIT = 12;
+const QUESTIONS_PER_PAGE = 20;
 
 function authorLabel(a: { name: string | null; email: string | null }): string {
   return a.name ?? a.email ?? "unknown";
 }
 
-export default async function GroupDetailPage({ params }: Props) {
-  const { slug } = await params;
+export default async function GroupDetailPage({ params, searchParams }: Props) {
+  const [{ slug }, sp] = await Promise.all([params, searchParams]);
   const group = await getGroupBySlug(slug);
   if (!group) notFound();
+
+  const page = Math.max(Number(sp.page) || 1, 1);
 
   const session = await getSession();
   const [memberCount, members, membership, questions] = await Promise.all([
     countApprovedMembers(group.id),
     listApprovedMembers(group.id, MEMBER_PREVIEW_LIMIT),
     session ? getMembership(group.id, session.user.id) : Promise.resolve(null),
-    listQuestionsForGroup(group.id, { page: 1, per: 20 }),
+    listQuestionsForGroup(group.id, { page, per: QUESTIONS_PER_PAGE }),
   ]);
+
+  const questionsTotalPages = Math.max(
+    Math.ceil(questions.total / QUESTIONS_PER_PAGE),
+    1,
+  );
+
+  const buildQuestionsHref = (p: number): string =>
+    p > 1 ? `/groups/${group.slug}?page=${p}` : `/groups/${group.slug}`;
 
   const isOwner = membership?.role === "owner" && membership.status === "approved";
   const isApproved = membership?.status === "approved";
@@ -141,7 +156,7 @@ export default async function GroupDetailPage({ params }: Props) {
                 }`}
           </CardDescription>
         </CardHeader>
-        <CardContent className="pt-2">
+        <CardContent className="space-y-3 pt-2">
           {members.length === 0 ? (
             <p className="text-sm text-muted-foreground">No members yet.</p>
           ) : (
@@ -159,6 +174,14 @@ export default async function GroupDetailPage({ params }: Props) {
               ))}
             </ul>
           )}
+          {members.length < memberCount ? (
+            <Link
+              href={`/groups/${group.slug}/members`}
+              className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+            >
+              View all members →
+            </Link>
+          ) : null}
         </CardContent>
       </Card>
 
@@ -186,26 +209,34 @@ export default async function GroupDetailPage({ params }: Props) {
             Questions {questions.total > 0 ? `(${questions.total})` : ""}
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-4 pt-4">
           {questions.items.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               No questions yet.
               {isApproved ? " Be the first to ask one." : ""}
             </p>
           ) : (
-            <ul className="divide-y divide-border">
-              {questions.items.map((q) => (
-                <li key={q.id} className="py-3 first:pt-0 last:pb-0">
-                  <Link href={`/q/${q.id}`} className="text-sm font-medium hover:underline">
-                    {q.title}
-                  </Link>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {authorLabel(q.author)} · {q.answerCount}{" "}
-                    {q.answerCount === 1 ? "answer" : "answers"} · Score {q.voteScore}
-                  </p>
-                </li>
-              ))}
-            </ul>
+            <>
+              <ul className="divide-y divide-border">
+                {questions.items.map((q) => (
+                  <li key={q.id} className="py-3 first:pt-0 last:pb-0">
+                    <Link href={`/q/${q.id}`} className="text-sm font-medium hover:underline">
+                      {q.title}
+                    </Link>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {authorLabel(q.author)} · {q.answerCount}{" "}
+                      {q.answerCount === 1 ? "answer" : "answers"} · Score {q.voteScore}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+              <Pagination
+                currentPage={page}
+                totalPages={questionsTotalPages}
+                buildHref={buildQuestionsHref}
+                label="Questions pagination"
+              />
+            </>
           )}
         </CardContent>
       </Card>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,21 +2,29 @@ import Link from "next/link";
 import { GroupCard } from "@/components/groups/group-card";
 import { SortTabs } from "@/components/groups/sort-tabs";
 import { Button } from "@/components/ui/button";
+import { Pagination } from "@/components/ui/pagination";
 import { getSession } from "@/lib/auth";
 import { listGroups, type ListGroupsSort } from "@/lib/groups";
 
 type Props = {
-  searchParams: Promise<{ sort?: string; includeArchived?: string }>;
+  searchParams: Promise<{ sort?: string; includeArchived?: string; page?: string }>;
 };
+
+const PER_PAGE = 20;
 
 function parseSort(value: string | undefined): ListGroupsSort {
   return value === "members" ? "members" : "newest";
 }
 
-function buildToggleHref(sort: ListGroupsSort, includeArchived: boolean): string {
+function buildGroupsHref(
+  sort: ListGroupsSort,
+  includeArchived: boolean,
+  page: number,
+): string {
   const params = new URLSearchParams();
   if (sort === "members") params.set("sort", "members");
-  if (!includeArchived) params.set("includeArchived", "1");
+  if (includeArchived) params.set("includeArchived", "1");
+  if (page > 1) params.set("page", String(page));
   const qs = params.toString();
   return qs ? `/groups?${qs}` : "/groups";
 }
@@ -25,10 +33,13 @@ export default async function GroupsPage({ searchParams }: Props) {
   const sp = await searchParams;
   const sort = parseSort(sp.sort);
   const includeArchived = sp.includeArchived === "1";
-  const [session, groups] = await Promise.all([
+  const page = Math.max(Number(sp.page) || 1, 1);
+  const [session, groupsPage] = await Promise.all([
     getSession(),
-    listGroups({ sort, includeArchived }),
+    listGroups({ sort, includeArchived, page, per: PER_PAGE }),
   ]);
+
+  const totalPages = Math.max(Math.ceil(groupsPage.total / PER_PAGE), 1);
 
   return (
     <div className="space-y-6">
@@ -44,13 +55,13 @@ export default async function GroupsPage({ searchParams }: Props) {
       <div className="flex flex-wrap items-center gap-3">
         <SortTabs active={sort} includeArchived={includeArchived} />
         <Link
-          href={buildToggleHref(sort, includeArchived)}
+          href={buildGroupsHref(sort, !includeArchived, 1)}
           className="text-sm text-muted-foreground underline-offset-4 hover:underline"
         >
           {includeArchived ? "Hide archived" : "Show archived"}
         </Link>
       </div>
-      {groups.length === 0 ? (
+      {groupsPage.items.length === 0 ? (
         <p className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
           No groups yet.{" "}
           {session ? (
@@ -62,11 +73,18 @@ export default async function GroupsPage({ searchParams }: Props) {
           )}
         </p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {groups.map((g) => (
-            <GroupCard key={g.id} group={g} />
-          ))}
-        </div>
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {groupsPage.items.map((g) => (
+              <GroupCard key={g.id} group={g} />
+            ))}
+          </div>
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            buildHref={(p) => buildGroupsHref(sort, includeArchived, p)}
+          />
+        </>
       )}
     </div>
   );

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Pagination } from "@/components/ui/pagination";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { AvatarUploadForm } from "@/components/avatar/avatar-upload-form";
 import { ProfileAnswerList } from "@/components/profile/profile-answer-list";
@@ -25,18 +26,38 @@ import { EditProfileForm } from "./edit-profile-form";
 
 const PAGE_SIZE = 20;
 
-export default async function MePage() {
+type Props = {
+  searchParams: Promise<{ qpage?: string; apage?: string }>;
+};
+
+export default async function MePage({ searchParams }: Props) {
   const session = await requireAuth();
   const userId = session.user.id;
+  const sp = await searchParams;
+  const qPage = Math.max(Number(sp.qpage) || 1, 1);
+  const aPage = Math.max(Number(sp.apage) || 1, 1);
 
   const [profile, questions, answers, groups, favorites, preferences] = await Promise.all([
     getOwnProfile(userId),
-    listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
-    listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listQuestionsByAuthor(userId, { page: qPage, per: PAGE_SIZE }),
+    listAnswersByAuthor(userId, { page: aPage, per: PAGE_SIZE }),
     listGroupsForUser(userId, { includePending: true }),
     listFavoritesByUser(userId),
     listPreferencesForUser(userId),
   ]);
+
+  const qTotalPages = Math.max(Math.ceil(questions.total / PAGE_SIZE), 1);
+  const aTotalPages = Math.max(Math.ceil(answers.total / PAGE_SIZE), 1);
+
+  const buildMeHref = (overrides: { qpage?: number; apage?: number }): string => {
+    const params = new URLSearchParams();
+    const nextQ = overrides.qpage ?? qPage;
+    const nextA = overrides.apage ?? aPage;
+    if (nextQ > 1) params.set("qpage", String(nextQ));
+    if (nextA > 1) params.set("apage", String(nextA));
+    const qs = params.toString();
+    return qs ? `/me?${qs}` : "/me";
+  };
 
   const mutedTypesByGroupId = Object.fromEntries(
     preferences.map((p) => [p.groupId, p.mutedTypes]),
@@ -78,7 +99,7 @@ export default async function MePage() {
             Your questions {questions.total > 0 ? `(${questions.total})` : ""}
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-4 pt-4">
           <ProfileQuestionList
             items={questions.items}
             emptyState={
@@ -91,6 +112,12 @@ export default async function MePage() {
               </>
             }
           />
+          <Pagination
+            currentPage={qPage}
+            totalPages={qTotalPages}
+            buildHref={(p) => buildMeHref({ qpage: p })}
+            label="Questions pagination"
+          />
         </CardContent>
       </Card>
 
@@ -100,10 +127,16 @@ export default async function MePage() {
             Your answers {answers.total > 0 ? `(${answers.total})` : ""}
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-4 pt-4">
           <ProfileAnswerList
             items={answers.items}
             emptyState="You haven't posted any answers yet."
+          />
+          <Pagination
+            currentPage={aPage}
+            totalPages={aTotalPages}
+            buildHref={(p) => buildMeHref({ apage: p })}
+            label="Answers pagination"
           />
         </CardContent>
       </Card>

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { MarkdownBody } from "@/components/markdown-body";
+import { Pagination } from "@/components/ui/pagination";
 import { ProfileAnswerList } from "@/components/profile/profile-answer-list";
 import { ProfileGroupList } from "@/components/profile/profile-group-list";
 import { ProfileQuestionList } from "@/components/profile/profile-question-list";
@@ -19,18 +20,37 @@ import {
 
 const PAGE_SIZE = 20;
 
-type Props = { params: Promise<{ userId: string }> };
+type Props = {
+  params: Promise<{ userId: string }>;
+  searchParams: Promise<{ qpage?: string; apage?: string }>;
+};
 
-export default async function PublicProfilePage({ params }: Props) {
-  const { userId } = await params;
+export default async function PublicProfilePage({ params, searchParams }: Props) {
+  const [{ userId }, sp] = await Promise.all([params, searchParams]);
   const profile = await getPublicUserProfile(userId);
   if (!profile) notFound();
 
+  const qPage = Math.max(Number(sp.qpage) || 1, 1);
+  const aPage = Math.max(Number(sp.apage) || 1, 1);
+
   const [questions, answers, groups] = await Promise.all([
-    listQuestionsByAuthor(userId, { page: 1, per: PAGE_SIZE }),
-    listAnswersByAuthor(userId, { page: 1, per: PAGE_SIZE }),
+    listQuestionsByAuthor(userId, { page: qPage, per: PAGE_SIZE }),
+    listAnswersByAuthor(userId, { page: aPage, per: PAGE_SIZE }),
     listGroupsForUser(userId, { includePending: false }),
   ]);
+
+  const qTotalPages = Math.max(Math.ceil(questions.total / PAGE_SIZE), 1);
+  const aTotalPages = Math.max(Math.ceil(answers.total / PAGE_SIZE), 1);
+
+  const buildProfileHref = (overrides: { qpage?: number; apage?: number }): string => {
+    const params = new URLSearchParams();
+    const nextQ = overrides.qpage ?? qPage;
+    const nextA = overrides.apage ?? aPage;
+    if (nextQ > 1) params.set("qpage", String(nextQ));
+    if (nextA > 1) params.set("apage", String(nextA));
+    const qs = params.toString();
+    return qs ? `/u/${userId}?${qs}` : `/u/${userId}`;
+  };
 
   const display = profile.name?.trim() || "Anonymous user";
 
@@ -66,10 +86,16 @@ export default async function PublicProfilePage({ params }: Props) {
             Questions {questions.total > 0 ? `(${questions.total})` : ""}
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-4 pt-4">
           <ProfileQuestionList
             items={questions.items}
             emptyState="No questions yet."
+          />
+          <Pagination
+            currentPage={qPage}
+            totalPages={qTotalPages}
+            buildHref={(p) => buildProfileHref({ qpage: p })}
+            label="Questions pagination"
           />
         </CardContent>
       </Card>
@@ -80,10 +106,16 @@ export default async function PublicProfilePage({ params }: Props) {
             Answers {answers.total > 0 ? `(${answers.total})` : ""}
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-4">
+        <CardContent className="space-y-4 pt-4">
           <ProfileAnswerList
             items={answers.items}
             emptyState="No answers yet."
+          />
+          <Pagination
+            currentPage={aPage}
+            totalPages={aTotalPages}
+            buildHref={(p) => buildProfileHref({ apage: p })}
+            label="Answers pagination"
           />
         </CardContent>
       </Card>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  currentPage: number;
+  totalPages: number;
+  buildHref: (page: number) => string;
+  label?: string;
+};
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  buildHref,
+  label = "Pagination",
+}: Props) {
+  if (totalPages <= 1) return null;
+
+  const prevDisabled = currentPage <= 1;
+  const nextDisabled = currentPage >= totalPages;
+
+  return (
+    <nav
+      aria-label={label}
+      className="flex items-center justify-between gap-3 pt-2"
+    >
+      <PageButton href={buildHref(currentPage - 1)} disabled={prevDisabled}>
+        Previous
+      </PageButton>
+      <span className="text-xs text-muted-foreground">
+        Page {currentPage} of {totalPages}
+      </span>
+      <PageButton href={buildHref(currentPage + 1)} disabled={nextDisabled}>
+        Next
+      </PageButton>
+    </nav>
+  );
+}
+
+function PageButton({
+  href,
+  disabled,
+  children,
+}: {
+  href: string;
+  disabled: boolean;
+  children: ReactNode;
+}) {
+  if (disabled) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        {children}
+      </Button>
+    );
+  }
+  return (
+    <Button variant="outline" size="sm" render={<Link href={href} />}>
+      {children}
+    </Button>
+  );
+}

--- a/src/lib/groups.test.ts
+++ b/src/lib/groups.test.ts
@@ -159,7 +159,7 @@ describe("listGroups", () => {
     // Force a small gap so createdAt ordering is unambiguous on coarse clocks.
     await new Promise((r) => setTimeout(r, 5));
     const b = await createGroup({ name: "B", slug: `${tag}-b` }, owner.id);
-    const list = await listGroups({ sort: "newest" });
+    const list = (await listGroups({ sort: "newest" })).items;
     const indexA = list.findIndex((g) => g.id === a.id);
     const indexB = list.findIndex((g) => g.id === b.id);
     expect(indexB).toBeGreaterThanOrEqual(0);
@@ -182,7 +182,7 @@ describe("listGroups", () => {
     await db.membership.create({
       data: { groupId: group.id, userId: m3.id, role: "member", status: "rejected" },
     });
-    const list = await listGroups({ sort: "newest" });
+    const list = (await listGroups({ sort: "newest" })).items;
     const found = list.find((g) => g.id === group.id);
     expect(found).toBeDefined();
     // owner + m1 = 2
@@ -200,7 +200,7 @@ describe("listGroups", () => {
         data: { groupId: big.id, userId: u.id, role: "member", status: "approved" },
       });
     }
-    const list = await listGroups({ sort: "members" });
+    const list = (await listGroups({ sort: "members" })).items;
     const indexBig = list.findIndex((g) => g.id === big.id);
     const indexSmall = list.findIndex((g) => g.id === small.id);
     expect(indexBig).toBeGreaterThanOrEqual(0);
@@ -214,13 +214,41 @@ describe("listGroups", () => {
     const group = await createGroup({ name: "Archy", slug }, owner.id);
     await archiveGroup(slug, owner.id);
 
-    const defaultList = await listGroups({ sort: "newest" });
+    const defaultList = (await listGroups({ sort: "newest" })).items;
     expect(defaultList.find((g) => g.id === group.id)).toBeUndefined();
 
-    const fullList = await listGroups({ sort: "newest", includeArchived: true });
+    const fullList = (await listGroups({ sort: "newest", includeArchived: true })).items;
     const found = fullList.find((g) => g.id === group.id);
     expect(found).toBeDefined();
     expect(found!.archivedAt).not.toBeNull();
+  });
+
+  it("respects page boundaries (page 2 returns expected slice)", async () => {
+    const owner = await makeUser("ls-page");
+    const tag = `ls-page-${Date.now()}`;
+    const created: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const g = await createGroup(
+        { name: `G${i}`, slug: `${tag}-${i}` },
+        owner.id,
+      );
+      created.push(g.id);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    // Newest-first → reversed ids.
+    const expected = [...created].reverse();
+
+    // These five are the most recently created in this DB, so under
+    // newest-first ordering they occupy the first slots.
+    const p1 = await listGroups({ sort: "newest", page: 1, per: 2 });
+    expect(p1.total).toBeGreaterThanOrEqual(5);
+    expect(p1.items.map((g) => g.id)).toEqual(expected.slice(0, 2));
+
+    const p2 = await listGroups({ sort: "newest", page: 2, per: 2 });
+    expect(p2.items.map((g) => g.id)).toEqual(expected.slice(2, 4));
+
+    const p3 = await listGroups({ sort: "newest", page: 3, per: 2 });
+    expect(p3.items.map((g) => g.id).slice(0, 1)).toEqual(expected.slice(4, 5));
   });
 });
 

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -66,10 +66,21 @@ export type GroupListItem = {
 
 export type ListGroupsSort = "newest" | "members";
 
+export type GroupListPage = {
+  items: GroupListItem[];
+  total: number;
+  page: number;
+  per: number;
+};
+
 export async function listGroups(opts: {
   sort: ListGroupsSort;
   includeArchived?: boolean;
-}): Promise<GroupListItem[]> {
+  page?: number;
+  per?: number;
+}): Promise<GroupListPage> {
+  const page = Math.max(opts.page ?? 1, 1);
+  const per = Math.min(Math.max(opts.per ?? 20, 1), 50);
   const where = opts.includeArchived ? {} : { archivedAt: null };
   const [groups, counts] = await Promise.all([
     db.group.findMany({
@@ -113,7 +124,9 @@ export async function listGroups(opts: {
     items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }
 
-  return items;
+  const total = items.length;
+  const start = (page - 1) * per;
+  return { items: items.slice(start, start + per), total, page, per };
 }
 
 export async function getGroupBySlug(slug: string): Promise<GroupWithOwner | null> {

--- a/src/lib/memberships.test.ts
+++ b/src/lib/memberships.test.ts
@@ -29,6 +29,7 @@ const {
   isOwnerOrModerator,
   leaveGroup,
   listApprovedMembers,
+  listApprovedMembersPage,
   listPendingApplications,
   listSuccessorCandidates,
   NotAMemberError,
@@ -557,5 +558,60 @@ describe("listApprovedMembers / listSuccessorCandidates", () => {
     });
     const list = await listSuccessorCandidates(group.id, owner.id);
     expect(list.map((m) => m.userId)).toEqual([u1.id]);
+  });
+});
+
+describe("listApprovedMembersPage", () => {
+  it("returns paginated slices ordered by joinedAt asc", async () => {
+    const { owner, group } = await makeGroup(next("paged-members"));
+    const created: string[] = [owner.id];
+    // Ensure subsequent membership createdAt timestamps are strictly after
+    // the owner's (created inside makeGroup) so ordering is deterministic.
+    await new Promise((r) => setTimeout(r, 5));
+    for (let i = 0; i < 5; i++) {
+      const u = await makeUser(`paged-${i}`);
+      await db.membership.create({
+        data: { groupId: group.id, userId: u.id, role: "member", status: "approved" },
+      });
+      created.push(u.id);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const p1 = await listApprovedMembersPage(group.id, { page: 1, per: 2 });
+    expect(p1.total).toBe(6);
+    expect(p1.items.map((m) => m.userId)).toEqual(created.slice(0, 2));
+
+    const p2 = await listApprovedMembersPage(group.id, { page: 2, per: 2 });
+    expect(p2.items.map((m) => m.userId)).toEqual(created.slice(2, 4));
+
+    const p3 = await listApprovedMembersPage(group.id, { page: 3, per: 2 });
+    expect(p3.items.map((m) => m.userId)).toEqual(created.slice(4, 6));
+
+    const p4 = await listApprovedMembersPage(group.id, { page: 4, per: 2 });
+    expect(p4.items).toEqual([]);
+    expect(p4.total).toBe(6);
+  });
+
+  it("excludes pending and rejected memberships from total and items", async () => {
+    const { owner, group } = await makeGroup(next("paged-filtered"));
+    const approved = await makeUser("paged-a");
+    await db.membership.create({
+      data: { groupId: group.id, userId: approved.id, role: "member", status: "approved" },
+    });
+    const pending = await makeUser("paged-p");
+    await db.membership.create({
+      data: { groupId: group.id, userId: pending.id, role: "member", status: "pending" },
+    });
+    const rejected = await makeUser("paged-r");
+    await db.membership.create({
+      data: { groupId: group.id, userId: rejected.id, role: "member", status: "rejected" },
+    });
+    const page = await listApprovedMembersPage(group.id, { page: 1, per: 20 });
+    expect(page.total).toBe(2);
+    const ids = page.items.map((m) => m.userId);
+    expect(ids).toContain(owner.id);
+    expect(ids).toContain(approved.id);
+    expect(ids).not.toContain(pending.id);
+    expect(ids).not.toContain(rejected.id);
   });
 });

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -229,6 +229,40 @@ export async function listApprovedMembers(
   }));
 }
 
+export type ApprovedMembersPage = {
+  items: ApprovedMember[];
+  total: number;
+  page: number;
+  per: number;
+};
+
+export async function listApprovedMembersPage(
+  groupId: string,
+  opts: { page: number; per: number },
+): Promise<ApprovedMembersPage> {
+  const page = Math.max(opts.page, 1);
+  const per = Math.min(Math.max(opts.per, 1), 50);
+  const skip = (page - 1) * per;
+  const [rows, total] = await Promise.all([
+    db.membership.findMany({
+      where: { groupId, status: "approved" },
+      orderBy: { createdAt: "asc" },
+      skip,
+      take: per,
+      include: { user: { select: { id: true, name: true, email: true, image: true } } },
+    }),
+    db.membership.count({ where: { groupId, status: "approved" } }),
+  ]);
+  const items = rows.map((m) => ({
+    userId: m.user.id,
+    name: m.user.name,
+    email: m.user.email,
+    image: m.user.image,
+    role: m.role,
+  }));
+  return { items, total, page, per };
+}
+
 export async function listApprovedMemberIds(groupId: string): Promise<string[]> {
   const rows = await db.membership.findMany({
     where: { groupId, status: "approved" },

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -103,6 +103,33 @@ describe("listQuestionsByAuthor", () => {
     expect(second.answerCount).toBe(1);
     expect(second.voteScore).toBe(1);
   });
+
+  it("respects page boundaries (page 2 returns expected slice)", async () => {
+    const author = await makeUser("qa-paginate");
+    const group = await createGroup(
+      { name: "QA Pag", slug: uniq("qap"), autoApprove: true },
+      author.id,
+    );
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const q = await createQuestion(
+        { title: `Q-${i}`, body: "body" },
+        group.id,
+        author.id,
+      );
+      ids.push(q.id);
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    // Newest-first → ids reversed.
+    const expected = [...ids].reverse();
+    const p1 = await listQuestionsByAuthor(author.id, { page: 1, per: 2 });
+    expect(p1.total).toBe(5);
+    expect(p1.items.map((q) => q.id)).toEqual(expected.slice(0, 2));
+    const p2 = await listQuestionsByAuthor(author.id, { page: 2, per: 2 });
+    expect(p2.items.map((q) => q.id)).toEqual(expected.slice(2, 4));
+    const p3 = await listQuestionsByAuthor(author.id, { page: 3, per: 2 });
+    expect(p3.items.map((q) => q.id)).toEqual(expected.slice(4, 5));
+  });
 });
 
 describe("listAnswersByAuthor", () => {
@@ -179,6 +206,35 @@ describe("listAnswersByAuthor", () => {
 
     const page = await listAnswersByAuthor(me.id, { page: 1, per: 20 });
     expect(page.total).toBe(0);
+  });
+
+  it("respects page boundaries (page 2 returns expected slice)", async () => {
+    const author = await makeUser("ans-paginate");
+    const group = await createGroup(
+      { name: "Ans Pag", slug: uniq("ansp"), autoApprove: true },
+      author.id,
+    );
+    const q = await createQuestion(
+      { title: "Pag Q", body: "?" },
+      group.id,
+      author.id,
+    );
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const a = await db.answer.create({
+        data: { questionId: q.id, authorId: author.id, body: `ans-${i}` },
+      });
+      ids.push(a.id);
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    const expected = [...ids].reverse();
+    const p1 = await listAnswersByAuthor(author.id, { page: 1, per: 2 });
+    expect(p1.total).toBe(5);
+    expect(p1.items.map((a) => a.id)).toEqual(expected.slice(0, 2));
+    const p2 = await listAnswersByAuthor(author.id, { page: 2, per: 2 });
+    expect(p2.items.map((a) => a.id)).toEqual(expected.slice(2, 4));
+    const p3 = await listAnswersByAuthor(author.id, { page: 3, per: 2 });
+    expect(p3.items.map((a) => a.id)).toEqual(expected.slice(4, 5));
   });
 });
 


### PR DESCRIPTION
## Summary
- Closes #48. Pagination math (`{ items, total, page, per }`) was already computed in lib functions but every consumer hardcoded `page: 1`; this surfaces it on the four polish-milestone pages so users can actually walk past the first 20 items.
- Adds a dedicated full-members route under `/groups/<slug>/members` since the group detail card was capped at a 12-row preview with no way to see the rest.
- Profile pages (`/me` and `/u/:userId`) host two paginated lists on one screen, so they use distinct `?qpage=` / `?apage=` params to paginate independently.

## Changes
- **UI**: new server-only `<Pagination>` component (`src/components/ui/pagination.tsx`) with disabled prev/next at boundaries; wired into `/groups`, `/groups/[slug]`, `/me`, `/u/[userId]`, and the new `/groups/[slug]/members` route. Group detail gains a "View all members →" link when the preview is truncated.
- **Lib**: `listGroups` now returns a paged result and slices in memory after the existing sort. New `listApprovedMembersPage(groupId, { page, per })` reuses the approved-membership filter; the existing `listApprovedMembers(groupId, limit)` stays for the 12-preview path.
- **Tests**: page-2/page-3 boundary slice tests added in `groups.test.ts`, `memberships.test.ts`, and `profile.test.ts` (questions + answers). `questions.test.ts` already covered `listQuestionsForGroup` page-2.

## Test plan
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 36 files / 402 tests passed.
- [ ] Manual: seed >20 groups and verify `/groups?page=2` shifts the slice and Next disables on the last page; verify `/groups/<slug>?page=2` for questions; verify "View all members →" lands on `/groups/<slug>/members` and paginates; verify `/me` and `/u/:userId` paginate questions and answers independently with `?qpage=` / `?apage=`.

## Notes
- `per` is held server-side at 20; not exposed via UI on these pages.
- Filter changes (sort tab, includeArchived toggle on `/groups`) drop `page` so users return to page 1 on each filter change.
- `src/app/search/page.tsx` still has its own local `PageLink`; intentionally left alone to keep the diff focused — easy follow-up to migrate it to the shared component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)