### PR TITLE
feat(groups): member management UI for moderators

### DIFF
--- a/src/app/api/groups/[slug]/membership/[userId]/route.test.ts
+++ b/src/app/api/groups/[slug]/membership/[userId]/route.test.ts
@@ -185,6 +185,118 @@ describe("PATCH /api/groups/[slug]/membership/[userId]", () => {
     );
     expect(res.status).toBe(403);
   });
+
+  it("owner can promote a member to moderator via role payload", async () => {
+    const setup = await setupGroupWithApplicant("promote", true);
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, { role: "moderator" }),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membership.role).toBe("moderator");
+  });
+
+  it("owner can demote a moderator to member", async () => {
+    const setup = await setupGroupWithApplicant("demote", true);
+    const group = (await db.group.findUnique({ where: { slug: setup.slug } }))!;
+    await db.membership.update({
+      where: {
+        userId_groupId: { userId: setup.applicantId, groupId: group.id },
+      },
+      data: { role: "moderator" },
+    });
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, { role: "member" }),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membership.role).toBe("member");
+  });
+
+  it("returns 409 when promoting a non-approved (pending) member", async () => {
+    const setup = await setupGroupWithApplicant("nonapproved-promote"); // applicant is pending
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, { role: "moderator" }),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("moderator cannot change roles (403)", async () => {
+    const setup = await setupGroupWithApplicant("modforbid", true);
+    const group = (await db.group.findUnique({ where: { slug: setup.slug } }))!;
+    // Make applicant a moderator.
+    await db.membership.update({
+      where: {
+        userId_groupId: { userId: setup.applicantId, groupId: group.id },
+      },
+      data: { role: "moderator" },
+    });
+    // Add a regular approved member.
+    const member = await db.user.create({
+      data: { email: `member-modforbid-${Date.now()}@example.com` },
+    });
+    await db.membership.create({
+      data: {
+        groupId: group.id,
+        userId: member.id,
+        role: "member",
+        status: "approved",
+      },
+    });
+    // Sign in as the moderator (the applicant we just promoted).
+    const moderatorEmail = (await db.user.findUnique({
+      where: { id: setup.applicantId },
+    }))!.email!;
+    cookieStore.clear();
+    await auth.signIn(moderatorEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, member.id, { role: "moderator" }),
+      ctx(setup.slug, member.id),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects role: 'owner' (400)", async () => {
+    const setup = await setupGroupWithApplicant("ownerrole", true);
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, { role: "owner" }),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects mixed status+role payload (400)", async () => {
+    const setup = await setupGroupWithApplicant("mixed");
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, { status: "approved", role: "member" }),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty payload (400)", async () => {
+    const setup = await setupGroupWithApplicant("empty");
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await PATCH(
+      patchReq(setup.slug, setup.applicantId, {}),
+      ctx(setup.slug, setup.applicantId),
+    );
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("DELETE /api/groups/[slug]/membership/[userId]", () => {
@@ -256,5 +368,55 @@ describe("DELETE /api/groups/[slug]/membership/[userId]", () => {
     });
     const res = await DELETE(deleteReq(slug, ghost.id), ctx(slug, ghost.id));
     expect(res.status).toBe(404);
+  });
+
+  it("moderator can remove a member", async () => {
+    const setup = await setupGroupWithApplicant("modkick", true);
+    const group = (await db.group.findUnique({ where: { slug: setup.slug } }))!;
+    // Promote applicant to moderator.
+    await db.membership.update({
+      where: {
+        userId_groupId: { userId: setup.applicantId, groupId: group.id },
+      },
+      data: { role: "moderator" },
+    });
+    // Create a regular member to remove.
+    const victim = await db.user.create({
+      data: { email: `victim-modkick-${Date.now()}@example.com` },
+    });
+    await db.membership.create({
+      data: {
+        groupId: group.id,
+        userId: victim.id,
+        role: "member",
+        status: "approved",
+      },
+    });
+    // Sign in as moderator.
+    const moderatorEmail = (await db.user.findUnique({
+      where: { id: setup.applicantId },
+    }))!.email!;
+    cookieStore.clear();
+    await auth.signIn(moderatorEmail);
+    const res = await DELETE(
+      deleteReq(setup.slug, victim.id),
+      ctx(setup.slug, victim.id),
+    );
+    expect(res.status).toBe(200);
+    const m = await db.membership.findUnique({
+      where: { userId_groupId: { userId: victim.id, groupId: group.id } },
+    });
+    expect(m).toBeNull();
+  });
+
+  it("owner cannot be removed (409)", async () => {
+    const setup = await setupGroupWithApplicant("ownerprot", true);
+    cookieStore.clear();
+    await auth.signIn(setup.ownerEmail);
+    const res = await DELETE(
+      deleteReq(setup.slug, setup.ownerId),
+      ctx(setup.slug, setup.ownerId),
+    );
+    expect(res.status).toBe(409);
   });
 });

--- a/src/app/api/groups/[slug]/membership/[userId]/route.ts
+++ b/src/app/api/groups/[slug]/membership/[userId]/route.ts
@@ -5,10 +5,11 @@ import { getGroupBySlugOrThrow } from "@/lib/groups";
 import {
   getMembership,
   removeMembership,
+  setMembershipRole,
   setMembershipStatus,
 } from "@/lib/memberships";
 import { notifyMembershipDecision } from "@/lib/notifications";
-import { updateMembershipStatusSchema } from "@/lib/validation/memberships";
+import { updateMembershipSchema } from "@/lib/validation/memberships";
 
 type Ctx = { params: Promise<{ slug: string; userId: string }> };
 
@@ -24,35 +25,45 @@ export async function PATCH(req: Request, ctx: Ctx): Promise<Response> {
     return Response.json({ error: "InvalidJson" }, { status: 400 });
   }
 
-  const parsed = updateMembershipStatusSchema.safeParse(body);
+  const parsed = updateMembershipSchema.safeParse(body);
   if (!parsed.success) return validationFailed(parsed.error);
 
   try {
     const group = await getGroupBySlugOrThrow(slug);
-    const previous = await getMembership(group.id, userId);
-    const membership = await setMembershipStatus(
+    if ("status" in parsed.data) {
+      const previous = await getMembership(group.id, userId);
+      const membership = await setMembershipStatus(
+        group.id,
+        userId,
+        parsed.data.status,
+        session.user.id,
+      );
+      const statusChanged = previous?.status !== membership.status;
+      if (statusChanged) {
+        try {
+          const actor = await db.user.findUnique({
+            where: { id: session.user.id },
+            select: { name: true },
+          });
+          await notifyMembershipDecision(
+            parsed.data.status,
+            userId,
+            { slug: group.slug, name: group.name },
+            { id: session.user.id, name: actor?.name ?? session.user.name },
+          );
+        } catch (notifyErr) {
+          console.error("notifyMembershipDecision failed:", notifyErr);
+        }
+      }
+      return Response.json({ membership });
+    }
+
+    const membership = await setMembershipRole(
       group.id,
       userId,
-      parsed.data.status,
+      parsed.data.role,
       session.user.id,
     );
-    const statusChanged = previous?.status !== membership.status;
-    if (statusChanged) {
-      try {
-        const actor = await db.user.findUnique({
-          where: { id: session.user.id },
-          select: { name: true },
-        });
-        await notifyMembershipDecision(
-          parsed.data.status,
-          userId,
-          { slug: group.slug, name: group.name },
-          { id: session.user.id, name: actor?.name ?? session.user.name },
-        );
-      } catch (notifyErr) {
-        console.error("notifyMembershipDecision failed:", notifyErr);
-      }
-    }
     return Response.json({ membership });
   } catch (err) {
     return errorToResponse(err);

--- a/src/app/groups/[slug]/settings/members-list.tsx
+++ b/src/app/groups/[slug]/settings/members-list.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { UserAvatar } from "@/components/ui/user-avatar";
+
+export type MembersListItem = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  role: "member" | "moderator" | "owner";
+};
+
+type Props = {
+  slug: string;
+  viewerUserId: string;
+  viewerIsOwner: boolean;
+  archived: boolean;
+  members: MembersListItem[];
+};
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string; error?: string };
+    return body.message ?? body.error ?? `Request failed (${res.status})`;
+  } catch {
+    return `Request failed (${res.status})`;
+  }
+}
+
+export function MembersList({
+  slug,
+  viewerUserId,
+  viewerIsOwner,
+  archived,
+  members,
+}: Props) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  if (members.length === 0) {
+    return <p className="text-sm text-muted-foreground">No members yet.</p>;
+  }
+
+  async function changeRole(member: MembersListItem, role: "member" | "moderator") {
+    setBusyId(member.userId);
+    try {
+      const res = await fetch(`/api/groups/${slug}/membership/${member.userId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role }),
+      });
+      if (!res.ok) {
+        toast.error(await readError(res));
+        return;
+      }
+      toast.success(
+        role === "moderator"
+          ? `Promoted ${member.name ?? member.email ?? "member"} to moderator.`
+          : `Demoted ${member.name ?? member.email ?? "moderator"} to member.`,
+      );
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function remove(member: MembersListItem) {
+    const label = member.name ?? member.email ?? "this member";
+    if (!confirm(`Remove ${label} from the group? They will lose access immediately.`)) {
+      return;
+    }
+    setBusyId(member.userId);
+    try {
+      const res = await fetch(`/api/groups/${slug}/membership/${member.userId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        toast.error(await readError(res));
+        return;
+      }
+      toast.success(`Removed ${label} from the group.`);
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <ul className="divide-y rounded-md border">
+      {members.map((m) => {
+        const showPromote =
+          viewerIsOwner && m.role === "member" && !archived;
+        const showDemote =
+          viewerIsOwner && m.role === "moderator" && !archived;
+        const showRemove =
+          m.role !== "owner" && m.userId !== viewerUserId && !archived;
+        const disabled = busyId !== null;
+
+        return (
+          <li key={m.userId} className="flex items-center justify-between gap-4 p-3">
+            <div className="flex items-center gap-3">
+              <UserAvatar user={m} size="sm" />
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">
+                  {m.name ?? m.email ?? m.userId}
+                </p>
+                {m.name && m.email ? (
+                  <p className="text-xs text-muted-foreground">{m.email}</p>
+                ) : null}
+              </div>
+              {m.role !== "member" ? (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {m.role}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2">
+              {showPromote ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={disabled}
+                  onClick={() => changeRole(m, "moderator")}
+                >
+                  {busyId === m.userId ? "…" : "Promote to moderator"}
+                </Button>
+              ) : null}
+              {showDemote ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={disabled}
+                  onClick={() => changeRole(m, "member")}
+                >
+                  {busyId === m.userId ? "…" : "Demote to member"}
+                </Button>
+              ) : null}
+              {showRemove ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={disabled}
+                  onClick={() => remove(m)}
+                >
+                  {busyId === m.userId ? "…" : "Remove"}
+                </Button>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/app/groups/[slug]/settings/page.tsx
+++ b/src/app/groups/[slug]/settings/page.tsx
@@ -6,9 +6,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { GroupAvatar } from "@/components/ui/group-avatar";
 import { requireAuth } from "@/lib/auth";
 import { getGroupBySlug } from "@/lib/groups";
-import { isOwner, listPendingApplications } from "@/lib/memberships";
+import {
+  isOwner,
+  isOwnerOrModerator,
+  listApprovedMembers,
+  listPendingApplications,
+} from "@/lib/memberships";
 import { ArchiveControls } from "./archive-controls";
 import { AutoApproveToggle } from "./auto-approve-toggle";
+import { MembersList, type MembersListItem } from "./members-list";
 import { PendingApplicationsList, type PendingApplicationView } from "./pending-applications-list";
 
 type Props = { params: Promise<{ slug: string }> };
@@ -18,7 +24,8 @@ export default async function GroupSettingsPage({ params }: Props) {
   const session = await requireAuth();
   const group = await getGroupBySlug(slug);
   if (!group) notFound();
-  if (!(await isOwner(group.id, session.user.id))) notFound();
+  if (!(await isOwnerOrModerator(group.id, session.user.id))) notFound();
+  const viewerIsOwner = await isOwner(group.id, session.user.id);
 
   const pending = group.archivedAt
     ? []
@@ -31,6 +38,15 @@ export default async function GroupSettingsPage({ params }: Props) {
   }));
 
   const isArchived = group.archivedAt != null;
+
+  const members = await listApprovedMembers(group.id, 200);
+  const memberItems: MembersListItem[] = members.map((m) => ({
+    userId: m.userId,
+    name: m.name,
+    email: m.email,
+    image: m.image,
+    role: m.role,
+  }));
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-8">
@@ -53,50 +69,54 @@ export default async function GroupSettingsPage({ params }: Props) {
         </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Avatar</CardTitle>
-          <CardDescription>
-            Shown on group cards, the group page, and search results. PNG, JPEG, or WebP — up to 2 MB.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isArchived ? (
-            <p className="text-sm text-muted-foreground">
-              Restore this group to change the avatar.
-            </p>
-          ) : (
-            <div className="flex items-center gap-4">
-              <GroupAvatar group={group} size="lg" />
-              <AvatarUploadForm
-                endpoint={`/api/groups/${group.slug}/avatar`}
-                hasImage={Boolean(group.image)}
-                label="Group avatar"
-              />
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {viewerIsOwner ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Avatar</CardTitle>
+            <CardDescription>
+              Shown on group cards, the group page, and search results. PNG, JPEG, or WebP — up to 2 MB.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isArchived ? (
+              <p className="text-sm text-muted-foreground">
+                Restore this group to change the avatar.
+              </p>
+            ) : (
+              <div className="flex items-center gap-4">
+                <GroupAvatar group={group} size="lg" />
+                <AvatarUploadForm
+                  endpoint={`/api/groups/${group.slug}/avatar`}
+                  hasImage={Boolean(group.image)}
+                  label="Group avatar"
+                />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Membership</CardTitle>
-          <CardDescription>
-            {isArchived
-              ? "Archived groups are read-only. Restore the group to manage membership."
-              : "Control how new members join this group."}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isArchived ? (
-            <p className="text-sm text-muted-foreground">
-              Auto-approve is currently {group.autoApprove ? "on" : "off"}.
-            </p>
-          ) : (
-            <AutoApproveToggle slug={group.slug} initial={group.autoApprove} />
-          )}
-        </CardContent>
-      </Card>
+      {viewerIsOwner ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Membership</CardTitle>
+            <CardDescription>
+              {isArchived
+                ? "Archived groups are read-only. Restore the group to manage membership."
+                : "Control how new members join this group."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isArchived ? (
+              <p className="text-sm text-muted-foreground">
+                Auto-approve is currently {group.autoApprove ? "on" : "off"}.
+              </p>
+            ) : (
+              <AutoApproveToggle slug={group.slug} initial={group.autoApprove} />
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
 
       {isArchived ? null : (
         <Card>
@@ -116,17 +136,41 @@ export default async function GroupSettingsPage({ params }: Props) {
 
       <Card>
         <CardHeader>
-          <CardTitle>{isArchived ? "Restore" : "Danger zone"}</CardTitle>
+          <CardTitle>Members</CardTitle>
           <CardDescription>
             {isArchived
-              ? "Restore this group to make it read-write again. It will reappear in the default group list and search."
-              : "Archive this group to make it read-only. The page stays browsable so existing links keep working."}
+              ? "Archived groups are read-only. Restore the group to manage members."
+              : viewerIsOwner
+                ? "Promote, demote, or remove members."
+                : "Remove members from this group."}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ArchiveControls slug={group.slug} archived={isArchived} />
+          <MembersList
+            slug={group.slug}
+            viewerUserId={session.user.id}
+            viewerIsOwner={viewerIsOwner}
+            archived={isArchived}
+            members={memberItems}
+          />
         </CardContent>
       </Card>
+
+      {viewerIsOwner ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{isArchived ? "Restore" : "Danger zone"}</CardTitle>
+            <CardDescription>
+              {isArchived
+                ? "Restore this group to make it read-write again. It will reappear in the default group list and search."
+                : "Archive this group to make it read-only. The page stays browsable so existing links keep working."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ArchiveControls slug={group.slug} archived={isArchived} />
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/memberships.test.ts
+++ b/src/lib/memberships.test.ts
@@ -35,6 +35,7 @@ const {
   NotAMemberError,
   NotFoundError,
   removeMembership,
+  setMembershipRole,
   setMembershipStatus,
   SoleOwnerCannotLeaveError,
   transferOwnershipAndLeave,
@@ -333,7 +334,7 @@ describe("removeMembership", () => {
     expect(await getMembership(group.id, u.id)).toBeNull();
   });
 
-  it("moderator cannot remove another member", async () => {
+  it("moderator can remove another member", async () => {
     const { group } = await makeGroup(next("rm-mod"));
     const mod = await makeUser("mod");
     await db.membership.create({
@@ -341,9 +342,8 @@ describe("removeMembership", () => {
     });
     const u = await makeUser("victim");
     await applyToGroup(group.id, u.id);
-    await expect(removeMembership(group.id, u.id, mod.id)).rejects.toBeInstanceOf(
-      AuthorizationError,
-    );
+    await removeMembership(group.id, u.id, mod.id);
+    expect(await getMembership(group.id, u.id)).toBeNull();
   });
 
   it("non-owner non-mod cannot remove another", async () => {
@@ -370,6 +370,106 @@ describe("removeMembership", () => {
     await expect(removeMembership(group.id, ghost.id, owner.id)).rejects.toBeInstanceOf(
       NotFoundError,
     );
+  });
+});
+
+describe("setMembershipRole", () => {
+  it("owner can promote member to moderator", async () => {
+    const { owner, group } = await makeGroup(next("smr-promote"));
+    const u = await makeUser("promotee");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "member", status: "approved" },
+    });
+    const updated = await setMembershipRole(group.id, u.id, "moderator", owner.id);
+    expect(updated.role).toBe("moderator");
+  });
+
+  it("owner can demote moderator to member", async () => {
+    const { owner, group } = await makeGroup(next("smr-demote"));
+    const u = await makeUser("demotee");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "moderator", status: "approved" },
+    });
+    const updated = await setMembershipRole(group.id, u.id, "member", owner.id);
+    expect(updated.role).toBe("member");
+  });
+
+  it("moderator cannot change roles", async () => {
+    const { group } = await makeGroup(next("smr-mod-forbid"));
+    const mod = await makeUser("mod");
+    await db.membership.create({
+      data: { groupId: group.id, userId: mod.id, role: "moderator", status: "approved" },
+    });
+    const u = await makeUser("target");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "member", status: "approved" },
+    });
+    await expect(
+      setMembershipRole(group.id, u.id, "moderator", mod.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("non-member cannot change roles", async () => {
+    const { group } = await makeGroup(next("smr-stranger"));
+    const stranger = await makeUser("stranger-smr");
+    const u = await makeUser("target-smr");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "member", status: "approved" },
+    });
+    await expect(
+      setMembershipRole(group.id, u.id, "moderator", stranger.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("cannot change the owner's role", async () => {
+    const { owner, group } = await makeGroup(next("smr-owner"));
+    await expect(
+      setMembershipRole(group.id, owner.id, "moderator", owner.id),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("rejects when group is archived", async () => {
+    const { owner, group } = await makeGroup(next("smr-archived"));
+    const u = await makeUser("archived-target");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "member", status: "approved" },
+    });
+    await db.group.update({
+      where: { id: group.id },
+      data: { archivedAt: new Date() },
+    });
+    await expect(
+      setMembershipRole(group.id, u.id, "moderator", owner.id),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("throws NotFoundError for a missing target membership", async () => {
+    const { owner, group } = await makeGroup(next("smr-missing"));
+    const ghost = await makeUser("ghost-smr");
+    await expect(
+      setMembershipRole(group.id, ghost.id, "moderator", owner.id),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("rejects when target membership is not approved", async () => {
+    const { owner, group } = await makeGroup(next("smr-nonapproved"));
+    const u = await makeUser("pending-target");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "member", status: "pending" },
+    });
+    await expect(
+      setMembershipRole(group.id, u.id, "moderator", owner.id),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("is a no-op when role is already the requested value", async () => {
+    const { owner, group } = await makeGroup(next("smr-noop"));
+    const u = await makeUser("noop-smr");
+    await db.membership.create({
+      data: { groupId: group.id, userId: u.id, role: "moderator", status: "approved" },
+    });
+    const second = await setMembershipRole(group.id, u.id, "moderator", owner.id);
+    expect(second.role).toBe("moderator");
   });
 });
 

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -150,6 +150,36 @@ export async function setMembershipStatus(
   });
 }
 
+export async function setMembershipRole(
+  groupId: string,
+  targetUserId: string,
+  newRole: "member" | "moderator",
+  actorUserId: string,
+): Promise<Membership> {
+  await assertOwner(groupId, actorUserId);
+  const group = await db.group.findUnique({
+    where: { id: groupId },
+    select: { archivedAt: true },
+  });
+  if (!group) throw new NotFoundError("Group not found.");
+  if (group.archivedAt) {
+    throw new ConflictError("This group is archived and is read-only.");
+  }
+  const target = await getMembership(groupId, targetUserId);
+  if (!target) throw new NotFoundError("Membership not found.");
+  if (target.status !== "approved") {
+    throw new ConflictError("Cannot change the role of a non-approved membership.");
+  }
+  if (target.role === "owner") {
+    throw new AuthorizationError("The group owner's role cannot be changed.");
+  }
+  if (target.role === newRole) return target;
+  return db.membership.update({
+    where: { userId_groupId: { userId: targetUserId, groupId } },
+    data: { role: newRole },
+  });
+}
+
 export async function removeMembership(
   groupId: string,
   targetUserId: string,
@@ -163,7 +193,7 @@ export async function removeMembership(
   }
 
   if (actorUserId !== targetUserId) {
-    if (!(await isOwner(groupId, actorUserId))) {
+    if (!(await isOwnerOrModerator(groupId, actorUserId))) {
       throw new AuthorizationError();
     }
   }

--- a/src/lib/validation/memberships.ts
+++ b/src/lib/validation/memberships.ts
@@ -1,7 +1,24 @@
 import { z } from "zod";
 
-export const updateMembershipStatusSchema = z.object({
-  status: z.enum(["approved", "rejected"]),
-});
+export const updateMembershipStatusSchema = z
+  .object({
+    status: z.enum(["approved", "rejected"]),
+  })
+  .strict();
 
 export type UpdateMembershipStatusInput = z.infer<typeof updateMembershipStatusSchema>;
+
+export const updateMembershipRoleSchema = z
+  .object({
+    role: z.enum(["member", "moderator"]),
+  })
+  .strict();
+
+export type UpdateMembershipRoleInput = z.infer<typeof updateMembershipRoleSchema>;
+
+export const updateMembershipSchema = z.union([
+  updateMembershipStatusSchema,
+  updateMembershipRoleSchema,
+]);
+
+export type UpdateMembershipInput = z.infer<typeof updateMembershipSchema>;


### PR DESCRIPTION
## Summary
- Adds moderator-facing member management to group settings: promote / demote (owner-only) and remove (owner or moderator), with a confirmation prompt on remove.
- Backend: new `setMembershipRole` domain function; `PATCH /api/groups/:slug/membership/:userId` now accepts a strict Zod union of `{ status }` or `{ role: "member" | "moderator" }`; `removeMembership` widened so moderators can remove non-owner members.
- Owner is protected at every layer: cannot be demoted, cannot be removed, cannot be reached via the role payload (`role: "owner"` rejected by the schema).

Closes #49

## Review verdicts
- Architecture review: ACCEPT (after one fix — added `target.status === "approved"` guard in `setMembershipRole` to prevent promoting a non-approved member)
- Security review: ACCEPT (no blocking issues)
- Test coverage: ACCEPT (420/420 pass)

## Out of scope (follow-ups)
- Notifications for role changes / removal
- Pagination of the members management UI (currently capped at 200)
- Migrating `confirm()` to the shadcn `Dialog`
- `removeMembership` archive-guard parity (pre-existing gap, not introduced here)

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run build` — pass
- [x] `npm test` — 420/420 pass

Implemented by Claude Code multi-agent pipeline.