### PR TITLE
feat(csrf): token-based CSRF protection on mutating endpoints (closes #50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,11 @@ The plan in [PROJECT_PLAN.md](PROJECT_PLAN.md) is a proposal, not a decided cont
 - **Search dual-track**: SQLite FTS5 in dev and Postgres `tsvector` in prod, gated by a `DATABASE_PROVIDER` env. Plan code so the query layer can branch on this without leaking DB-specific SQL into route handlers.
 - **Notifications are pull-based for v1**: `Notification` rows are fanned out at write-time and polled by the client. WebSockets / push are explicitly out of scope.
 - **Authorization model**: membership status (`pending` / `approved` / `rejected`) and role (`member` / `moderator` / `owner`) on `Membership` are the basis for nearly every write check. Posting questions, posting answers, accepting answers, and approving applications all key off these — keep the check helpers centralized.
+- **CSRF protection (issue [#50](https://github.com/HundredAcreStudio/sme-directory/issues/50))**: double-submit cookie pattern. A non-httpOnly `sme_csrf` cookie is issued by [src/middleware.ts](src/middleware.ts) on the first non-mutating request (and rotated by `signIn` / cleared by `signOut`). The same middleware enforces a `x-csrf-token` header check on POST/PATCH/PUT/DELETE under `/api/*` and returns 403 on mismatch. New routes / actions inherit protection automatically as long as they follow these rules:
+  - **API route handlers** (`app/api/**`): nothing to do — middleware gates them. Tests bypass middleware so route unit tests don't need a token.
+  - **Client `fetch` callsites** that target `/api/*` with a mutating method: use `csrfFetch` from [src/lib/csrf-client.ts](src/lib/csrf-client.ts), or add `[CSRF_HEADER]: readCsrfToken()` to the headers object.
+  - **Server actions invoked via `<form action={...}>`**: render `<CsrfField />` (client) or `<CsrfInput />` (server) inside the form, then `await assertCsrf(formData)` at the top of the action. On `CsrfError`, return the error in form state — do not let it bubble.
+  - **Server actions invoked programmatically** (e.g. `await voteAction(...)` from a client component): accept a `csrfToken: string` argument, pass `readCsrfToken()` from the caller, and `await assertCsrfToken(csrfToken)` at the top of the action.
 
 ## Workflow conventions
 

--- a/src/app/groups/[slug]/actions.ts
+++ b/src/app/groups/[slug]/actions.ts
@@ -3,10 +3,12 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { assertCsrf } from "@/lib/csrf-server";
 import { getGroupBySlug } from "@/lib/groups";
 import { leaveGroup, transferOwnershipAndLeave } from "@/lib/memberships";
 
 export async function confirmLeaveAction(slug: string, formData: FormData): Promise<void> {
+  await assertCsrf(formData);
   const session = await getSession();
   if (!session) {
     redirect(`/login?returnTo=/groups/${slug}`);

--- a/src/app/groups/[slug]/ask/actions.ts
+++ b/src/app/groups/[slug]/ask/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { assertCsrf, CsrfError } from "@/lib/csrf-server";
 import { getGroupBySlug } from "@/lib/groups";
 import { assertApprovedMember, AuthorizationError } from "@/lib/memberships";
 import { createQuestion } from "@/lib/questions";
@@ -20,6 +21,12 @@ export async function createQuestionAction(
   _prev: AskQuestionState,
   formData: FormData,
 ): Promise<AskQuestionState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to post a question." };

--- a/src/app/groups/[slug]/ask/ask-question-form.tsx
+++ b/src/app/groups/[slug]/ask/ask-question-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { createQuestionAction, type AskQuestionState } from "./actions";
 
 const initialState: AskQuestionState = {};
@@ -17,6 +18,7 @@ export function AskQuestionForm({ slug }: Props) {
 
   return (
     <form action={formAction} className="space-y-5">
+      <CsrfField />
       <div className="space-y-1">
         <label htmlFor="title" className="block text-sm font-medium">
           Title

--- a/src/app/groups/[slug]/leave/page.tsx
+++ b/src/app/groups/[slug]/leave/page.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { CsrfInput } from "@/components/csrf-input";
 import { requireAuth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { getGroupBySlug } from "@/lib/groups";
@@ -78,6 +79,7 @@ function SimpleLeaveCard({ slug }: { slug: string }) {
       </CardHeader>
       <CardContent>
         <form action={confirmLeaveAction.bind(null, slug)} className="flex gap-2">
+          <CsrfInput />
           <Button type="submit" variant="destructive">
             Yes, leave
           </Button>
@@ -107,6 +109,7 @@ function SoleOwnerWithSuccessorsCard({
       </CardHeader>
       <CardContent>
         <form action={confirmLeaveAction.bind(null, slug)} className="space-y-4">
+          <CsrfInput />
           <div className="space-y-1">
             <label htmlFor="successorUserId" className="block text-sm font-medium">
               New owner

--- a/src/app/groups/[slug]/membership-actions.tsx
+++ b/src/app/groups/[slug]/membership-actions.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { csrfFetch } from "@/lib/csrf-client";
 
 type MembershipShape = {
   role: "member" | "moderator" | "owner";
@@ -54,7 +55,7 @@ export function MembershipActions({ slug, isAuthenticated, currentUserId, member
   async function apply() {
     setBusy(true);
     try {
-      const res = await fetch(`/api/groups/${slug}/membership`, { method: "POST" });
+      const res = await csrfFetch(`/api/groups/${slug}/membership`, { method: "POST" });
       if (!res.ok) {
         toast.error(await readError(res));
         return;
@@ -75,7 +76,7 @@ export function MembershipActions({ slug, isAuthenticated, currentUserId, member
     if (!currentUserId) return;
     setBusy(true);
     try {
-      const res = await fetch(`/api/groups/${slug}/membership/${currentUserId}`, {
+      const res = await csrfFetch(`/api/groups/${slug}/membership/${currentUserId}`, {
         method: "DELETE",
       });
       if (!res.ok) {

--- a/src/app/groups/[slug]/settings/actions.ts
+++ b/src/app/groups/[slug]/settings/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import { assertCsrf, assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { archiveGroup, unarchiveGroup, updateGroup } from "@/lib/groups";
 import { AuthorizationError, ConflictError, NotFoundError } from "@/lib/memberships";
 
@@ -14,6 +15,12 @@ export async function toggleAutoApproveAction(
   _prev: ToggleAutoApproveState,
   formData: FormData,
 ): Promise<ToggleAutoApproveState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) return { error: "You must be signed in." };
 
@@ -43,7 +50,13 @@ export async function toggleAutoApproveAction(
 
 export type ArchiveActionResult = { error?: string; ok?: true };
 
-export async function archiveGroupAction(slug: string): Promise<ArchiveActionResult> {
+export async function archiveGroupAction(slug: string, csrfToken: string): Promise<ArchiveActionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) return { error: "You must be signed in." };
 
@@ -69,7 +82,13 @@ export async function archiveGroupAction(slug: string): Promise<ArchiveActionRes
   }
 }
 
-export async function unarchiveGroupAction(slug: string): Promise<ArchiveActionResult> {
+export async function unarchiveGroupAction(slug: string, csrfToken: string): Promise<ArchiveActionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) return { error: "You must be signed in." };
 

--- a/src/app/groups/[slug]/settings/archive-controls.tsx
+++ b/src/app/groups/[slug]/settings/archive-controls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { archiveGroupAction, unarchiveGroupAction } from "./actions";
 
 type Props = {
@@ -22,7 +23,7 @@ export function ArchiveControls({ slug, archived }: Props) {
     }
     setError(null);
     startTransition(async () => {
-      const result = await archiveGroupAction(slug);
+      const result = await archiveGroupAction(slug, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };
@@ -30,7 +31,7 @@ export function ArchiveControls({ slug, archived }: Props) {
   const onUnarchive = () => {
     setError(null);
     startTransition(async () => {
-      const result = await unarchiveGroupAction(slug);
+      const result = await unarchiveGroupAction(slug, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };

--- a/src/app/groups/[slug]/settings/auto-approve-toggle.tsx
+++ b/src/app/groups/[slug]/settings/auto-approve-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState, useEffect, useRef } from "react";
 import { toast } from "sonner";
+import { CsrfField } from "@/components/csrf-field";
 import { toggleAutoApproveAction, type ToggleAutoApproveState } from "./actions";
 
 const initialState: ToggleAutoApproveState = {};
@@ -24,6 +25,7 @@ export function AutoApproveToggle({ slug, initial }: Props) {
       action={formAction}
       className="flex items-center justify-between gap-4 rounded-md border p-4"
     >
+      <CsrfField />
       <input type="hidden" name="slug" value={slug} />
       <div className="space-y-0.5">
         <label htmlFor="autoApprove" className="text-sm font-medium">

--- a/src/app/groups/[slug]/settings/pending-applications-list.tsx
+++ b/src/app/groups/[slug]/settings/pending-applications-list.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { CSRF_HEADER, readCsrfToken } from "@/lib/csrf-client";
 
 export type PendingApplicationView = {
   userId: string;
@@ -39,7 +40,10 @@ export function PendingApplicationsList({ slug, applications }: Props) {
     try {
       const res = await fetch(`/api/groups/${slug}/membership/${userId}`, {
         method: "PATCH",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          [CSRF_HEADER]: readCsrfToken(),
+        },
         body: JSON.stringify({ status }),
       });
       if (!res.ok) {

--- a/src/app/groups/new/actions.ts
+++ b/src/app/groups/new/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { assertCsrf, CsrfError } from "@/lib/csrf-server";
 import { createGroup, SlugConflictError } from "@/lib/groups";
 import { createGroupSchema } from "@/lib/validation/groups";
 
@@ -17,6 +18,12 @@ export async function createGroupAction(
   _prev: CreateGroupState,
   formData: FormData,
 ): Promise<CreateGroupState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to create a group." };

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useState } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { slugify } from "@/lib/slug";
 import { createGroupAction, type CreateGroupState } from "./actions";
 
@@ -18,6 +19,7 @@ export function NewGroupForm() {
 
   return (
     <form action={formAction} className="space-y-5">
+      <CsrfField />
       <div className="space-y-1">
         <label htmlFor="name" className="block text-sm font-medium">
           Name

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -2,10 +2,17 @@
 
 import { redirect } from "next/navigation";
 import { signIn, signOut } from "@/lib/auth";
+import { assertCsrf, CsrfError } from "@/lib/csrf-server";
 
 export type SignInState = { error?: string };
 
 export async function signInAction(_prev: SignInState, formData: FormData): Promise<SignInState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const email = String(formData.get("email") ?? "");
   try {
     await signIn(email);
@@ -15,7 +22,8 @@ export async function signInAction(_prev: SignInState, formData: FormData): Prom
   redirect("/account");
 }
 
-export async function signOutAction(): Promise<void> {
+export async function signOutAction(formData: FormData): Promise<void> {
+  await assertCsrf(formData);
   await signOut();
   redirect("/");
 }

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { signInAction, type SignInState } from "./actions";
 
 const initialState: SignInState = {};
@@ -10,6 +11,7 @@ export function LoginForm() {
 
   return (
     <form action={formAction} className="space-y-4">
+      <CsrfField />
       <div className="space-y-1">
         <label htmlFor="email" className="block text-sm font-medium">
           Email

--- a/src/app/me/actions.ts
+++ b/src/app/me/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import { assertCsrf, CsrfError } from "@/lib/csrf-server";
 import { updateUserProfile } from "@/lib/profile";
 import { updateMeSchema } from "@/lib/validation/users";
 
@@ -18,6 +19,12 @@ export async function updateMeAction(
   _prev: MeFormState,
   formData: FormData,
 ): Promise<MeFormState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to edit your profile." };

--- a/src/app/me/edit-profile-form.tsx
+++ b/src/app/me/edit-profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useEffect, useState } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { MarkdownBody } from "@/components/markdown-body";
 import { updateMeAction, type MeFormState } from "./actions";
 
@@ -29,6 +30,7 @@ export function EditProfileForm({ name, bio }: Props) {
   if (editing) {
     return (
       <form action={formAction} className="space-y-3">
+        <CsrfField />
         <div className="space-y-1">
           <label htmlFor="edit-profile-name" className="block text-sm font-medium">
             Name

--- a/src/app/notifications/notifications-controls.tsx
+++ b/src/app/notifications/notifications-controls.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
+import { csrfFetch } from "@/lib/csrf-client";
 import { NOTIFICATION_CATEGORIES, type NotificationCategory } from "@/lib/notification-categories";
 
 type Props = {
@@ -59,7 +60,7 @@ export function NotificationsControls({ selectedTypes, unreadOnly, per, hasUnrea
 
   async function markAllRead() {
     try {
-      const res = await fetch("/api/notifications/read-all", { method: "POST" });
+      const res = await csrfFetch("/api/notifications/read-all", { method: "POST" });
       if (!res.ok) return;
       router.refresh();
     } catch {
@@ -164,7 +165,7 @@ export function MarkRowReadButton({
 
   async function onClick() {
     try {
-      const res = await fetch(`/api/notifications/${id}/read`, { method: "POST" });
+      const res = await csrfFetch(`/api/notifications/${id}/read`, { method: "POST" });
       if (!res.ok) return;
       startTransition(() => router.refresh());
     } catch {

--- a/src/app/q/[id]/accept-answer-button.tsx
+++ b/src/app/q/[id]/accept-answer-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { acceptAnswerAction } from "./actions";
 
 type Props = {
@@ -15,7 +16,7 @@ export function AcceptAnswerButton({ questionId, answerId }: Props) {
   const onClick = () => {
     setError(null);
     startTransition(async () => {
-      const result = await acceptAnswerAction(questionId, answerId);
+      const result = await acceptAnswerAction(questionId, answerId, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import { assertCsrf, assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import {
   AuthorizationError,
   NotFoundError,
@@ -39,6 +40,12 @@ export async function createAnswerAction(
   _prev: AnswerFormState,
   formData: FormData,
 ): Promise<AnswerFormState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to post an answer." };
@@ -92,6 +99,12 @@ export async function updateAnswerAction(
   _prev: AnswerFormState,
   formData: FormData,
 ): Promise<AnswerFormState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to edit an answer." };
@@ -140,6 +153,12 @@ export async function updateQuestionAction(
   _prev: QuestionFormState,
   formData: FormData,
 ): Promise<QuestionFormState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to edit a question." };
@@ -184,7 +203,14 @@ export type ResolveQuestionResult = { error?: string; ok?: boolean };
 export async function acceptAnswerAction(
   questionId: string,
   answerId: string | null,
+  csrfToken: string,
 ): Promise<ResolveQuestionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to mark a question as answered." };
@@ -213,7 +239,14 @@ export async function acceptAnswerAction(
 
 export async function reopenQuestionAction(
   questionId: string,
+  csrfToken: string,
 ): Promise<ResolveQuestionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to reopen a question." };
@@ -244,7 +277,14 @@ export type DeleteQuestionResult = { error?: string; ok?: boolean };
 
 export async function deleteQuestionAction(
   questionId: string,
+  csrfToken: string,
 ): Promise<DeleteQuestionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to delete a question." };
@@ -279,7 +319,14 @@ export type DeleteAnswerResult = { error?: string; ok?: boolean };
 export async function deleteAnswerAction(
   answerId: string,
   questionId: string,
+  csrfToken: string,
 ): Promise<DeleteAnswerResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to delete an answer." };

--- a/src/app/q/[id]/answer-actions.tsx
+++ b/src/app/q/[id]/answer-actions.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useActionState, useEffect, useState, useTransition } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { MarkdownBody } from "@/components/markdown-body";
+import { readCsrfToken } from "@/lib/csrf-client";
 import {
   deleteAnswerAction,
   updateAnswerAction,
@@ -51,7 +53,7 @@ export function AnswerActions({
     if (!confirm("Delete this answer? This cannot be undone.")) return;
     setDeleteError(null);
     startDelete(async () => {
-      const result = await deleteAnswerAction(answerId, questionId);
+      const result = await deleteAnswerAction(answerId, questionId, readCsrfToken());
       if (result.error) setDeleteError(result.error);
     });
   };
@@ -59,6 +61,7 @@ export function AnswerActions({
   if (editing) {
     return (
       <form action={editFormAction} className="space-y-2">
+        <CsrfField />
         <textarea
           name="body"
           rows={6}

--- a/src/app/q/[id]/answer-form.tsx
+++ b/src/app/q/[id]/answer-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useEffect, useRef } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { createAnswerAction, type AnswerFormState } from "./actions";
 
 const initialState: AnswerFormState = {};
@@ -24,6 +25,7 @@ export function AnswerForm({ questionId }: Props) {
 
   return (
     <form ref={formRef} action={formAction} className="space-y-3">
+      <CsrfField />
       <div className="space-y-1">
         <label htmlFor="answer-body" className="block text-sm font-medium">
           Your answer <span className="text-zinc-500">(Markdown supported)</span>

--- a/src/app/q/[id]/edit-question-form.tsx
+++ b/src/app/q/[id]/edit-question-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useEffect, useState } from "react";
+import { CsrfField } from "@/components/csrf-field";
 import { MarkdownBody } from "@/components/markdown-body";
 import { updateQuestionAction, type QuestionFormState } from "./actions";
 
@@ -33,6 +34,7 @@ export function EditQuestionForm({ questionId, title, body, canEdit }: Props) {
   if (editing) {
     return (
       <form action={formAction} className="space-y-3">
+        <CsrfField />
         <div className="space-y-1">
           <label htmlFor="edit-question-title" className="block text-sm font-medium">
             Title

--- a/src/app/q/[id]/favorite-actions.ts
+++ b/src/app/q/[id]/favorite-actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import { assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { NotFoundError } from "@/lib/memberships";
 import { toggleFavorite, type FavoriteTargetType } from "@/lib/favorites";
 
@@ -13,7 +14,14 @@ export async function favoriteAction(
   targetType: FavoriteTargetType,
   targetId: string,
   questionId: string,
+  csrfToken: string,
 ): Promise<FavoriteActionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { ok: false, error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { ok: false, error: "You must be signed in to favorite." };

--- a/src/app/q/[id]/favorite-button.tsx
+++ b/src/app/q/[id]/favorite-button.tsx
@@ -2,6 +2,7 @@
 
 import { StarIcon } from "lucide-react";
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { favoriteAction } from "./favorite-actions";
 import type { FavoriteTargetType } from "@/lib/favorites";
 
@@ -33,7 +34,7 @@ export function FavoriteButton({
     setFavorited(!prevFavorited);
 
     startTransition(async () => {
-      const result = await favoriteAction(targetType, targetId, questionId);
+      const result = await favoriteAction(targetType, targetId, questionId, readCsrfToken());
       if (result.ok) {
         setFavorited(result.favorited);
       } else {

--- a/src/app/q/[id]/question-delete-button.tsx
+++ b/src/app/q/[id]/question-delete-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { deleteQuestionAction } from "./actions";
 
 type Props = {
@@ -21,7 +22,7 @@ export function QuestionDeleteButton({ questionId }: Props) {
     }
     setError(null);
     startTransition(async () => {
-      const result = await deleteQuestionAction(questionId);
+      const result = await deleteQuestionAction(questionId, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };

--- a/src/app/q/[id]/question-resolve-controls.tsx
+++ b/src/app/q/[id]/question-resolve-controls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { acceptAnswerAction, reopenQuestionAction } from "./actions";
 
 type Props = {
@@ -30,7 +31,7 @@ export function QuestionResolveControls({
   const onMarkAnswered = () => {
     setError(null);
     startTransition(async () => {
-      const result = await acceptAnswerAction(questionId, null);
+      const result = await acceptAnswerAction(questionId, null, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };
@@ -38,7 +39,7 @@ export function QuestionResolveControls({
   const onReopen = () => {
     setError(null);
     startTransition(async () => {
-      const result = await reopenQuestionAction(questionId);
+      const result = await reopenQuestionAction(questionId, readCsrfToken());
       if (result.error) setError(result.error);
     });
   };

--- a/src/app/q/[id]/vote-actions.ts
+++ b/src/app/q/[id]/vote-actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import { assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { AuthorizationError, NotFoundError } from "@/lib/memberships";
 import { castVote, type VoteTargetType } from "@/lib/votes";
 
@@ -13,7 +14,14 @@ export async function voteAction(
   targetType: VoteTargetType,
   targetId: string,
   questionId: string,
+  csrfToken: string,
 ): Promise<VoteActionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { ok: false, error: err.message };
+    throw err;
+  }
   const session = await getSession();
   if (!session) {
     return { ok: false, error: "You must be signed in to vote." };

--- a/src/app/q/[id]/vote-button.tsx
+++ b/src/app/q/[id]/vote-button.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronUpIcon } from "lucide-react";
 import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
 import { voteAction } from "./vote-actions";
 import type { VoteTargetType } from "@/lib/votes";
 
@@ -39,7 +40,7 @@ export function VoteButton({
     setVoted(!prevVoted);
 
     startTransition(async () => {
-      const result = await voteAction(targetType, targetId, questionId);
+      const result = await voteAction(targetType, targetId, questionId, readCsrfToken());
       if (result.ok) {
         setScore(result.voteScore);
         setVoted(result.voted);

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { signOutAction } from "@/app/login/actions";
 import { Button } from "@/components/ui/button";
+import { CsrfField } from "@/components/csrf-field";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   DropdownMenu,
@@ -64,6 +65,7 @@ export function UserMenu() {
         <DropdownMenuItem render={<Link href="/account" />}>Account</DropdownMenuItem>
         <DropdownMenuSeparator />
         <form action={signOutAction}>
+          <CsrfField />
           <DropdownMenuItem render={<button type="submit" className="w-full" />}>
             Sign out
           </DropdownMenuItem>

--- a/src/components/avatar/avatar-upload-form.tsx
+++ b/src/components/avatar/avatar-upload-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { csrfFetch } from "@/lib/csrf-client";
 
 const ALLOWED_MIME = ["image/png", "image/jpeg", "image/webp"];
 const MAX_BYTES = 2 * 1024 * 1024;
@@ -39,7 +40,7 @@ export function AvatarUploadForm({ endpoint, hasImage = false, label = "Avatar" 
     try {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch(endpoint, { method: "POST", body: form });
+      const res = await csrfFetch(endpoint, { method: "POST", body: form });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         toast.error(data.message ?? data.error ?? `Upload failed (${res.status}).`);
@@ -56,7 +57,7 @@ export function AvatarUploadForm({ endpoint, hasImage = false, label = "Avatar" 
   async function onRemove() {
     setSubmitting(true);
     try {
-      const res = await fetch(endpoint, { method: "DELETE" });
+      const res = await csrfFetch(endpoint, { method: "DELETE" });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         toast.error(data.message ?? data.error ?? `Remove failed (${res.status}).`);

--- a/src/components/csrf-field.tsx
+++ b/src/components/csrf-field.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CSRF_FIELD, readCsrfToken } from "@/lib/csrf-client";
+
+/**
+ * Hidden form field that carries the double-submit CSRF token.
+ *
+ * Reads the `sme_csrf` cookie on mount (the cookie is non-httpOnly so the
+ * client can echo it back). Server-rendered HTML emits an empty value to
+ * avoid a hydration mismatch — by the time a user can submit, the effect has
+ * populated the real token.
+ */
+export function CsrfField(): React.ReactElement {
+  const [token, setToken] = useState("");
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setToken(readCsrfToken());
+  }, []);
+  return <input type="hidden" name={CSRF_FIELD} value={token} />;
+}

--- a/src/components/csrf-input.tsx
+++ b/src/components/csrf-input.tsx
@@ -1,0 +1,7 @@
+import { CSRF_FIELD } from "@/lib/csrf";
+import { getCsrfToken } from "@/lib/csrf-server";
+
+export async function CsrfInput(): Promise<React.ReactElement> {
+  const token = (await getCsrfToken()) ?? "";
+  return <input type="hidden" name={CSRF_FIELD} value={token} />;
+}

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useSession } from "@/lib/auth-client";
+import { csrfFetch } from "@/lib/csrf-client";
 import type {
   NotificationListResult,
   ParsedNotification,
@@ -148,7 +149,7 @@ export function NotificationBell() {
       prev.map((n) => (n.id === id && !n.readAt ? { ...n, readAt: new Date().toISOString() } : n)),
     );
     setUnreadCount((prev) => Math.max(0, prev - 1));
-    void fetch(`/api/notifications/${id}/read`, { method: "POST" }).catch(() => {});
+    void csrfFetch(`/api/notifications/${id}/read`, { method: "POST" }).catch(() => {});
   }, []);
 
   const handleMarkAllRead = useCallback(async () => {
@@ -157,7 +158,7 @@ export function NotificationBell() {
     );
     setUnreadCount(0);
     try {
-      await fetch("/api/notifications/read-all", { method: "POST" });
+      await csrfFetch("/api/notifications/read-all", { method: "POST" });
     } catch {
       // optimistic update already applied; refetch to reconcile if it failed
       void fetchNotifications();

--- a/src/components/notification-preferences-control.tsx
+++ b/src/components/notification-preferences-control.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 
+import { CSRF_HEADER, readCsrfToken } from "@/lib/csrf-client";
 import {
   NOTIFICATION_CATEGORIES,
   type NotificationCategory,
@@ -33,7 +34,10 @@ export function NotificationPreferencesControl({
     try {
       const res = await fetch(`/api/notification-preferences/${groupId}`, {
         method: "PUT",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          [CSRF_HEADER]: readCsrfToken(),
+        },
         body: JSON.stringify({ mutedTypes: next }),
       });
       if (!res.ok) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { SignJWT, jwtVerify } from "jose";
 import { db } from "@/lib/db";
+import { CSRF_COOKIE, generateCsrfToken } from "@/lib/csrf";
 
 export type Session = {
   user: {
@@ -73,6 +74,16 @@ async function writeSessionCookie(session: Session): Promise<void> {
     path: "/",
     maxAge: SESSION_MAX_AGE_SECONDS,
   });
+  // Issue a fresh CSRF token alongside the session so the double-submit cookie
+  // is rotated on every sign-in (the middleware also issues one for anonymous
+  // visits, but we rotate here so a recycled browser starts a clean session).
+  store.set(CSRF_COOKIE, generateCsrfToken(), {
+    httpOnly: false,
+    sameSite: "lax",
+    secure: isProduction(),
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
 }
 
 export async function getSession(): Promise<Session | null> {
@@ -129,4 +140,5 @@ export async function refreshSession(): Promise<Session | null> {
 export async function signOut(): Promise<void> {
   const store = await cookies();
   store.delete(SESSION_COOKIE);
+  store.delete(CSRF_COOKIE);
 }

--- a/src/lib/csrf-client.ts
+++ b/src/lib/csrf-client.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { CSRF_COOKIE, CSRF_FIELD, CSRF_HEADER } from "@/lib/csrf";
+
+export { CSRF_FIELD, CSRF_HEADER };
+
+export function readCsrfToken(): string {
+  if (typeof document === "undefined") return "";
+  const match = document.cookie.match(new RegExp("(?:^|; )" + CSRF_COOKIE + "=([^;]+)"));
+  return match ? decodeURIComponent(match[1]!) : "";
+}
+
+export function csrfHeaders(extra?: HeadersInit): Headers {
+  const headers = new Headers(extra);
+  headers.set(CSRF_HEADER, readCsrfToken());
+  return headers;
+}
+
+export function csrfFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  return fetch(input, { ...init, headers: csrfHeaders(init.headers) });
+}

--- a/src/lib/csrf-server.test.ts
+++ b/src/lib/csrf-server.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the server-side CSRF helpers used by Server Actions.
+ *
+ * Stubs `next/headers` cookies() with an in-memory Map (same shape used by
+ * auth.test.ts) so we can exercise assertCsrf / assertCsrfToken without
+ * spinning up Next.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CSRF_COOKIE, CSRF_FIELD, generateCsrfToken } from "./csrf";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+const csrfServer = await import("./csrf-server");
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+describe("assertCsrf (form-driven)", () => {
+  it("throws CsrfError when the cookie is missing", async () => {
+    const fd = new FormData();
+    fd.set(CSRF_FIELD, generateCsrfToken());
+    await expect(csrfServer.assertCsrf(fd)).rejects.toBeInstanceOf(csrfServer.CsrfError);
+  });
+
+  it("throws CsrfError when the form field is missing", async () => {
+    const token = generateCsrfToken();
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: token });
+    const fd = new FormData();
+    await expect(csrfServer.assertCsrf(fd)).rejects.toBeInstanceOf(csrfServer.CsrfError);
+  });
+
+  it("throws CsrfError when the field does not match the cookie", async () => {
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: generateCsrfToken() });
+    const fd = new FormData();
+    fd.set(CSRF_FIELD, generateCsrfToken());
+    await expect(csrfServer.assertCsrf(fd)).rejects.toBeInstanceOf(csrfServer.CsrfError);
+  });
+
+  it("resolves when the field matches the cookie", async () => {
+    const token = generateCsrfToken();
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: token });
+    const fd = new FormData();
+    fd.set(CSRF_FIELD, token);
+    await expect(csrfServer.assertCsrf(fd)).resolves.toBeUndefined();
+  });
+});
+
+describe("assertCsrfToken (programmatic)", () => {
+  it("throws when the provided token is null/empty", async () => {
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: generateCsrfToken() });
+    await expect(csrfServer.assertCsrfToken(null)).rejects.toBeInstanceOf(csrfServer.CsrfError);
+    await expect(csrfServer.assertCsrfToken("")).rejects.toBeInstanceOf(csrfServer.CsrfError);
+  });
+
+  it("throws when the provided token does not match the cookie", async () => {
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: generateCsrfToken() });
+    await expect(csrfServer.assertCsrfToken(generateCsrfToken())).rejects.toBeInstanceOf(
+      csrfServer.CsrfError,
+    );
+  });
+
+  it("resolves when the provided token matches the cookie", async () => {
+    const token = generateCsrfToken();
+    cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value: token });
+    await expect(csrfServer.assertCsrfToken(token)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/csrf-server.ts
+++ b/src/lib/csrf-server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { CSRF_COOKIE, CSRF_FIELD, verifyCsrfToken } from "@/lib/csrf";
+
+export class CsrfError extends Error {
+  constructor(message = "Invalid or missing CSRF token.") {
+    super(message);
+    this.name = "CsrfError";
+  }
+}
+
+export async function getCsrfToken(): Promise<string | null> {
+  const store = await cookies();
+  return store.get(CSRF_COOKIE)?.value ?? null;
+}
+
+export async function clearCsrfCookie(): Promise<void> {
+  const store = await cookies();
+  store.delete(CSRF_COOKIE);
+}
+
+export async function assertCsrf(formData: FormData): Promise<void> {
+  const provided = formData.get(CSRF_FIELD);
+  await assertCsrfToken(typeof provided === "string" ? provided : null);
+}
+
+export async function assertCsrfToken(token: string | null | undefined): Promise<void> {
+  const expected = await getCsrfToken();
+  if (!verifyCsrfToken(token ?? null, expected)) {
+    throw new CsrfError();
+  }
+}

--- a/src/lib/csrf.test.ts
+++ b/src/lib/csrf.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure-helpers test for the CSRF library.
+ *
+ * Exercises:
+ *   - generateCsrfToken: shape (lowercase hex, 64 chars)
+ *   - isValidTokenShape: rejects junk
+ *   - verifyCsrfToken: constant-time compare semantics
+ *   - csrfRequiresCheck: gates POST/PATCH/PUT/DELETE under /api/* only
+ */
+import { describe, expect, it } from "vitest";
+import { csrfRequiresCheck, generateCsrfToken, isValidTokenShape, verifyCsrfToken } from "./csrf";
+
+describe("generateCsrfToken", () => {
+  it("returns a 64-char lowercase hex string", () => {
+    const token = generateCsrfToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns distinct values across calls", () => {
+    const a = generateCsrfToken();
+    const b = generateCsrfToken();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("isValidTokenShape", () => {
+  it.each([
+    [null, false],
+    [undefined, false],
+    ["", false],
+    ["not-hex-but-long-enough-to-fool-a-naive-length-check-aaaaaaaaaaaaa", false],
+    ["A".repeat(64), false], // uppercase hex is rejected
+    ["0".repeat(63), false],
+    ["0".repeat(65), false],
+    ["0".repeat(64), true],
+    ["abcdef" + "0".repeat(58), true],
+  ])("isValidTokenShape(%p) === %p", (input, expected) => {
+    expect(isValidTokenShape(input)).toBe(expected);
+  });
+});
+
+describe("verifyCsrfToken", () => {
+  const valid = "a".repeat(64);
+
+  it("returns false when either token is missing", () => {
+    expect(verifyCsrfToken(null, valid)).toBe(false);
+    expect(verifyCsrfToken(valid, null)).toBe(false);
+    expect(verifyCsrfToken(null, null)).toBe(false);
+  });
+
+  it("returns false when shapes are invalid", () => {
+    expect(verifyCsrfToken("short", "short")).toBe(false);
+    expect(verifyCsrfToken(valid, "X".repeat(64))).toBe(false);
+  });
+
+  it("returns false when tokens differ", () => {
+    expect(verifyCsrfToken(valid, "b".repeat(64))).toBe(false);
+  });
+
+  it("returns true when tokens match exactly", () => {
+    expect(verifyCsrfToken(valid, valid)).toBe(true);
+  });
+});
+
+describe("csrfRequiresCheck", () => {
+  it.each([
+    ["GET", "/api/foo", false],
+    ["HEAD", "/api/foo", false],
+    ["OPTIONS", "/api/foo", false],
+    ["POST", "/", false],
+    ["POST", "/me", false],
+    ["POST", "/api", true],
+    ["POST", "/api/foo", true],
+    ["PATCH", "/api/foo/bar", true],
+    ["PUT", "/api/notification-preferences/abc", true],
+    ["DELETE", "/api/groups/x/membership/y", true],
+    ["post", "/api/foo", true], // case-insensitive method
+  ])("csrfRequiresCheck(%p, %p) === %p", (method, path, expected) => {
+    expect(csrfRequiresCheck(method, path)).toBe(expected);
+  });
+});

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -1,0 +1,57 @@
+/**
+ * CSRF protection — double-submit cookie pattern.
+ *
+ * The `sme_csrf` cookie is issued by the middleware on the first request that
+ * does not already carry one and refreshed via `signOut` (which clears it).
+ * It is intentionally NOT httpOnly so the client can echo it back via the
+ * `x-csrf-token` header (for `fetch`) or a `_csrf` form field (for forms /
+ * server actions). The middleware enforces the header check on POST/PATCH/
+ * PUT/DELETE under `/api/*`. Server actions validate the form field via
+ * `assertCsrf(formData)`.
+ *
+ * Keep the constants and pure-helpers in this file so both the Edge runtime
+ * (middleware) and the Node runtime (route handlers, server actions, RSC) can
+ * share them without dragging in `next/headers`.
+ */
+export const CSRF_COOKIE = "sme_csrf";
+export const CSRF_HEADER = "x-csrf-token";
+export const CSRF_FIELD = "_csrf";
+
+const TOKEN_BYTES = 32;
+const HEX_TOKEN_LENGTH = TOKEN_BYTES * 2;
+
+export function generateCsrfToken(): string {
+  const bytes = new Uint8Array(TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i]!.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+export function isValidTokenShape(token: string | null | undefined): token is string {
+  if (typeof token !== "string") return false;
+  if (token.length !== HEX_TOKEN_LENGTH) return false;
+  return /^[0-9a-f]+$/.test(token);
+}
+
+export function verifyCsrfToken(
+  provided: string | null | undefined,
+  expected: string | null | undefined,
+): boolean {
+  if (!isValidTokenShape(provided) || !isValidTokenShape(expected)) return false;
+  if (provided.length !== expected.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < provided.length; i += 1) {
+    mismatch |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+const MUTATING_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+export function csrfRequiresCheck(method: string, pathname: string): boolean {
+  if (!MUTATING_METHODS.has(method.toUpperCase())) return false;
+  return pathname === "/api" || pathname.startsWith("/api/");
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Middleware CSRF tests.
+ *
+ * The middleware is the only place that enforces CSRF on `/api/*` mutating
+ * requests. We send synthetic `NextRequest`s through it and assert that
+ * missing / mismatched tokens are 403 while valid tokens (header echo of the
+ * `sme_csrf` cookie) pass through.
+ */
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "./middleware";
+import { CSRF_COOKIE, CSRF_HEADER, generateCsrfToken } from "@/lib/csrf";
+
+function makeRequest(opts: {
+  method: string;
+  path: string;
+  cookieToken?: string | null;
+  headerToken?: string | null;
+}): NextRequest {
+  const url = new URL(`http://localhost${opts.path}`);
+  const headers = new Headers();
+  if (opts.headerToken !== undefined && opts.headerToken !== null) {
+    headers.set(CSRF_HEADER, opts.headerToken);
+  }
+  if (opts.cookieToken !== undefined && opts.cookieToken !== null) {
+    headers.set("cookie", `${CSRF_COOKIE}=${opts.cookieToken}`);
+  }
+  return new NextRequest(url, { method: opts.method, headers });
+}
+
+describe("middleware CSRF enforcement on /api/*", () => {
+  it("returns 403 when both cookie and header are missing on POST", async () => {
+    const res = middleware(makeRequest({ method: "POST", path: "/api/favorites" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("CsrfFailed");
+  });
+
+  it("returns 403 when only the header is missing", () => {
+    const token = generateCsrfToken();
+    const res = middleware(
+      makeRequest({
+        method: "POST",
+        path: "/api/favorites",
+        cookieToken: token,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when only the cookie is missing", () => {
+    const token = generateCsrfToken();
+    const res = middleware(
+      makeRequest({
+        method: "POST",
+        path: "/api/favorites",
+        headerToken: token,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when header and cookie do not match", () => {
+    const res = middleware(
+      makeRequest({
+        method: "POST",
+        path: "/api/favorites",
+        cookieToken: generateCsrfToken(),
+        headerToken: generateCsrfToken(),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the header is malformed", () => {
+    const token = generateCsrfToken();
+    const res = middleware(
+      makeRequest({
+        method: "POST",
+        path: "/api/favorites",
+        cookieToken: token,
+        headerToken: "not-a-valid-token",
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it.each(["POST", "PATCH", "PUT", "DELETE"])("passes through %s when token matches", (method) => {
+    const token = generateCsrfToken();
+    const res = middleware(
+      makeRequest({
+        method,
+        path: "/api/favorites",
+        cookieToken: token,
+        headerToken: token,
+      }),
+    );
+    // Pass-through: status 200 (default for NextResponse.next()).
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("middleware CSRF token issuance", () => {
+  it("issues a fresh sme_csrf cookie on a non-mutating request without one", () => {
+    const res = middleware(makeRequest({ method: "GET", path: "/" }));
+    const setCookie = res.cookies.get(CSRF_COOKIE);
+    expect(setCookie).toBeDefined();
+    expect(setCookie!.value).toMatch(/^[0-9a-f]{64}$/);
+    expect(setCookie!.httpOnly).toBe(false);
+    expect(setCookie!.sameSite).toBe("lax");
+  });
+
+  it("does not rotate the cookie when one already exists", () => {
+    const existing = generateCsrfToken();
+    const res = middleware(makeRequest({ method: "GET", path: "/groups", cookieToken: existing }));
+    expect(res.cookies.get(CSRF_COOKIE)).toBeUndefined();
+  });
+
+  it("does not validate the token on non-/api/ POSTs (server actions)", () => {
+    const res = middleware(
+      makeRequest({ method: "POST", path: "/me", cookieToken: generateCsrfToken() }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("does not validate the token on /api/ GETs", () => {
+    const res = middleware(makeRequest({ method: "GET", path: "/api/notifications" }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  CSRF_COOKIE,
+  CSRF_HEADER,
+  csrfRequiresCheck,
+  generateCsrfToken,
+  verifyCsrfToken,
+} from "@/lib/csrf";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+export function middleware(req: NextRequest): NextResponse {
+  const existing = req.cookies.get(CSRF_COOKIE)?.value ?? null;
+  const isMutatingApi = csrfRequiresCheck(req.method, req.nextUrl.pathname);
+
+  if (isMutatingApi) {
+    const provided = req.headers.get(CSRF_HEADER);
+    if (!verifyCsrfToken(provided, existing)) {
+      return NextResponse.json(
+        { error: "CsrfFailed", message: "Invalid or missing CSRF token." },
+        { status: 403 },
+      );
+    }
+    // Token is valid — pass through without rotating it.
+    return NextResponse.next();
+  }
+
+  // Non-mutating request. Issue a token if the user does not already have one
+  // so that subsequent forms / fetches can echo it back.
+  if (existing) {
+    return NextResponse.next();
+  }
+
+  const token = generateCsrfToken();
+  // Forward the new cookie on the request as well so RSC `cookies()` calls in
+  // this same render see it (otherwise the first page render after a fresh
+  // visit would not have the token available for forms).
+  const requestHeaders = new Headers(req.headers);
+  const cookieHeader = requestHeaders.get("cookie");
+  const updated = cookieHeader
+    ? `${cookieHeader}; ${CSRF_COOKIE}=${token}`
+    : `${CSRF_COOKIE}=${token}`;
+  requestHeaders.set("cookie", updated);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.cookies.set(CSRF_COOKIE, token, {
+    httpOnly: false,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+  });
+  return response;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary

Adds defense-in-depth CSRF protection on top of the existing `sameSite=lax` session cookie, per [#50](https://github.com/HundredAcreStudio/sme-directory/issues/50). Closes #50.

The model is a **double-submit cookie**:

- A non-httpOnly `sme_csrf` cookie (64-char hex, 30-day TTL) is issued by Next.js middleware on the first non-mutating request, rotated on `signIn`, and cleared on `signOut`.
- The same middleware enforces a constant-time `x-csrf-token` ↔ cookie compare on POST/PATCH/PUT/DELETE under `/api/*`. Mismatch returns `403 {error: "CsrfFailed"}`.
- Forms render `<CsrfField />` (client) or `<CsrfInput />` (server) so server actions can `await assertCsrf(formData)`.
- Programmatic server actions (e.g. `voteAction`, `favoriteAction`) take a `csrfToken: string` argument and call `assertCsrfToken` — necessary because React's server-action wire protocol doesn't expose custom HTTP headers.
- Client `fetch` callsites use a new `csrfFetch` helper (or inline `[CSRF_HEADER]: readCsrfToken()`).

The pattern is documented in `CLAUDE.md` so new routes / actions inherit protection.

## Why this shape

- **Why middleware, not per-route**: middleware sits before every API handler so new routes are protected by default; route-handler unit tests stay simple (they bypass middleware).
- **Why server actions don't go through middleware**: Next.js server actions POST to the page route, not `/api/*`, so they fall outside the matcher. Validation happens inside the action via `assertCsrf` / `assertCsrfToken`.
- **Why a `csrfToken` argument on programmatic actions**: server actions invoked via `useTransition` go through React's wire protocol, which doesn't surface custom request headers — passing the token as a plain argument is the simplest defense-in-depth.

## Tests

- `src/lib/csrf.test.ts` — token shape, constant-time compare, path/method gating
- `src/lib/csrf-server.test.ts` — `assertCsrf` (form-driven) + `assertCsrfToken` (programmatic), happy + sad paths
- `src/middleware.test.ts` — missing token → 403, mismatch → 403, malformed → 403, valid → 200, plus issuance + non-`/api/` pass-through

`npm test` 39 files / 448 tests pass. `npm run typecheck` and `npm run lint` clean.

## Test plan
- [ ] Cold load `/login`: cookie `sme_csrf` is set, sign in works, session rotates the cookie
- [ ] Sign out clears both `sme_session` and `sme_csrf`
- [ ] `curl -X POST /api/favorites` (no header) returns 403; with valid `x-csrf-token` + cookie returns the normal 401/200
- [ ] Submit a form (e.g. ask question, edit profile) — the hidden `_csrf` field carries the token and the action succeeds
- [ ] Vote / favorite buttons (programmatic actions) still work
- [ ] Avatar upload still works (multipart fetch with header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)