### PR TITLE
feat(rate-limit): token-bucket rate limiting on mutating endpoints

### DIFF
--- a/src/app/groups/[slug]/ask/actions.ts
+++ b/src/app/groups/[slug]/ask/actions.ts
@@ -6,6 +6,7 @@ import { assertCsrf, CsrfError } from "@/lib/csrf-server";
 import { getGroupBySlug } from "@/lib/groups";
 import { assertApprovedMember, AuthorizationError } from "@/lib/memberships";
 import { createQuestion } from "@/lib/questions";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 import { createQuestionSchema } from "@/lib/validation/questions";
 
 export type FieldError = { path: string; message: string };
@@ -30,6 +31,16 @@ export async function createQuestionAction(
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to post a question." };
+  }
+
+  try {
+    await assertRateLimitForAction("questions");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return { error: `Too many questions. Try again in ${seconds} seconds.` };
+    }
+    throw err;
   }
 
   const raw = {

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -3,16 +3,30 @@
 import { redirect } from "next/navigation";
 import { signIn, signOut } from "@/lib/auth";
 import { assertCsrf, CsrfError } from "@/lib/csrf-server";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 
 export type SignInState = { error?: string };
 
 export async function signInAction(_prev: SignInState, formData: FormData): Promise<SignInState> {
+  // Rate-limit BEFORE CSRF: brute-force probes may not have a valid CSRF token,
+  // but they should still consume budget so we can throttle the attacker's IP.
+  try {
+    await assertRateLimitForAction("signIn");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return { error: `Too many attempts. Try again in ${seconds} seconds.` };
+    }
+    throw err;
+  }
+
   try {
     await assertCsrf(formData);
   } catch (err) {
     if (err instanceof CsrfError) return { error: err.message };
     throw err;
   }
+
   const email = String(formData.get("email") ?? "");
   try {
     await signIn(email);

--- a/src/app/q/[id]/actions.ts
+++ b/src/app/q/[id]/actions.ts
@@ -20,11 +20,23 @@ import {
   updateQuestion,
 } from "@/lib/questions";
 import { db } from "@/lib/db";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 import {
   createAnswerSchema,
   updateAnswerSchema,
 } from "@/lib/validation/answers";
 import { updateQuestionSchema } from "@/lib/validation/questions";
+
+function rateLimitedFormState<T extends { error?: string }>(
+  err: RateLimitError,
+  extra: Omit<T, "error">,
+): T {
+  const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+  return {
+    ...(extra as object),
+    error: `Too many requests. Try again in ${seconds} seconds.`,
+  } as T;
+}
 
 export type FieldError = { path: string; message: string };
 
@@ -49,6 +61,15 @@ export async function createAnswerAction(
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to post an answer." };
+  }
+
+  try {
+    await assertRateLimitForAction("questions");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitedFormState<AnswerFormState>(err, {});
+    }
+    throw err;
   }
 
   const raw = { body: String(formData.get("body") ?? "") };
@@ -110,6 +131,15 @@ export async function updateAnswerAction(
     return { error: "You must be signed in to edit an answer." };
   }
 
+  try {
+    await assertRateLimitForAction("questions");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitedFormState<AnswerFormState>(err, {});
+    }
+    throw err;
+  }
+
   const raw = { body: String(formData.get("body") ?? "") };
   const parsed = updateAnswerSchema.safeParse(raw);
   if (!parsed.success) {
@@ -162,6 +192,15 @@ export async function updateQuestionAction(
   const session = await getSession();
   if (!session) {
     return { error: "You must be signed in to edit a question." };
+  }
+
+  try {
+    await assertRateLimitForAction("questions");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitedFormState<QuestionFormState>(err, {});
+    }
+    throw err;
   }
 
   const raw = {

--- a/src/app/q/[id]/favorite-actions.ts
+++ b/src/app/q/[id]/favorite-actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
 import { assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { NotFoundError } from "@/lib/memberships";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 import { toggleFavorite, type FavoriteTargetType } from "@/lib/favorites";
 
 export type FavoriteActionResult =
@@ -25,6 +26,19 @@ export async function favoriteAction(
   const session = await getSession();
   if (!session) {
     return { ok: false, error: "You must be signed in to favorite." };
+  }
+
+  try {
+    await assertRateLimitForAction("favorites");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return {
+        ok: false,
+        error: `Too many favorites. Try again in ${seconds} seconds.`,
+      };
+    }
+    throw err;
   }
 
   try {

--- a/src/app/q/[id]/vote-actions.ts
+++ b/src/app/q/[id]/vote-actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
 import { assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { AuthorizationError, NotFoundError } from "@/lib/memberships";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 import { castVote, type VoteTargetType } from "@/lib/votes";
 
 export type VoteActionResult =
@@ -25,6 +26,19 @@ export async function voteAction(
   const session = await getSession();
   if (!session) {
     return { ok: false, error: "You must be signed in to vote." };
+  }
+
+  try {
+    await assertRateLimitForAction("votes");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return {
+        ok: false,
+        error: `Too many votes. Try again in ${seconds} seconds.`,
+      };
+    }
+    throw err;
   }
 
   try {

--- a/src/lib/rate-limit/auth-edge.ts
+++ b/src/lib/rate-limit/auth-edge.ts
@@ -1,0 +1,36 @@
+/**
+ * Edge-safe session reading for the rate-limit middleware.
+ *
+ * Mirrors `readToken` from `@/lib/auth` but without `server-only`, Prisma, or
+ * `next/headers` so it can be imported from `src/middleware.ts`.
+ */
+
+import { jwtVerify } from "jose";
+import type { NextRequest } from "next/server";
+
+const SESSION_COOKIE = "sme_session";
+const ALG = "HS256";
+
+function getSecret(): Uint8Array | null {
+  const secret = process.env["AUTH_SECRET"];
+  if (!secret || secret.length < 32) return null;
+  return new TextEncoder().encode(secret);
+}
+
+/**
+ * Extract the user id from the signed session cookie, or `null` if the cookie
+ * is missing/invalid. Never throws — invalid tokens fall through to the IP
+ * key in the rate-limit pipeline.
+ */
+export async function readUserIdFromRequest(req: NextRequest): Promise<string | null> {
+  const token = req.cookies.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+  const secret = getSecret();
+  if (!secret) return null;
+  try {
+    const { payload } = await jwtVerify(token, secret, { algorithms: [ALG] });
+    return typeof payload.sub === "string" ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/rate-limit/config.ts
+++ b/src/lib/rate-limit/config.ts
@@ -1,0 +1,76 @@
+/**
+ * Rate-limit groups and per-group limits.
+ *
+ * Limits are derived as `capacity` / `windowMs` to keep the configuration
+ * intuitive (e.g. "5 sign-ins per minute") while exposing the token-bucket
+ * primitives the store needs.
+ */
+
+import type { Limit } from "./store";
+
+export type LimitGroup = "signIn" | "votes" | "favorites" | "questions" | "default";
+
+export type LimitScope = "ip" | "user";
+
+export type LimitConfig = Limit & { scope: LimitScope; windowMs: number; max: number };
+
+function tokensPerMs(max: number, windowMs: number): number {
+  return max / windowMs;
+}
+
+const MINUTE_MS = 60_000;
+
+function build(max: number, windowMs: number, scope: LimitScope): LimitConfig {
+  return {
+    capacity: max,
+    refillRatePerMs: tokensPerMs(max, windowMs),
+    scope,
+    windowMs,
+    max,
+  };
+}
+
+export const LIMITS: Record<LimitGroup, LimitConfig> = {
+  // Brute-force protection — keyed by IP because the attacker has no session.
+  signIn: build(5, MINUTE_MS, "ip"),
+  // Per-user throttle on voting spam.
+  votes: build(30, MINUTE_MS, "user"),
+  // Per-user throttle on favorite churn.
+  favorites: build(30, MINUTE_MS, "user"),
+  // Per-user throttle on question/answer authorship.
+  questions: build(10, MINUTE_MS, "user"),
+  // Catch-all for any mutating /api/* path not matched by a specific group.
+  // Looser than per-feature limits to avoid blocking legitimate workflows.
+  default: build(60, MINUTE_MS, "user"),
+};
+
+/**
+ * Resolve which rate-limit group applies to a mutating `/api/*` request, or
+ * `null` if the path is not under `/api/` at all (the request should pass
+ * through untouched).
+ *
+ * For any `/api/*` path that is not matched by a specific group, `"default"`
+ * is returned so that every mutation has *some* ceiling — the default limit is
+ * intentionally looser than per-feature limits to avoid blocking legitimate
+ * workflows.
+ *
+ * Path matching is intentionally conservative: GETs/HEADs are never rate
+ * limited at the middleware layer, and routes that are already gated by
+ * server-action `assertRateLimitForAction` calls don't need a second pass.
+ */
+export function groupForApiPath(pathname: string): LimitGroup | null {
+  if (!pathname.startsWith("/api/")) return null;
+
+  if (pathname.startsWith("/api/votes")) return "votes";
+  if (pathname.startsWith("/api/favorites")) return "favorites";
+  if (
+    pathname.startsWith("/api/questions") ||
+    pathname.match(/^\/api\/groups\/[^/]+\/questions/) ||
+    pathname.match(/^\/api\/answers\//) ||
+    pathname.match(/^\/api\/groups\/[^/]+\/membership/)
+  ) {
+    return "questions";
+  }
+  // Any other mutating /api/* request falls through to the default ceiling.
+  return "default";
+}

--- a/src/lib/rate-limit/index.test.ts
+++ b/src/lib/rate-limit/index.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  RateLimitError,
+  __resetStoreForTests,
+  assertRateLimit,
+  consume,
+} from "./index";
+import { LIMITS, groupForApiPath } from "./config";
+
+beforeEach(async () => {
+  await __resetStoreForTests();
+});
+
+describe("assertRateLimit", () => {
+  it("allows N calls up to capacity, then throws RateLimitError with retryAfterMs >= 1", async () => {
+    const capacity = LIMITS.signIn.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      await expect(
+        assertRateLimit({ group: "signIn", ip: "1.2.3.4" }),
+      ).resolves.toBeUndefined();
+    }
+
+    let caught: unknown;
+    try {
+      await assertRateLimit({ group: "signIn", ip: "1.2.3.4" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    expect((caught as RateLimitError).retryAfterMs).toBeGreaterThanOrEqual(1);
+  });
+
+  it("isolates ip-scoped buckets per ip", async () => {
+    for (let i = 0; i < LIMITS.signIn.capacity; i += 1) {
+      await assertRateLimit({ group: "signIn", ip: "1.1.1.1" });
+    }
+    await expect(
+      assertRateLimit({ group: "signIn", ip: "1.1.1.1" }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+
+    // Different IP — fresh bucket.
+    await expect(
+      assertRateLimit({ group: "signIn", ip: "2.2.2.2" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("isolates user-scoped buckets per userId", async () => {
+    for (let i = 0; i < LIMITS.votes.capacity; i += 1) {
+      await assertRateLimit({ group: "votes", userId: "u1", ip: "1.1.1.1" });
+    }
+    await expect(
+      assertRateLimit({ group: "votes", userId: "u1", ip: "1.1.1.1" }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+
+    await expect(
+      assertRateLimit({ group: "votes", userId: "u2", ip: "1.1.1.1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back to ip when user-scope group has no userId", async () => {
+    for (let i = 0; i < LIMITS.votes.capacity; i += 1) {
+      await assertRateLimit({ group: "votes", userId: null, ip: "9.9.9.9" });
+    }
+    await expect(
+      assertRateLimit({ group: "votes", userId: null, ip: "9.9.9.9" }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+});
+
+describe("consume", () => {
+  it("returns allowed=false with positive retryAfterMs once over the limit", async () => {
+    const capacity = LIMITS.questions.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      const r = await consume("k", "questions");
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await consume("k", "questions");
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("groupForApiPath — default coverage", () => {
+  it("returns null for non-/api/ paths", () => {
+    expect(groupForApiPath("/")).toBeNull();
+    expect(groupForApiPath("/groups/foo")).toBeNull();
+  });
+
+  it("returns a specific group for known /api/ paths", () => {
+    expect(groupForApiPath("/api/votes")).toBe("votes");
+    expect(groupForApiPath("/api/favorites")).toBe("favorites");
+    expect(groupForApiPath("/api/questions/123")).toBe("questions");
+  });
+
+  it("returns 'default' for previously-unmatched mutating /api/* paths", () => {
+    // These are the routes identified in the security review as having no group.
+    expect(groupForApiPath("/api/groups")).toBe("default");
+    expect(groupForApiPath("/api/groups/my-group")).toBe("default");
+    expect(groupForApiPath("/api/groups/my-group/unarchive")).toBe("default");
+    expect(groupForApiPath("/api/groups/my-group/avatar")).toBe("default");
+    expect(groupForApiPath("/api/me")).toBe("default");
+    expect(groupForApiPath("/api/notification-preferences/group-1")).toBe("default");
+    expect(groupForApiPath("/api/notifications/42/read")).toBe("default");
+    expect(groupForApiPath("/api/notifications/read-all")).toBe("default");
+    expect(groupForApiPath("/api/users/me/avatar")).toBe("default");
+  });
+
+  it("'default' group is present in LIMITS with a user-scoped config", () => {
+    const limit = LIMITS["default"];
+    expect(limit).toBeDefined();
+    expect(limit.scope).toBe("user");
+    expect(limit.capacity).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/rate-limit/index.ts
+++ b/src/lib/rate-limit/index.ts
@@ -1,0 +1,159 @@
+/**
+ * Rate-limit public surface.
+ *
+ * - Server actions call `assertRateLimitForAction(group)` at the top of the
+ *   handler; over-limit throws `RateLimitError(retryAfterMs)`, which the
+ *   action catches and surfaces in its existing form-state shape.
+ * - The middleware calls `applyRateLimitToApiRequest(req)` to enforce limits
+ *   on mutating `/api/*` requests before they reach the route handler.
+ *
+ * The store backend is selected via `getStore()`. In dev/test it is the
+ * in-memory token-bucket implementation; production deployments can swap in a
+ * shared store (Redis, Upstash KV, etc.) without changing call sites.
+ */
+
+import type { NextRequest } from "next/server";
+import { LIMITS, groupForApiPath, type LimitGroup } from "./config";
+import { MemoryStore, type RateLimitStore } from "./store";
+import { readUserIdFromRequest } from "./auth-edge";
+import { clientIpFromHeaders, clientIpFromRequest } from "./ip";
+
+export { LIMITS, groupForApiPath } from "./config";
+export type { LimitGroup } from "./config";
+export { clientIpFromHeaders, clientIpFromRequest } from "./ip";
+
+export class RateLimitError extends Error {
+  readonly retryAfterMs: number;
+  constructor(retryAfterMs: number) {
+    super(`Rate limit exceeded. Retry after ${retryAfterMs}ms.`);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+let store: RateLimitStore | null = null;
+
+export function getStore(): RateLimitStore {
+  if (!store) store = new MemoryStore();
+  return store;
+}
+
+/**
+ * Test hook — discards the singleton so each test starts with empty buckets.
+ */
+export async function __resetStoreForTests(): Promise<void> {
+  if (store) await store.reset();
+  store = null;
+}
+
+export type ConsumeOk = { allowed: true; retryAfterMs: 0; remaining: number };
+export type ConsumeFail = { allowed: false; retryAfterMs: number; remaining: number };
+
+/**
+ * Consume one token for `(key, group)`. Lower-level helper exposed for
+ * tests; production callers should prefer `assertRateLimit`.
+ */
+export async function consume(
+  key: string,
+  group: LimitGroup,
+): Promise<ConsumeOk | ConsumeFail> {
+  const limit = LIMITS[group];
+  const result = await getStore().consume(`${group}:${key}`, 1, limit);
+  if (result.allowed) {
+    return { allowed: true, retryAfterMs: 0, remaining: result.remaining };
+  }
+  return {
+    allowed: false,
+    retryAfterMs: result.retryAfterMs,
+    remaining: result.remaining,
+  };
+}
+
+/**
+ * Throw `RateLimitError` if the caller is over the limit.
+ *
+ * The bucket key is derived from the configured scope:
+ *   - `user` scope → `userId`, falling back to `ip` when there is no session
+ *     (so anonymous brute force still consumes budget).
+ *   - `ip` scope   → `ip`.
+ *
+ * `"unknown"` is used as a last resort when neither identity is available;
+ * this collapses anonymous bursts into a single shared bucket, which is the
+ * correct fail-closed behavior for misconfigured deployments.
+ */
+export async function assertRateLimit(opts: {
+  group: LimitGroup;
+  userId?: string | null;
+  ip?: string | null;
+}): Promise<void> {
+  const limit = LIMITS[opts.group];
+  let key: string;
+  if (limit.scope === "user") {
+    key = opts.userId || opts.ip || "unknown";
+  } else {
+    key = opts.ip || "unknown";
+  }
+  const result = await consume(key, opts.group);
+  if (!result.allowed) throw new RateLimitError(result.retryAfterMs);
+}
+
+/**
+ * Server-action convenience wrapper. Reads the session and forwarded IP from
+ * `next/headers` and `@/lib/auth` so callers only need to know their group.
+ *
+ * Imports are deferred so the function tree is free of `next/headers` and
+ * `server-only` until it actually runs in a server-action context.
+ */
+export async function assertRateLimitForAction(group: LimitGroup): Promise<void> {
+  const [{ headers }, { getSession }] = await Promise.all([
+    import("next/headers"),
+    import("@/lib/auth"),
+  ]);
+  const hdrs = await headers();
+  const ip = clientIpFromHeaders(hdrs) ?? "unknown";
+  const session = await getSession();
+  await assertRateLimit({ group, userId: session?.user.id ?? null, ip });
+}
+
+/**
+ * Middleware entry point. Returns `null` if the request is allowed (or not
+ * subject to rate limiting), or a 429 `Response` with `Retry-After` if the
+ * caller is over the limit.
+ *
+ * Only mutating verbs are inspected — GET/HEAD/OPTIONS pass through untouched.
+ */
+export async function applyRateLimitToApiRequest(
+  req: NextRequest,
+): Promise<Response | null> {
+  const method = req.method.toUpperCase();
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+    return null;
+  }
+
+  const url = new URL(req.url);
+  const group = groupForApiPath(url.pathname);
+  if (!group) return null;
+
+  const limit = LIMITS[group];
+  const ip = clientIpFromRequest(req);
+  const userId = await readUserIdFromRequest(req);
+  const key =
+    limit.scope === "user" ? userId || ip || "unknown" : ip || "unknown";
+  const result = await consume(key, group);
+  if (result.allowed) return null;
+
+  const retryAfterSec = Math.max(1, Math.ceil(result.retryAfterMs / 1000));
+  return new Response(
+    JSON.stringify({
+      error: "RateLimited",
+      message: "Too many requests. Try again shortly.",
+    }),
+    {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfterSec),
+      },
+    },
+  );
+}

--- a/src/lib/rate-limit/ip.test.ts
+++ b/src/lib/rate-limit/ip.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { clientIpFromHeaders, isPrivateIp } from "./ip";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHeaders(map: Record<string, string>) {
+  return {
+    get(name: string): string | null {
+      return map[name.toLowerCase()] ?? null;
+    },
+  };
+}
+
+function withEnv(key: string, value: string | undefined, fn: () => void) {
+  const original = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isPrivateIp
+// ---------------------------------------------------------------------------
+
+describe("isPrivateIp", () => {
+  it("identifies loopback IPv4", () => {
+    expect(isPrivateIp("127.0.0.1")).toBe(true);
+  });
+
+  it("identifies 10.x private range", () => {
+    expect(isPrivateIp("10.0.0.1")).toBe(true);
+    expect(isPrivateIp("10.255.255.255")).toBe(true);
+  });
+
+  it("identifies 172.16-31 private range", () => {
+    expect(isPrivateIp("172.16.0.1")).toBe(true);
+    expect(isPrivateIp("172.31.255.255")).toBe(true);
+    expect(isPrivateIp("172.15.0.1")).toBe(false);
+    expect(isPrivateIp("172.32.0.1")).toBe(false);
+  });
+
+  it("identifies 192.168 private range", () => {
+    expect(isPrivateIp("192.168.1.1")).toBe(true);
+    expect(isPrivateIp("192.169.1.1")).toBe(false);
+  });
+
+  it("identifies IPv6 loopback", () => {
+    expect(isPrivateIp("::1")).toBe(true);
+  });
+
+  it("identifies IPv6 unique-local", () => {
+    expect(isPrivateIp("fc00::1")).toBe(true);
+    expect(isPrivateIp("fd12:3456:789a::1")).toBe(true);
+  });
+
+  it("does not flag public IPs as private", () => {
+    expect(isPrivateIp("1.2.3.4")).toBe(false);
+    expect(isPrivateIp("8.8.8.8")).toBe(false);
+    expect(isPrivateIp("203.0.113.1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clientIpFromHeaders — XFF spoofing / trusted-proxy hop count
+// ---------------------------------------------------------------------------
+
+describe("clientIpFromHeaders", () => {
+  it("does NOT use the leftmost (spoofed) XFF value when TRUSTED_PROXY_HOPS=1", () => {
+    // Attacker forges leftmost entry; LB appends real client (1.2.3.4) rightmost.
+    // With hops=1, we pick the rightmost non-private entry — the real client.
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      const headers = makeHeaders({
+        "x-forwarded-for": "evil.0.0.1, 1.2.3.4",
+      });
+      const ip = clientIpFromHeaders(headers);
+      expect(ip).toBe("1.2.3.4");
+    });
+  });
+
+  it("respects TRUSTED_PROXY_HOPS=2 (two trusted proxies in chain)", () => {
+    // [client, proxy1, lb] — lb wrote its view as the last; client is at idx len-2
+    withEnv("TRUSTED_PROXY_HOPS", "2", () => {
+      const headers = makeHeaders({
+        "x-forwarded-for": "5.6.7.8, 10.0.0.1, 203.0.113.1",
+      });
+      // candidates after removing private: [5.6.7.8, 203.0.113.1]
+      // idx = 2 - 2 = 0  → 5.6.7.8
+      const ip = clientIpFromHeaders(headers);
+      expect(ip).toBe("5.6.7.8");
+    });
+  });
+
+  it("skips private IPs in the XFF chain", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      const headers = makeHeaders({
+        // private intermediary, then real client
+        "x-forwarded-for": "9.9.9.9, 10.0.0.5, 203.0.113.50",
+      });
+      // non-private: [9.9.9.9, 203.0.113.50]
+      // idx = 2 - 1 = 1 → 203.0.113.50
+      const ip = clientIpFromHeaders(headers);
+      expect(ip).toBe("203.0.113.50");
+    });
+  });
+
+  it("prefers x-real-ip over x-forwarded-for when TRUSTED_PROXY_HOPS >= 1", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      const headers = makeHeaders({
+        "x-real-ip": "11.22.33.44",
+        "x-forwarded-for": "5.5.5.5, 6.6.6.6",
+      });
+      expect(clientIpFromHeaders(headers)).toBe("11.22.33.44");
+    });
+  });
+
+  it("prefers cf-connecting-ip over x-real-ip and x-forwarded-for", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      const headers = makeHeaders({
+        "cf-connecting-ip": "99.88.77.66",
+        "x-real-ip": "11.22.33.44",
+        "x-forwarded-for": "5.5.5.5, 6.6.6.6",
+      });
+      expect(clientIpFromHeaders(headers)).toBe("99.88.77.66");
+    });
+  });
+
+  it("returns null when TRUSTED_PROXY_HOPS=0 (header trust disabled)", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "0", () => {
+      const headers = makeHeaders({
+        "cf-connecting-ip": "99.88.77.66",
+        "x-forwarded-for": "5.5.5.5",
+      });
+      expect(clientIpFromHeaders(headers)).toBeNull();
+    });
+  });
+
+  it("returns null when all XFF entries are private", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      const headers = makeHeaders({
+        "x-forwarded-for": "10.0.0.1, 192.168.1.1",
+      });
+      expect(clientIpFromHeaders(headers)).toBeNull();
+    });
+  });
+
+  it("returns null when no relevant headers are present", () => {
+    withEnv("TRUSTED_PROXY_HOPS", "1", () => {
+      expect(clientIpFromHeaders(makeHeaders({}))).toBeNull();
+    });
+  });
+});

--- a/src/lib/rate-limit/ip.ts
+++ b/src/lib/rate-limit/ip.ts
@@ -1,0 +1,140 @@
+/**
+ * Trusted-proxy-aware client IP extraction for rate limiting.
+ *
+ * Strategy (in priority order):
+ *   1. `cf-connecting-ip` — set by Cloudflare, never forgeable upstream of CF.
+ *   2. `x-real-ip`       — set by a known proxy when TRUSTED_PROXY_HOPS >= 1.
+ *   3. `x-forwarded-for` — take the N-th-from-rightmost non-private value,
+ *                          where N = TRUSTED_PROXY_HOPS (default 1).
+ *   4. `req.ip`          — Edge-runtime fallback on NextRequest.
+ *   5. `"unknown"`       — last resort.
+ *
+ * Set `TRUSTED_PROXY_HOPS=0` to skip headers entirely and rely on req.ip only.
+ * Set `TRUSTED_PROXY_HOPS=1` (default) for a single trusted proxy (e.g. your
+ * load balancer).  Set higher if you have a chain of known proxies.
+ *
+ * Private / loopback addresses are never used as client IPs — they indicate
+ * intermediate infrastructure, not real clients.
+ */
+
+import type { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Private / loopback CIDR patterns (IPv4 + IPv6).
+// ---------------------------------------------------------------------------
+
+/** Returns true if the IP string is a private/loopback address. */
+export function isPrivateIp(ip: string): boolean {
+  const trimmed = ip.trim();
+
+  // IPv6 loopback
+  if (trimmed === "::1") return true;
+
+  // IPv6 unique-local fc00::/7  (covers fc.. and fd..)
+  if (/^f[cd][0-9a-f]{2}:/i.test(trimmed)) return true;
+
+  // IPv4 mapped as ::ffff:x.x.x.x
+  const v4mapped = trimmed.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  const v4 = v4mapped ? v4mapped[1]! : trimmed;
+
+  const parts = v4.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
+    return false; // Not recognisable IPv4 — not private
+  }
+
+  const [a, b] = parts as [number, number, number, number];
+
+  return (
+    a === 127 || // 127.0.0.0/8  loopback
+    a === 10 || // 10.0.0.0/8   private
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 private
+    (a === 192 && b === 168) // 192.168.0.0/16 private
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function trustedProxyHops(): number {
+  const raw = process.env["TRUSTED_PROXY_HOPS"];
+  if (!raw) return 1; // default: one trusted proxy
+  const n = parseInt(raw, 10);
+  return isNaN(n) || n < 0 ? 1 : n;
+}
+
+/**
+ * Pick the N-th-from-rightmost non-private IP from a comma-separated XFF header.
+ *
+ * XFF is built left-to-right as packets traverse proxies:
+ *   client → proxy1 → proxy2 → your-LB
+ * The LB appends the real client IP as the last entry it saw, so the rightmost
+ * is your own LB's view. The next one in (rightmost − 1) is the actual client
+ * when you have one trusted proxy.
+ */
+function pickFromXff(xff: string, hops: number): string | null {
+  const candidates = xff
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !isPrivateIp(s));
+
+  if (candidates.length === 0) return null;
+
+  // The "client" is hops positions from the right (1-indexed).
+  // hops=1 means the rightmost non-private entry is the client.
+  const idx = candidates.length - hops;
+  if (idx < 0) return null;
+  const ip = candidates[idx];
+  return ip && ip.length > 0 ? ip : null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the best-available client IP from a raw `Headers` object.
+ *
+ * Used by `assertRateLimitForAction` (server actions) where only headers are
+ * available, not a full `NextRequest`.
+ */
+export function clientIpFromHeaders(headers: {
+  get(name: string): string | null;
+}): string | null {
+  const hops = trustedProxyHops();
+  if (hops === 0) return null; // caller must use req.ip or "unknown"
+
+  // Priority 1: Cloudflare
+  const cf = headers.get("cf-connecting-ip")?.trim();
+  if (cf && cf.length > 0 && !isPrivateIp(cf)) return cf;
+
+  // Priority 2: x-real-ip (set by nginx / known reverse proxy)
+  const xri = headers.get("x-real-ip")?.trim();
+  if (xri && xri.length > 0 && !isPrivateIp(xri)) return xri;
+
+  // Priority 3: x-forwarded-for with trusted-hop counting
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    const ip = pickFromXff(xff, hops);
+    if (ip) return ip;
+  }
+
+  return null;
+}
+
+/**
+ * Extract the best-available client IP from a `NextRequest`.
+ *
+ * Used by `applyRateLimitToApiRequest` (middleware).
+ * Falls back to `req.ip` when header-based extraction yields nothing.
+ */
+export function clientIpFromRequest(req: NextRequest): string {
+  const fromHeaders = clientIpFromHeaders(req.headers);
+  if (fromHeaders) return fromHeaders;
+
+  // Edge runtime exposes `req.ip` (may be undefined in test environments).
+  const reqIp = (req as NextRequest & { ip?: string }).ip;
+  if (reqIp && reqIp.length > 0 && !isPrivateIp(reqIp)) return reqIp;
+
+  return "unknown";
+}

--- a/src/lib/rate-limit/store.test.ts
+++ b/src/lib/rate-limit/store.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "./store";
+
+function makeClock(initial = 0) {
+  let now = initial;
+  return {
+    advance: (ms: number) => {
+      now += ms;
+    },
+    set: (ms: number) => {
+      now = ms;
+    },
+    fn: () => now,
+  };
+}
+
+describe("MemoryStore token bucket", () => {
+  it("starts a new bucket at full capacity and decrements on consume", async () => {
+    const clock = makeClock(1_000);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 5, refillRatePerMs: 5 / 60_000 };
+
+    const r1 = await store.consume("k", 1, limit);
+    expect(r1.allowed).toBe(true);
+    expect(r1.remaining).toBe(4);
+    const r2 = await store.consume("k", 1, limit);
+    expect(r2.allowed).toBe(true);
+    expect(r2.remaining).toBe(3);
+  });
+
+  it("blocks once the bucket is empty and reports a positive retryAfterMs", async () => {
+    const clock = makeClock(1_000);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 3, refillRatePerMs: 3 / 60_000 };
+
+    for (let i = 0; i < 3; i += 1) {
+      const ok = await store.consume("k", 1, limit);
+      expect(ok.allowed).toBe(true);
+    }
+
+    const blocked = await store.consume("k", 1, limit);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("refills tokens as time advances and never exceeds capacity", async () => {
+    const clock = makeClock(0);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 5, refillRatePerMs: 5 / 60_000 };
+
+    for (let i = 0; i < 5; i += 1) {
+      const ok = await store.consume("k", 1, limit);
+      expect(ok.allowed).toBe(true);
+    }
+    const blocked = await store.consume("k", 1, limit);
+    expect(blocked.allowed).toBe(false);
+
+    // After a full window the bucket should be back at capacity.
+    clock.advance(60_000);
+    const refilled = await store.consume("k", 1, limit);
+    expect(refilled.allowed).toBe(true);
+    // remaining is capacity - 1 because we just consumed one.
+    expect(refilled.remaining).toBeCloseTo(4, 5);
+
+    // Even with a huge time jump, tokens never exceed capacity.
+    clock.advance(60_000 * 100);
+    const stillCapped = await store.consume("k", 1, limit);
+    expect(stillCapped.allowed).toBe(true);
+    expect(stillCapped.remaining).toBeLessThanOrEqual(limit.capacity);
+  });
+
+  it("keeps separate buckets per key", async () => {
+    const clock = makeClock(0);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 2, refillRatePerMs: 2 / 60_000 };
+
+    await store.consume("a", 1, limit);
+    await store.consume("a", 1, limit);
+    const aBlocked = await store.consume("a", 1, limit);
+    expect(aBlocked.allowed).toBe(false);
+
+    const bAllowed = await store.consume("b", 1, limit);
+    expect(bAllowed.allowed).toBe(true);
+  });
+
+  it("returns a sane retryAfterMs when cost exceeds remaining tokens", async () => {
+    const clock = makeClock(0);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 5, refillRatePerMs: 5 / 60_000 };
+
+    for (let i = 0; i < 5; i += 1) await store.consume("k", 1, limit);
+    const blocked = await store.consume("k", 1, limit);
+    expect(blocked.allowed).toBe(false);
+    // 1 token / (5/60000 per ms) = 12_000 ms.
+    expect(blocked.retryAfterMs).toBeGreaterThanOrEqual(11_000);
+    expect(blocked.retryAfterMs).toBeLessThanOrEqual(13_000);
+  });
+
+  it("reset() clears all buckets", async () => {
+    const clock = makeClock(0);
+    const store = new MemoryStore(clock.fn);
+    const limit = { capacity: 1, refillRatePerMs: 1 / 60_000 };
+
+    await store.consume("k", 1, limit);
+    const blocked = await store.consume("k", 1, limit);
+    expect(blocked.allowed).toBe(false);
+
+    await store.reset();
+    const fresh = await store.consume("k", 1, limit);
+    expect(fresh.allowed).toBe(true);
+  });
+});
+
+describe("MemoryStore sweep and eviction", () => {
+  const limit = { capacity: 5, refillRatePerMs: 5 / 60_000 };
+  // 2 * windowMs = 2 * 60_000 ms = 120_000 ms
+  const TWO_WINDOWS = 120_001;
+
+  it("sweeps stale fully-refilled entries after sweep cadence", async () => {
+    const clock = makeClock(0);
+    // sweepCadence=5 so sweep fires every 5 consumes; maxBuckets=100 (large, so cap isn't hit)
+    const store = new MemoryStore(clock.fn, { maxBuckets: 100, sweepCadence: 5 });
+
+    // Populate 10 keys, each consuming all tokens (so bucket is drained).
+    for (let i = 0; i < 10; i++) {
+      for (let j = 0; j < 5; j++) {
+        await store.consume(`key-${i}`, 1, limit);
+      }
+    }
+
+    // Advance past 2 windows so all buckets fully refill and become stale.
+    clock.advance(TWO_WINDOWS);
+
+    // One more consume (5th call in next batch triggers sweep).
+    // Fill 4 more calls first, then the 5th triggers the sweep.
+    for (let i = 0; i < 4; i++) {
+      await store.consume("trigger", 1, limit);
+    }
+    // This 5th consume triggers the sweep.
+    await store.consume("trigger", 1, limit);
+
+    // All 10 stale keys should have been swept (the "trigger" key is active, kept).
+    // We can verify by checking the store size indirectly: each stale key should
+    // no longer consume from the cap.  A direct size check requires exposing internals,
+    // so we verify behavior: populating 100 keys after sweep should not trigger cap eviction.
+    // Instead, do a simpler behavioral test: stale keys are gone, so consuming them again
+    // gives full capacity (new bucket created).
+    clock.advance(1); // tiny advance so new buckets start fresh
+    const r = await store.consume("key-0", 1, limit);
+    // If key-0 was swept, a fresh bucket starts at capacity; the first consume succeeds.
+    expect(r.allowed).toBe(true);
+  });
+
+  it("evicts oldest entries (FIFO) when map exceeds MAX_BUCKETS", async () => {
+    const clock = makeClock(0);
+    // Very small cap to force eviction.
+    const store = new MemoryStore(clock.fn, { maxBuckets: 10, sweepCadence: 1 });
+
+    // Drain 20 keys so none are stale-sweepable (tokens < capacity).
+    for (let i = 0; i < 20; i++) {
+      await store.consume(`key-${i}`, 1, limit);
+    }
+
+    // After 20 inserts with sweepCadence=1, eviction runs on every call.
+    // The map must now be <= maxBuckets.
+    // We can't read .size directly, but we can confirm the store accepts new keys
+    // without crashing and continues to function correctly.
+    const r = await store.consume("new-key", 1, limit);
+    expect(r.allowed).toBe(true);
+  });
+
+  it("does not sweep active (non-stale) entries", async () => {
+    const clock = makeClock(0);
+    const store = new MemoryStore(clock.fn, { maxBuckets: 100, sweepCadence: 5 });
+
+    // Consume one token from "active-key" (partially drained, not stale).
+    await store.consume("active-key", 1, limit);
+
+    // Advance past 2 windows.
+    clock.advance(TWO_WINDOWS);
+
+    // Re-consume to mark it as recently accessed (resets lastRefillMs via refill).
+    await store.consume("active-key", 1, limit);
+
+    // Trigger sweep by firing 5 consumes on other keys.
+    for (let i = 0; i < 5; i++) {
+      await store.consume(`other-${i}`, 1, limit);
+    }
+
+    // "active-key" should still be tracked — it was accessed recently.
+    // If it survived the sweep, consuming again costs from its current bucket.
+    const r = await store.consume("active-key", 1, limit);
+    expect(r.allowed).toBe(true);
+  });
+});

--- a/src/lib/rate-limit/store.ts
+++ b/src/lib/rate-limit/store.ts
@@ -1,0 +1,131 @@
+/**
+ * Rate-limit storage backends.
+ *
+ * The token-bucket algorithm is implemented in the store so that swapping the
+ * backing storage (memory for dev, Redis/KV for prod) does not require
+ * re-implementing the math.
+ *
+ * Bucket math:
+ *   state: { tokens: number; lastRefillMs: number }
+ *   on consume(key, cost, { capacity, refillRatePerMs }):
+ *     now = clock()
+ *     if no state for key: state = { tokens: capacity, lastRefillMs: now }
+ *     elapsed = now - lastRefillMs
+ *     tokens = min(capacity, tokens + elapsed * refillRatePerMs)
+ *     if tokens >= cost: tokens -= cost; persist; return { allowed, remaining }
+ *     else: retryAfterMs = ceil((cost - tokens) / refillRatePerMs)
+ *           return { allowed: false, retryAfterMs }
+ */
+
+export type Limit = {
+  /** Max tokens in the bucket — also the burst limit. */
+  capacity: number;
+  /** Refill rate, expressed as tokens per millisecond. */
+  refillRatePerMs: number;
+};
+
+export type ConsumeResult =
+  | { allowed: true; remaining: number; retryAfterMs: 0 }
+  | { allowed: false; remaining: number; retryAfterMs: number };
+
+export type Clock = () => number;
+
+export interface RateLimitStore {
+  consume(key: string, cost: number, limit: Limit): Promise<ConsumeResult>;
+  reset(): Promise<void>;
+}
+
+type BucketState = { tokens: number; lastRefillMs: number };
+
+/** Default maximum number of live bucket entries before eviction runs. */
+const DEFAULT_MAX_BUCKETS = 100_000;
+
+/** Default number of `consume()` calls between automatic sweep checks. */
+const DEFAULT_SWEEP_CADENCE = 1_000;
+
+export class MemoryStore implements RateLimitStore {
+  private readonly buckets = new Map<string, BucketState>();
+  private readonly clock: Clock;
+  private readonly maxBuckets: number;
+  private readonly sweepCadence: number;
+  private consumeCount = 0;
+
+  constructor(
+    clock: Clock = Date.now,
+    opts: { maxBuckets?: number; sweepCadence?: number } = {},
+  ) {
+    this.clock = clock;
+    this.maxBuckets = opts.maxBuckets ?? DEFAULT_MAX_BUCKETS;
+    this.sweepCadence = opts.sweepCadence ?? DEFAULT_SWEEP_CADENCE;
+  }
+
+  async consume(key: string, cost: number, limit: Limit): Promise<ConsumeResult> {
+    const now = this.clock();
+    const existing = this.buckets.get(key);
+    const state: BucketState = existing
+      ? refill(existing, now, limit)
+      : { tokens: limit.capacity, lastRefillMs: now };
+
+    const allowed = state.tokens >= cost;
+    if (allowed) {
+      state.tokens -= cost;
+    }
+    // Always persist so subsequent calls observe the current token level.
+    this.buckets.set(key, state);
+
+    this.consumeCount += 1;
+    if (
+      this.consumeCount % this.sweepCadence === 0 ||
+      this.buckets.size > this.maxBuckets
+    ) {
+      this.sweep(now, limit);
+    }
+
+    if (allowed) {
+      return { allowed: true, remaining: state.tokens, retryAfterMs: 0 };
+    }
+
+    const deficit = cost - state.tokens;
+    const retryAfterMs = Math.max(1, Math.ceil(deficit / limit.refillRatePerMs));
+    return { allowed: false, remaining: state.tokens, retryAfterMs };
+  }
+
+  /**
+   * Remove stale fully-refilled entries. If the map is still over `maxBuckets`
+   * after the sweep, evict the oldest (insertion-order) entries until we are
+   * back under the cap. `Map` preserves insertion order so `map.keys()` iterates
+   * oldest-first.
+   */
+  private sweep(now: number, limit: Limit): void {
+    // Stale threshold: fully refilled AND not accessed in the last 2 windows.
+    const staleThreshold = now - 2 * (limit.capacity / limit.refillRatePerMs);
+
+    for (const [k, v] of this.buckets) {
+      if (v.tokens >= limit.capacity && v.lastRefillMs < staleThreshold) {
+        this.buckets.delete(k);
+      }
+    }
+
+    // FIFO eviction if still over cap after sweep.
+    if (this.buckets.size > this.maxBuckets) {
+      const excess = this.buckets.size - this.maxBuckets;
+      let evicted = 0;
+      for (const k of this.buckets.keys()) {
+        if (evicted >= excess) break;
+        this.buckets.delete(k);
+        evicted += 1;
+      }
+    }
+  }
+
+  async reset(): Promise<void> {
+    this.buckets.clear();
+    this.consumeCount = 0;
+  }
+}
+
+function refill(state: BucketState, now: number, limit: Limit): BucketState {
+  const elapsed = Math.max(0, now - state.lastRefillMs);
+  const refilled = Math.min(limit.capacity, state.tokens + elapsed * limit.refillRatePerMs);
+  return { tokens: refilled, lastRefillMs: now };
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,21 +1,29 @@
 /**
- * Middleware CSRF tests.
+ * Middleware tests.
  *
- * The middleware is the only place that enforces CSRF on `/api/*` mutating
- * requests. We send synthetic `NextRequest`s through it and assert that
- * missing / mismatched tokens are 403 while valid tokens (header echo of the
- * `sme_csrf` cookie) pass through.
+ * The middleware enforces two cross-cutting policies:
+ *   1. Rate limiting on mutating `/api/*` requests (issue #51).
+ *   2. CSRF (double-submit cookie) on the same paths (issue #50).
+ *
+ * Rate limiting runs first so that brute-force probes without a CSRF token
+ * still consume budget. We exercise both layers here.
  */
-import { describe, expect, it } from "vitest";
-import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
 import { middleware } from "./middleware";
 import { CSRF_COOKIE, CSRF_HEADER, generateCsrfToken } from "@/lib/csrf";
+import { LIMITS, __resetStoreForTests } from "@/lib/rate-limit";
+
+beforeEach(async () => {
+  await __resetStoreForTests();
+});
 
 function makeRequest(opts: {
   method: string;
   path: string;
   cookieToken?: string | null;
   headerToken?: string | null;
+  ip?: string;
 }): NextRequest {
   const url = new URL(`http://localhost${opts.path}`);
   const headers = new Headers();
@@ -25,20 +33,23 @@ function makeRequest(opts: {
   if (opts.cookieToken !== undefined && opts.cookieToken !== null) {
     headers.set("cookie", `${CSRF_COOKIE}=${opts.cookieToken}`);
   }
+  if (opts.ip) {
+    headers.set("x-forwarded-for", opts.ip);
+  }
   return new NextRequest(url, { method: opts.method, headers });
 }
 
 describe("middleware CSRF enforcement on /api/*", () => {
   it("returns 403 when both cookie and header are missing on POST", async () => {
-    const res = middleware(makeRequest({ method: "POST", path: "/api/favorites" }));
+    const res = await middleware(makeRequest({ method: "POST", path: "/api/favorites" }));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe("CsrfFailed");
   });
 
-  it("returns 403 when only the header is missing", () => {
+  it("returns 403 when only the header is missing", async () => {
     const token = generateCsrfToken();
-    const res = middleware(
+    const res = await middleware(
       makeRequest({
         method: "POST",
         path: "/api/favorites",
@@ -48,9 +59,9 @@ describe("middleware CSRF enforcement on /api/*", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when only the cookie is missing", () => {
+  it("returns 403 when only the cookie is missing", async () => {
     const token = generateCsrfToken();
-    const res = middleware(
+    const res = await middleware(
       makeRequest({
         method: "POST",
         path: "/api/favorites",
@@ -60,8 +71,8 @@ describe("middleware CSRF enforcement on /api/*", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when header and cookie do not match", () => {
-    const res = middleware(
+  it("returns 403 when header and cookie do not match", async () => {
+    const res = await middleware(
       makeRequest({
         method: "POST",
         path: "/api/favorites",
@@ -72,9 +83,9 @@ describe("middleware CSRF enforcement on /api/*", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when the header is malformed", () => {
+  it("returns 403 when the header is malformed", async () => {
     const token = generateCsrfToken();
-    const res = middleware(
+    const res = await middleware(
       makeRequest({
         method: "POST",
         path: "/api/favorites",
@@ -85,24 +96,32 @@ describe("middleware CSRF enforcement on /api/*", () => {
     expect(res.status).toBe(403);
   });
 
-  it.each(["POST", "PATCH", "PUT", "DELETE"])("passes through %s when token matches", (method) => {
-    const token = generateCsrfToken();
-    const res = middleware(
-      makeRequest({
-        method,
-        path: "/api/favorites",
-        cookieToken: token,
-        headerToken: token,
-      }),
-    );
-    // Pass-through: status 200 (default for NextResponse.next()).
-    expect(res.status).toBe(200);
-  });
+  it.each(["POST", "PATCH", "PUT", "DELETE"])(
+    "passes through %s when token matches",
+    async (method) => {
+      const token = generateCsrfToken();
+      const res = await middleware(
+        makeRequest({
+          method,
+          path: "/api/favorites",
+          cookieToken: token,
+          headerToken: token,
+          // Use a per-method IP so the small favorites bucket isn't exhausted
+          // by the parameterized run.
+          ip: `198.51.100.${method.length}`,
+        }),
+      );
+      // Pass-through: status 200 (default for NextResponse.next()).
+      expect(res.status).toBe(200);
+    },
+  );
 });
 
 describe("middleware CSRF token issuance", () => {
-  it("issues a fresh sme_csrf cookie on a non-mutating request without one", () => {
-    const res = middleware(makeRequest({ method: "GET", path: "/" }));
+  it("issues a fresh sme_csrf cookie on a non-mutating request without one", async () => {
+    const res = (await middleware(
+      makeRequest({ method: "GET", path: "/" }),
+    )) as NextResponse;
     const setCookie = res.cookies.get(CSRF_COOKIE);
     expect(setCookie).toBeDefined();
     expect(setCookie!.value).toMatch(/^[0-9a-f]{64}$/);
@@ -110,21 +129,111 @@ describe("middleware CSRF token issuance", () => {
     expect(setCookie!.sameSite).toBe("lax");
   });
 
-  it("does not rotate the cookie when one already exists", () => {
-    const existing = generateCsrfToken();
-    const res = middleware(makeRequest({ method: "GET", path: "/groups", cookieToken: existing }));
+  it("does not rotate the cookie when one already exists", async () => {
+    const res = (await middleware(
+      makeRequest({ method: "GET", path: "/groups", cookieToken: generateCsrfToken() }),
+    )) as NextResponse;
     expect(res.cookies.get(CSRF_COOKIE)).toBeUndefined();
   });
 
-  it("does not validate the token on non-/api/ POSTs (server actions)", () => {
-    const res = middleware(
+  it("does not validate the token on non-/api/ POSTs (server actions)", async () => {
+    const res = await middleware(
       makeRequest({ method: "POST", path: "/me", cookieToken: generateCsrfToken() }),
     );
     expect(res.status).toBe(200);
   });
 
-  it("does not validate the token on /api/ GETs", () => {
-    const res = middleware(makeRequest({ method: "GET", path: "/api/notifications" }));
+  it("does not validate the token on /api/ GETs", async () => {
+    const res = await middleware(makeRequest({ method: "GET", path: "/api/notifications" }));
     expect(res.status).toBe(200);
+  });
+});
+
+describe("middleware rate limiting on mutating /api/* routes", () => {
+  function mutatingRequest(path: string, ip: string): NextRequest {
+    const token = generateCsrfToken();
+    return makeRequest({
+      method: "POST",
+      path,
+      cookieToken: token,
+      headerToken: token,
+      ip,
+    });
+  }
+
+  it("allows up to capacity requests on a mutating /api/* route", async () => {
+    const capacity = LIMITS.questions.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      const res = await middleware(
+        mutatingRequest("/api/groups/foo/membership/u-1", "10.0.0.1"),
+      );
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it("returns 429 with Retry-After once the bucket is empty", async () => {
+    const capacity = LIMITS.questions.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      await middleware(mutatingRequest("/api/groups/foo/membership/u-1", "10.0.0.2"));
+    }
+    const res = await middleware(
+      mutatingRequest("/api/groups/foo/membership/u-1", "10.0.0.2"),
+    );
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("RateLimited");
+    const retry = res.headers.get("Retry-After");
+    expect(retry).not.toBeNull();
+    expect(Number(retry)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not rate-limit GET requests", async () => {
+    for (let i = 0; i < LIMITS.votes.capacity * 2; i += 1) {
+      const res = await middleware(
+        makeRequest({
+          method: "GET",
+          path: "/api/votes",
+          ip: "10.0.0.3",
+        }),
+      );
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it("scopes buckets by IP for unauthenticated requests", async () => {
+    const capacity = LIMITS.votes.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      await middleware(mutatingRequest("/api/votes", "1.1.1.1"));
+    }
+    const blocked = await middleware(mutatingRequest("/api/votes", "1.1.1.1"));
+    expect(blocked.status).toBe(429);
+    // A different IP has its own bucket.
+    const fresh = await middleware(mutatingRequest("/api/votes", "1.1.1.2"));
+    expect(fresh.status).not.toBe(429);
+  });
+
+  it("rate-limits BEFORE CSRF (so brute-force probes still consume budget)", async () => {
+    // Send capacity requests with NO CSRF tokens — they should 403, but each
+    // still consumes a token. The (capacity+1)th request should be 429, not
+    // 403, proving rate-limit ran first.
+    const capacity = LIMITS.questions.capacity;
+    for (let i = 0; i < capacity; i += 1) {
+      const res = await middleware(
+        makeRequest({
+          method: "POST",
+          path: "/api/groups/foo/membership/u-1",
+          ip: "10.0.0.99",
+        }),
+      );
+      expect(res.status).toBe(403);
+    }
+    const res = await middleware(
+      makeRequest({
+        method: "POST",
+        path: "/api/groups/foo/membership/u-1",
+        ip: "10.0.0.99",
+      }),
+    );
+    expect(res.status).toBe(429);
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,14 +6,30 @@ import {
   generateCsrfToken,
   verifyCsrfToken,
 } from "@/lib/csrf";
+import { applyRateLimitToApiRequest } from "@/lib/rate-limit";
 
 const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 
-export function middleware(req: NextRequest): NextResponse {
-  const existing = req.cookies.get(CSRF_COOKIE)?.value ?? null;
+/**
+ * Edge middleware combining rate-limiting and CSRF protection.
+ *
+ * Order is intentional:
+ *   1. Rate-limit mutating `/api/*` requests FIRST. Brute-force probes that
+ *      have no CSRF token must still consume rate-limit budget — otherwise the
+ *      attacker pays no cost for failed-CSRF requests.
+ *   2. CSRF check runs second on the same `/api/*` mutations. If the token
+ *      mismatches we reject with 403.
+ *   3. For all other requests (including non-`/api/*` GETs) we issue a fresh
+ *      `sme_csrf` cookie when one is missing so subsequent forms can echo it.
+ */
+export async function middleware(req: NextRequest): Promise<NextResponse | Response> {
   const isMutatingApi = csrfRequiresCheck(req.method, req.nextUrl.pathname);
 
   if (isMutatingApi) {
+    const limited = await applyRateLimitToApiRequest(req);
+    if (limited) return limited;
+
+    const existing = req.cookies.get(CSRF_COOKIE)?.value ?? null;
     const provided = req.headers.get(CSRF_HEADER);
     if (!verifyCsrfToken(provided, existing)) {
       return NextResponse.json(
@@ -27,6 +43,7 @@ export function middleware(req: NextRequest): NextResponse {
 
   // Non-mutating request. Issue a token if the user does not already have one
   // so that subsequent forms / fetches can echo it back.
+  const existing = req.cookies.get(CSRF_COOKIE)?.value ?? null;
   if (existing) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary

- Pluggable token-bucket rate limiter (`src/lib/rate-limit/`) keyed by user id when authed or IP when anonymous; MemoryStore ships now, `RateLimitStore` interface is async-ready for a Redis/KV swap.
- Per-group limits per the issue: signIn 5/min/IP, votes 30/min/user, favorites 30/min/user, questions/answers 10/min/user, plus a default 60/min/user catch-all so every mutating `/api/*` request has a ceiling.
- Middleware rate-limits `/api/*` mutations **before** the CSRF check (so brute-force probes still consume budget); `assertRateLimitForAction` is wired into the five mutating server actions (signIn, vote, favorite, ask-question, answer/question CRUD).
- Trusted-proxy IP extraction (`TRUSTED_PROXY_HOPS` env; prefer `cf-connecting-ip` / `x-real-ip`; skip private/loopback IPs) defeats client-supplied XFF spoofing.
- MemoryStore capped at 100k buckets with periodic sweep + FIFO eviction so IP rotation cannot exhaust the heap.

Closes #51

## Review verdicts

| Reviewer        | Verdict | Notes                                      |
|-----------------|---------|--------------------------------------------|
| Architecture    | ACCEPT  | Token-bucket math correct, store cleanly pluggable, ordering preserved |
| Security        | ACCEPT  | After fixes: XFF trust hardened, default group covers all mutating /api/* paths, MemoryStore bounded |
| Test coverage   | ACCEPT  | 504/504 pass — refill math, IP extraction, key isolation, sweep/eviction, middleware ordering |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds (Edge-runtime safe)
- [x] `npm test` — 504/504 pass
- [ ] Manual smoke: hammer `/api/votes` from a single IP and confirm 429 + `Retry-After`
- [ ] Manual smoke: 6 sign-ins from same IP within a minute → 6th is rate-limited
- [ ] Verify production deployment sets `TRUSTED_PROXY_HOPS` correctly for the chosen proxy topology

## Follow-ups (out of scope)

- Redis / Upstash KV implementation of `RateLimitStore` for multi-instance prod (interface is ready).
- Lint rule or checklist comment to ensure new mutating server actions remember to call `assertRateLimitForAction`.

Implemented by Claude Code multi-agent pipeline.