### PR TITLE
feat(errors): add app-wide error and not-found boundaries (closes #52)

### DIFF
--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import RootError from "./error";
+
+describe("RootError boundary", () => {
+  it("renders the branded error UI with a retry button", () => {
+    const reset = vi.fn();
+    const html = renderToStaticMarkup(
+      <RootError error={Object.assign(new Error("boom"), { digest: "abc123" })} reset={reset} />,
+    );
+    expect(html).toContain("Something went wrong");
+    expect(html).toContain("Try again");
+    expect(html).toContain("abc123");
+  });
+
+  it("omits the digest reference when none is provided", () => {
+    const html = renderToStaticMarkup(<RootError error={new Error("boom")} reset={() => {}} />);
+    expect(html).toContain("Try again");
+    expect(html).not.toContain("Reference:");
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/log-server-error";
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logServerError("page", error);
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-semibold tracking-tight">Something went wrong</h1>
+      <p className="text-zinc-600 dark:text-zinc-400">
+        An unexpected error occurred while rendering this page. You can try again, or head back to a
+        familiar place.
+      </p>
+      <Card>
+        <CardHeader>
+          <CardTitle>What happened</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The error was logged. If the problem persists, please report it to the team.
+          </p>
+          {error.digest ? (
+            <p className="font-mono text-xs text-muted-foreground">
+              Reference: <span data-testid="error-digest">{error.digest}</span>
+            </p>
+          ) : null}
+          <Button type="button" onClick={() => reset()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import { logServerError } from "@/lib/log-server-error";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logServerError("global", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#fafafa",
+          color: "#18181b",
+        }}
+      >
+        <div style={{ maxWidth: "32rem", padding: "1.5rem", textAlign: "center" }}>
+          <h1 style={{ fontSize: "1.75rem", fontWeight: 600, marginBottom: "0.5rem" }}>
+            SME Directory is having trouble loading
+          </h1>
+          <p style={{ color: "#52525b", marginBottom: "1.25rem" }}>
+            A critical error occurred. Please try again in a moment.
+          </p>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: "0.5rem",
+              border: "1px solid #d4d4d8",
+              background: "#18181b",
+              color: "#fafafa",
+              fontSize: "0.875rem",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/groups/[slug]/error.tsx
+++ b/src/app/groups/[slug]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/log-server-error";
+
+export default function GroupError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logServerError("page:groups/[slug]", error);
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Couldn&apos;t load this group</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Something went wrong</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            We hit an error rendering this group. Try again, or browse all groups.
+          </p>
+          {error.digest ? (
+            <p className="font-mono text-xs text-muted-foreground">
+              Reference: <span data-testid="error-digest">{error.digest}</span>
+            </p>
+          ) : null}
+          <Button type="button" onClick={() => reset()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -1,0 +1,14 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import NotFound from "./not-found";
+
+describe("NotFound boundary", () => {
+  it("renders branded 404 with quick links to home and groups", () => {
+    const html = renderToStaticMarkup(<NotFound />);
+    expect(html).toContain("Page not found");
+    expect(html).toContain('href="/"');
+    expect(html).toContain('href="/groups"');
+    expect(html).toContain('href="/search"');
+  });
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export default function NotFound() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-semibold tracking-tight">Page not found</h1>
+      <p className="text-zinc-600 dark:text-zinc-400">
+        We couldn&apos;t find what you were looking for. It may have been moved, deleted, or the
+        link might be wrong.
+      </p>
+      <Card>
+        <CardHeader>
+          <CardTitle>Quick links</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/" className={cn(buttonVariants({ variant: "default" }))}>
+              Home
+            </Link>
+            <Link href="/groups" className={cn(buttonVariants({ variant: "outline" }))}>
+              Browse groups
+            </Link>
+            <Link href="/search" className={cn(buttonVariants({ variant: "outline" }))}>
+              Search
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/q/[id]/error.test.tsx
+++ b/src/app/q/[id]/error.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import QuestionError from "./error";
+
+describe("Question segment error boundary", () => {
+  it("renders the segment-specific error UI with a retry button", () => {
+    const reset = vi.fn();
+    const html = renderToStaticMarkup(
+      <QuestionError error={new Error("db down")} reset={reset} />,
+    );
+    expect(html).toContain("Couldn&#x27;t load this question");
+    expect(html).toContain("Try again");
+  });
+});

--- a/src/app/q/[id]/error.tsx
+++ b/src/app/q/[id]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/log-server-error";
+
+export default function QuestionError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logServerError("page:q/[id]", error);
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Couldn&apos;t load this question</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Something went wrong</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            We hit an error rendering this question. Try again, or go back and pick another.
+          </p>
+          {error.digest ? (
+            <p className="font-mono text-xs text-muted-foreground">
+              Reference: <span data-testid="error-digest">{error.digest}</span>
+            </p>
+          ) : null}
+          <Button type="button" onClick={() => reset()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/u/[userId]/error.tsx
+++ b/src/app/u/[userId]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/log-server-error";
+
+export default function UserProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logServerError("page:u/[userId]", error);
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Couldn&apos;t load this profile</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Something went wrong</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            We hit an error rendering this profile. Try again in a moment.
+          </p>
+          {error.digest ? (
+            <p className="font-mono text-xs text-muted-foreground">
+              Reference: <span data-testid="error-digest">{error.digest}</span>
+            </p>
+          ) : null}
+          <Button type="button" onClick={() => reset()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/memberships";
 import { SlugConflictError } from "@/lib/groups";
 import { ImageTooLargeError, InvalidImageError } from "@/lib/avatars";
+import { logServerError } from "@/lib/log-server-error";
 
 export function unauthorized(): Response {
   return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -59,6 +60,6 @@ export function errorToResponse(err: unknown): Response {
     return validationFailed(err);
   }
   // Unknown — surface a generic 500. The error is intentionally not echoed back.
-  console.error("Unhandled error in route handler:", err);
+  logServerError("api", err);
   return Response.json({ error: "InternalServerError" }, { status: 500 });
 }

--- a/src/lib/log-server-error.ts
+++ b/src/lib/log-server-error.ts
@@ -1,0 +1,3 @@
+export function logServerError(scope: string, err: unknown): void {
+  console.error(`[${scope}]`, err);
+}


### PR DESCRIPTION
## Summary
- Closes #52. Failures used to fall through to the default Next.js error page and `notFound()` produced the bare framework 404 — both felt like the app crashed.
- Branded boundaries keep failures on-app (header/footer preserved) and give users a retry path.
- Page errors and the existing API 500 branch now share one `logServerError` seam, so a future logger swap is one place.

## Changes
- **App routes**: `app/error.tsx`, `app/global-error.tsx` (layout-level fallback with its own `<html>`), `app/not-found.tsx` with quick links to Home / Groups / Search.
- **Segment boundaries**: `error.tsx` for `/q/[id]`, `/groups/[slug]`, `/u/[userId]`, each with segment-specific copy and a retry button.
- **Logging**: new `src/lib/log-server-error.ts`; `src/lib/api/errors.ts` 500 branch routes through it.
- **Tests**: smoke tests for root error, not-found, and the `/q/[id]` segment boundary using `react-dom/server` (no jsdom needed).

## Test plan
- [x] `npm test` — 470 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean; `/_not-found` appears in the route map
- [ ] Manual: hit `/q/does-not-exist`, `/groups/does-not-exist`, `/u/does-not-exist` to see the branded 404; temporarily throw inside a page to see the segment error boundary render with header/footer intact (not run in this session)

## Notes
- `global-error.tsx` inlines styles since the global stylesheet may not be loaded when the root layout itself fails.
- Nested routes under `/groups/[slug]/*` (ask, leave, members, settings) bubble up to `groups/[slug]/error.tsx` per the issue's scope; can be tightened later if needed.