### PR TITLE
feat(ux): loading skeletons, a11y polish, and form UX hardening

### DIFF
--- a/src/app/api/groups/check-slug/route.test.ts
+++ b/src/app/api/groups/check-slug/route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * GET /api/groups/check-slug route handler tests.
+ *
+ * Mirrors the throw-away SQLite pattern used by the rest of the api/* tests.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testDbPath = path.join(os.tmpdir(), `sme-api-check-slug-test-${Date.now()}.db`);
+process.env.DATABASE_URL = `file:${testDbPath}`;
+process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+
+type Cookie = { name: string; value: string };
+const cookieStore = new Map<string, Cookie>();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => cookieStore.get(name),
+    set: (name: string, value: string) => {
+      cookieStore.set(name, { name, value });
+    },
+    delete: (name: string) => {
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+const auth = await import("@/lib/auth");
+const { db } = await import("@/lib/db");
+const { GET } = await import("./route");
+
+beforeAll(async () => {
+  const root = path.resolve(import.meta.dirname, "../../../../..");
+  execSync("node_modules/.bin/prisma migrate deploy", {
+    cwd: root,
+    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+    stdio: "pipe",
+  });
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  for (const ext of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${testDbPath}${ext}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+function makeRequest(slug: string): Request {
+  return new Request(`http://localhost/api/groups/check-slug?slug=${encodeURIComponent(slug)}`);
+}
+
+describe("GET /api/groups/check-slug", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await GET(makeRequest("anything"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns valid:false for a malformed slug", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await GET(makeRequest("Bad Slug!"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.valid).toBe(false);
+    expect(json.available).toBe(false);
+  });
+
+  it("returns valid:true, available:true when the slug is unused", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const slug = `free-${Date.now()}`;
+    const res = await GET(makeRequest(slug));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.valid).toBe(true);
+    expect(json.available).toBe(true);
+  });
+
+  it("returns valid:true, available:false when the slug already exists", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const slug = `taken-${Date.now()}`;
+    const user = await db.user.create({
+      data: { email: `slug-owner-${Date.now()}@example.com` },
+    });
+    await db.group.create({
+      data: { slug, name: "Taken", createdById: user.id },
+    });
+    const res = await GET(makeRequest(slug));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.valid).toBe(true);
+    expect(json.available).toBe(false);
+  });
+
+  it("returns valid:false on empty slug", async () => {
+    await auth.signIn(`u-${Date.now()}@example.com`);
+    const res = await GET(makeRequest(""));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.valid).toBe(false);
+  });
+});

--- a/src/app/api/groups/check-slug/route.ts
+++ b/src/app/api/groups/check-slug/route.ts
@@ -1,0 +1,45 @@
+import { getSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { errorToResponse, unauthorized } from "@/lib/api/errors";
+import { groupSlugSchema } from "@/lib/validation/groups";
+
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 30;
+const buckets = new Map<string, number[]>();
+
+function takeToken(userId: string, now: number): boolean {
+  const cutoff = now - RATE_WINDOW_MS;
+  const recent = (buckets.get(userId) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= RATE_MAX) {
+    buckets.set(userId, recent);
+    return false;
+  }
+  recent.push(now);
+  buckets.set(userId, recent);
+  return true;
+}
+
+export async function GET(req: Request): Promise<Response> {
+  try {
+    const session = await getSession();
+    if (!session) return unauthorized();
+
+    if (!takeToken(session.user.id, Date.now())) {
+      return Response.json({ error: "RateLimited" }, { status: 429 });
+    }
+
+    const url = new URL(req.url);
+    const raw = url.searchParams.get("slug") ?? "";
+    const parsed = groupSlugSchema.safeParse(raw);
+    if (!parsed.success) {
+      return Response.json({ valid: false, available: false }, { status: 200 });
+    }
+    const existing = await db.group.findUnique({
+      where: { slug: parsed.data },
+      select: { id: true },
+    });
+    return Response.json({ valid: true, available: existing === null }, { status: 200 });
+  } catch (err) {
+    return errorToResponse(err);
+  }
+}

--- a/src/app/groups/[slug]/ask/ask-question-form.tsx
+++ b/src/app/groups/[slug]/ask/ask-question-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useRef, useState } from "react";
 import { CsrfField } from "@/components/csrf-field";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
 import { createQuestionAction, type AskQuestionState } from "./actions";
 
 const initialState: AskQuestionState = {};
@@ -15,9 +16,20 @@ type Props = { slug: string };
 export function AskQuestionForm({ slug }: Props) {
   const action = createQuestionAction.bind(null, slug);
   const [state, formAction, isPending] = useActionState(action, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(isDirty && !isPending);
 
   return (
-    <form action={formAction} className="space-y-5">
+    <form
+      ref={formRef}
+      action={formAction}
+      onChange={() => setIsDirty(true)}
+      onSubmit={() => setIsDirty(false)}
+      className="space-y-5"
+    >
       <CsrfField />
       <div className="space-y-1">
         <label htmlFor="title" className="block text-sm font-medium">

--- a/src/app/groups/[slug]/loading.tsx
+++ b/src/app/groups/[slug]/loading.tsx
@@ -1,0 +1,51 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6" aria-busy="true" aria-live="polite">
+      <div className="rounded-lg border border-border">
+        <div className="space-y-3 border-b p-6">
+          <div className="flex items-start gap-3">
+            <div className="h-12 w-12 animate-pulse rounded-full bg-muted" />
+            <div className="space-y-2">
+              <div className="h-5 w-48 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-64 animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-3 p-6">
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-3/4 animate-pulse rounded bg-muted" />
+          <div className="h-8 w-32 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border">
+        <div className="space-y-2 border-b p-6">
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+        </div>
+        <ul className="space-y-2 p-6">
+          {[0, 1, 2, 3].map((i) => (
+            <li key={i} className="flex items-center gap-3">
+              <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
+              <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="rounded-lg border border-border">
+        <div className="border-b p-6">
+          <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+        </div>
+        <ul className="divide-y divide-border">
+          {[0, 1, 2].map((i) => (
+            <li key={i} className="space-y-2 p-6">
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/groups/[slug]/settings/archive-controls.tsx
+++ b/src/app/groups/[slug]/settings/archive-controls.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { readCsrfToken } from "@/lib/csrf-client";
 import { archiveGroupAction, unarchiveGroupAction } from "./actions";
 
@@ -12,16 +21,11 @@ type Props = {
 export function ArchiveControls({ slug, archived }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const onArchive = () => {
-    if (
-      !confirm(
-        "Archive this group? It becomes read-only — no new questions, answers, votes, or applications. The group is hidden from the default list and search; existing content stays browsable. You can restore it later.",
-      )
-    ) {
-      return;
-    }
+  const onArchiveConfirm = () => {
     setError(null);
+    setConfirmOpen(false);
     startTransition(async () => {
       const result = await archiveGroupAction(slug, readCsrfToken());
       if (result.error) setError(result.error);
@@ -48,14 +52,36 @@ export function ArchiveControls({ slug, archived }: Props) {
           {pending ? "Restoring…" : "Restore group"}
         </button>
       ) : (
-        <button
-          type="button"
-          onClick={onArchive}
-          disabled={pending}
-          className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-60 dark:border-red-700/60 dark:text-red-300 dark:hover:bg-red-900/20"
-        >
-          {pending ? "Archiving…" : "Archive group"}
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            disabled={pending}
+            className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-60 dark:border-red-700/60 dark:text-red-300 dark:hover:bg-red-900/20"
+          >
+            {pending ? "Archiving…" : "Archive group"}
+          </button>
+          <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Archive this group?</DialogTitle>
+                <DialogDescription>
+                  It becomes read-only — no new questions, answers, votes, or applications. The
+                  group is hidden from the default list and search; existing content stays
+                  browsable. You can restore it later.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="destructive" onClick={onArchiveConfirm}>
+                  Archive group
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
       )}
       {error ? (
         <span className="text-xs text-red-600 dark:text-red-400" role="alert">

--- a/src/app/groups/[slug]/settings/members-list.tsx
+++ b/src/app/groups/[slug]/settings/members-list.tsx
@@ -4,6 +4,14 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { UserAvatar } from "@/components/ui/user-avatar";
 
 export type MembersListItem = {
@@ -40,6 +48,7 @@ export function MembersList({
 }: Props) {
   const router = useRouter();
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [pendingRemoval, setPendingRemoval] = useState<MembersListItem | null>(null);
 
   if (members.length === 0) {
     return <p className="text-sm text-muted-foreground">No members yet.</p>;
@@ -68,11 +77,11 @@ export function MembersList({
     }
   }
 
-  async function remove(member: MembersListItem) {
+  async function confirmRemove() {
+    const member = pendingRemoval;
+    if (!member) return;
     const label = member.name ?? member.email ?? "this member";
-    if (!confirm(`Remove ${label} from the group? They will lose access immediately.`)) {
-      return;
-    }
+    setPendingRemoval(null);
     setBusyId(member.userId);
     try {
       const res = await fetch(`/api/groups/${slug}/membership/${member.userId}`, {
@@ -90,69 +99,89 @@ export function MembersList({
   }
 
   return (
-    <ul className="divide-y rounded-md border">
-      {members.map((m) => {
-        const showPromote =
-          viewerIsOwner && m.role === "member" && !archived;
-        const showDemote =
-          viewerIsOwner && m.role === "moderator" && !archived;
-        const showRemove =
-          m.role !== "owner" && m.userId !== viewerUserId && !archived;
-        const disabled = busyId !== null;
+    <>
+      <ul className="divide-y rounded-md border">
+        {members.map((m) => {
+          const showPromote = viewerIsOwner && m.role === "member" && !archived;
+          const showDemote = viewerIsOwner && m.role === "moderator" && !archived;
+          const showRemove = m.role !== "owner" && m.userId !== viewerUserId && !archived;
+          const disabled = busyId !== null || pendingRemoval !== null;
 
-        return (
-          <li key={m.userId} className="flex items-center justify-between gap-4 p-3">
-            <div className="flex items-center gap-3">
-              <UserAvatar user={m} size="sm" />
-              <div className="space-y-0.5">
-                <p className="text-sm font-medium">
-                  {m.name ?? m.email ?? m.userId}
-                </p>
-                {m.name && m.email ? (
-                  <p className="text-xs text-muted-foreground">{m.email}</p>
+          return (
+            <li key={m.userId} className="flex items-center justify-between gap-4 p-3">
+              <div className="flex items-center gap-3">
+                <UserAvatar user={m} size="sm" />
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">{m.name ?? m.email ?? m.userId}</p>
+                  {m.name && m.email ? (
+                    <p className="text-xs text-muted-foreground">{m.email}</p>
+                  ) : null}
+                </div>
+                {m.role !== "member" ? (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {m.role}
+                  </span>
                 ) : null}
               </div>
-              {m.role !== "member" ? (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {m.role}
-                </span>
-              ) : null}
-            </div>
-            <div className="flex items-center gap-2">
-              {showPromote ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={disabled}
-                  onClick={() => changeRole(m, "moderator")}
-                >
-                  {busyId === m.userId ? "…" : "Promote to moderator"}
-                </Button>
-              ) : null}
-              {showDemote ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={disabled}
-                  onClick={() => changeRole(m, "member")}
-                >
-                  {busyId === m.userId ? "…" : "Demote to member"}
-                </Button>
-              ) : null}
-              {showRemove ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={disabled}
-                  onClick={() => remove(m)}
-                >
-                  {busyId === m.userId ? "…" : "Remove"}
-                </Button>
-              ) : null}
-            </div>
-          </li>
-        );
-      })}
-    </ul>
+              <div className="flex items-center gap-2">
+                {showPromote ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => changeRole(m, "moderator")}
+                  >
+                    {busyId === m.userId ? "…" : "Promote to moderator"}
+                  </Button>
+                ) : null}
+                {showDemote ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => changeRole(m, "member")}
+                  >
+                    {busyId === m.userId ? "…" : "Demote to member"}
+                  </Button>
+                ) : null}
+                {showRemove ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setPendingRemoval(m)}
+                  >
+                    {busyId === m.userId ? "…" : "Remove"}
+                  </Button>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <Dialog
+        open={pendingRemoval !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemoval(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Remove {pendingRemoval?.name ?? pendingRemoval?.email ?? "this member"}?
+            </DialogTitle>
+            <DialogDescription>They will lose access to the group immediately.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingRemoval(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmRemove}>
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { CsrfField } from "@/components/csrf-field";
-import { slugify } from "@/lib/slug";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
+import { SLUG_MIN_LENGTH, slugify } from "@/lib/slug";
 import { createGroupAction, type CreateGroupState } from "./actions";
 
 const initialState: CreateGroupState = {};
+
+type SlugStatus =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "available" }
+  | { kind: "taken" }
+  | { kind: "invalid" };
 
 function fieldError(state: CreateGroupState, path: string): string | undefined {
   return state.fieldErrors?.find((e) => e.path === path)?.message;
@@ -16,9 +24,64 @@ export function NewGroupForm() {
   const [name, setName] = useState(state.values?.name ?? "");
   const [slugOverride, setSlugOverride] = useState<string | null>(state.values?.slug ?? null);
   const slug = slugOverride ?? slugify(name);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [checked, setChecked] = useState<{ slug: string; status: SlugStatus }>({
+    slug: "",
+    status: { kind: "idle" },
+  });
+  const slugStatus: SlugStatus =
+    slug.length < SLUG_MIN_LENGTH
+      ? { kind: "idle" }
+      : checked.slug === slug
+        ? checked.status
+        : { kind: "checking" };
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(isDirty && !isPending);
+
+  useEffect(() => {
+    if (slug.length < SLUG_MIN_LENGTH) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/groups/check-slug?slug=${encodeURIComponent(slug)}`, {
+          method: "GET",
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setChecked({ slug, status: { kind: "idle" } });
+          return;
+        }
+        const body = (await res.json()) as { valid: boolean; available: boolean };
+        if (cancelled) return;
+        if (!body.valid) {
+          setChecked({ slug, status: { kind: "invalid" } });
+        } else if (body.available) {
+          setChecked({ slug, status: { kind: "available" } });
+        } else {
+          setChecked({ slug, status: { kind: "taken" } });
+        }
+      } catch {
+        if (!cancelled) setChecked({ slug, status: { kind: "idle" } });
+      }
+    }, 350);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [slug]);
+
+  const slugFieldError = fieldError(state, "slug");
 
   return (
-    <form action={formAction} className="space-y-5">
+    <form
+      ref={formRef}
+      action={formAction}
+      onChange={() => setIsDirty(true)}
+      onSubmit={() => setIsDirty(false)}
+      className="space-y-5"
+    >
       <CsrfField />
       <div className="space-y-1">
         <label htmlFor="name" className="block text-sm font-medium">
@@ -52,19 +115,36 @@ export function NewGroupForm() {
           name="slug"
           type="text"
           required
-          minLength={2}
+          minLength={SLUG_MIN_LENGTH}
           maxLength={64}
           value={slug}
           onChange={(e) => setSlugOverride(e.target.value)}
           placeholder="kubernetes"
+          aria-invalid={
+            slugStatus.kind === "taken" || slugStatus.kind === "invalid" || Boolean(slugFieldError)
+          }
+          aria-describedby="slug-status"
           className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
         />
         <p className="text-xs text-zinc-500 dark:text-zinc-400">
           URL-safe identifier. Auto-derived from the name; edit if you want a different one.
         </p>
-        {fieldError(state, "slug") ? (
+        <p id="slug-status" aria-live="polite" className="min-h-[1rem] text-xs">
+          {slugStatus.kind === "checking" ? (
+            <span className="text-zinc-500 dark:text-zinc-400">Checking availability…</span>
+          ) : slugStatus.kind === "available" ? (
+            <span className="text-green-700 dark:text-green-400">Available</span>
+          ) : slugStatus.kind === "taken" ? (
+            <span className="text-red-600 dark:text-red-400">Already taken</span>
+          ) : slugStatus.kind === "invalid" ? (
+            <span className="text-red-600 dark:text-red-400">
+              Use lowercase letters, numbers, and dashes.
+            </span>
+          ) : null}
+        </p>
+        {slugFieldError ? (
           <p className="text-sm text-red-600 dark:text-red-400" role="alert">
-            {fieldError(state, "slug")}
+            {slugFieldError}
           </p>
         ) : null}
       </div>
@@ -110,7 +190,7 @@ export function NewGroupForm() {
 
       <button
         type="submit"
-        disabled={isPending}
+        disabled={isPending || slugStatus.kind === "taken" || slugStatus.kind === "invalid"}
         className="w-full rounded bg-zinc-900 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
       >
         {isPending ? "Creating…" : "Create group"}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,6 +36,12 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="flex min-h-full flex-col bg-background text-foreground">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:ring-2 focus:ring-ring focus:outline-none"
+        >
+          Skip to content
+        </a>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"
@@ -44,7 +50,13 @@ export default async function RootLayout({
         >
           <SessionProvider initialSession={session}>
             <SiteHeader />
-            <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">{children}</main>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="mx-auto w-full max-w-5xl flex-1 px-4 py-8 focus:outline-none"
+            >
+              {children}
+            </main>
             <SiteFooter />
             <Toaster />
           </SessionProvider>

--- a/src/app/me/edit-profile-form.tsx
+++ b/src/app/me/edit-profile-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useActionState, useEffect, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { CsrfField } from "@/components/csrf-field";
 import { MarkdownBody } from "@/components/markdown-body";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
 import { updateMeAction, type MeFormState } from "./actions";
 
 const initialState: MeFormState = {};
@@ -19,17 +20,29 @@ type Props = {
 export function EditProfileForm({ name, bio }: Props) {
   const [editing, setEditing] = useState(false);
   const [state, formAction, isPending] = useActionState(updateMeAction, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(editing && isDirty && !isPending);
 
   useEffect(() => {
     if (state.ok) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditing(false);
+      setIsDirty(false);
     }
   }, [state.ok]);
 
   if (editing) {
     return (
-      <form action={formAction} className="space-y-3">
+      <form
+        ref={formRef}
+        action={formAction}
+        onChange={() => setIsDirty(true)}
+        onSubmit={() => setIsDirty(false)}
+        className="space-y-3"
+      >
         <CsrfField />
         <div className="space-y-1">
           <label htmlFor="edit-profile-name" className="block text-sm font-medium">
@@ -87,7 +100,10 @@ export function EditProfileForm({ name, bio }: Props) {
           </button>
           <button
             type="button"
-            onClick={() => setEditing(false)}
+            onClick={() => {
+              setEditing(false);
+              setIsDirty(false);
+            }}
             className="rounded border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
           >
             Cancel

--- a/src/app/me/loading.tsx
+++ b/src/app/me/loading.tsx
@@ -1,0 +1,38 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6" aria-busy="true" aria-live="polite">
+      <div className="rounded-lg border border-border">
+        <div className="border-b p-6">
+          <div className="flex items-start gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="flex-1 space-y-2">
+              <div className="h-5 w-48 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-64 animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4 p-6">
+          <div className="h-9 w-40 animate-pulse rounded-md bg-muted" />
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-20 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="rounded-lg border border-border">
+          <div className="border-b p-6">
+            <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+          </div>
+          <ul className="divide-y divide-border">
+            {[0, 1].map((j) => (
+              <li key={j} className="space-y-2 p-6">
+                <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/q/[id]/answer-form.tsx
+++ b/src/app/q/[id]/answer-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useActionState, useEffect, useRef } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { CsrfField } from "@/components/csrf-field";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
 import { createAnswerAction, type AnswerFormState } from "./actions";
 
 const initialState: AnswerFormState = {};
@@ -16,15 +17,26 @@ export function AnswerForm({ questionId }: Props) {
   const action = createAnswerAction.bind(null, questionId);
   const [state, formAction, isPending] = useActionState(action, initialState);
   const formRef = useRef<HTMLFormElement>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(isDirty && !isPending);
 
   useEffect(() => {
     if (state.ok && formRef.current) {
       formRef.current.reset();
+      setIsDirty(false);
     }
   }, [state.ok]);
 
   return (
-    <form ref={formRef} action={formAction} className="space-y-3">
+    <form
+      ref={formRef}
+      action={formAction}
+      onChange={() => setIsDirty(true)}
+      onSubmit={() => setIsDirty(false)}
+      className="space-y-3"
+    >
       <CsrfField />
       <div className="space-y-1">
         <label htmlFor="answer-body" className="block text-sm font-medium">

--- a/src/app/q/[id]/edit-question-form.tsx
+++ b/src/app/q/[id]/edit-question-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useActionState, useEffect, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import { CsrfField } from "@/components/csrf-field";
 import { MarkdownBody } from "@/components/markdown-body";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
 import { updateQuestionAction, type QuestionFormState } from "./actions";
 
 const initialState: QuestionFormState = {};
@@ -23,17 +24,29 @@ export function EditQuestionForm({ questionId, title, body, canEdit }: Props) {
 
   const action = updateQuestionAction.bind(null, questionId);
   const [state, formAction, isPending] = useActionState(action, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(editing && isDirty && !isPending);
 
   useEffect(() => {
     if (state.ok) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditing(false);
+      setIsDirty(false);
     }
   }, [state.ok]);
 
   if (editing) {
     return (
-      <form action={formAction} className="space-y-3">
+      <form
+        ref={formRef}
+        action={formAction}
+        onChange={() => setIsDirty(true)}
+        onSubmit={() => setIsDirty(false)}
+        className="space-y-3"
+      >
         <CsrfField />
         <div className="space-y-1">
           <label htmlFor="edit-question-title" className="block text-sm font-medium">
@@ -93,7 +106,10 @@ export function EditQuestionForm({ questionId, title, body, canEdit }: Props) {
           </button>
           <button
             type="button"
-            onClick={() => setEditing(false)}
+            onClick={() => {
+              setEditing(false);
+              setIsDirty(false);
+            }}
             className="rounded border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
           >
             Cancel

--- a/src/app/q/[id]/loading.tsx
+++ b/src/app/q/[id]/loading.tsx
@@ -1,0 +1,43 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 py-8" aria-busy="true" aria-live="polite">
+      <div className="rounded-lg border border-border">
+        <div className="space-y-3 border-b p-6">
+          <div className="h-7 w-3/4 animate-pulse rounded bg-muted" />
+          <div className="flex items-center gap-2">
+            <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
+            <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+        <div className="space-y-3 p-6">
+          <div className="flex gap-2">
+            <div className="h-8 w-20 animate-pulse rounded-md bg-muted" />
+            <div className="h-8 w-20 animate-pulse rounded-md bg-muted" />
+          </div>
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+        <ul className="space-y-3">
+          {[0, 1].map((i) => (
+            <li key={i} className="rounded-lg border border-border">
+              <div className="space-y-3 p-6">
+                <div className="flex items-center gap-3">
+                  <div className="h-8 w-12 animate-pulse rounded-md bg-muted" />
+                  <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
+                  <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                </div>
+                <div className="h-3 w-full animate-pulse rounded bg-muted" />
+                <div className="h-3 w-5/6 animate-pulse rounded bg-muted" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/u/[userId]/loading.tsx
+++ b/src/app/u/[userId]/loading.tsx
@@ -1,0 +1,32 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6" aria-busy="true" aria-live="polite">
+      <div className="rounded-lg border border-border">
+        <div className="space-y-3 border-b p-6">
+          <div className="h-6 w-48 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-64 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="space-y-2 p-6">
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="rounded-lg border border-border">
+          <div className="border-b p-6">
+            <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+          </div>
+          <ul className="divide-y divide-border">
+            {[0, 1].map((j) => (
+              <li key={j} className="space-y-2 p-6">
+                <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/markdown-body.tsx
+++ b/src/components/markdown-body.tsx
@@ -1,13 +1,30 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 type Props = { source: string };
 
+const components: Components = {
+  table: ({ children, ...props }) => (
+    <div className="overflow-x-auto">
+      <table {...props}>{children}</table>
+    </div>
+  ),
+  pre: ({ children, ...props }) => (
+    <pre tabIndex={0} {...props}>
+      {children}
+    </pre>
+  ),
+};
+
 export function MarkdownBody({ source }: Props) {
   return (
     <div className="prose prose-zinc max-w-none text-sm dark:prose-invert">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={components}
+      >
         {source}
       </ReactMarkdown>
     </div>

--- a/src/components/nav-link.tsx
+++ b/src/components/nav-link.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  href: string;
+  exact?: boolean;
+  className?: string;
+  activeClassName?: string;
+  inactiveClassName?: string;
+  children: React.ReactNode;
+};
+
+export function NavLink({
+  href,
+  exact = false,
+  className,
+  activeClassName = "text-foreground font-medium",
+  inactiveClassName = "text-muted-foreground hover:text-foreground",
+  children,
+}: Props) {
+  const pathname = usePathname();
+  // The root path "/" matches every pathname's startsWith check, so always treat it as exact.
+  const exactMatch = exact || href === "/";
+  const isActive = exactMatch
+    ? pathname === href
+    : pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(className, isActive ? activeClassName : inactiveClassName)}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { UserMenu } from "@/components/auth/user-menu";
 import { HeaderSearch } from "@/components/header-search";
 import { ModeToggle } from "@/components/mode-toggle";
+import { NavLink } from "@/components/nav-link";
 import { NotificationBell } from "@/components/notification-bell";
 
 export function SiteHeader() {
@@ -15,9 +16,7 @@ export function SiteHeader() {
         <div className="flex flex-1 items-center justify-end gap-3">
           <HeaderSearch />
           <nav className="flex items-center gap-3 text-sm">
-            <Link href="/groups" className="text-muted-foreground hover:text-foreground">
-              Groups
-            </Link>
+            <NavLink href="/groups">Groups</NavLink>
             <ModeToggle />
             <NotificationBell />
             <UserMenu />

--- a/src/lib/forms.ts
+++ b/src/lib/forms.ts
@@ -1,0 +1,55 @@
+import { useEffect, type RefObject } from "react";
+
+export type FieldError = { path: string; message: string };
+
+/**
+ * Focus the first invalid field after a submit error.
+ *
+ * Why: server-action forms render error text inline but never move focus, so
+ * keyboard/screen-reader users have to hunt for the failing field. This watches
+ * `fieldErrors` and sends focus to the first matching `[name=...]` inside the form.
+ */
+export function findFirstErrorField(
+  form: HTMLFormElement | ParentNode,
+  fieldErrors: readonly FieldError[] | undefined,
+): HTMLElement | null {
+  if (!fieldErrors || fieldErrors.length === 0) return null;
+  for (const err of fieldErrors) {
+    const el = form.querySelector<HTMLElement>(`[name="${CSS.escape(err.path)}"]`);
+    if (el) return el;
+  }
+  return null;
+}
+
+export function useFocusFirstError(
+  formRef: RefObject<HTMLFormElement | null>,
+  fieldErrors: readonly FieldError[] | undefined,
+): void {
+  useEffect(() => {
+    if (!fieldErrors || fieldErrors.length === 0) return;
+    const form = formRef.current;
+    if (!form) return;
+    const el = findFirstErrorField(form, fieldErrors);
+    if (el && typeof el.focus === "function") el.focus();
+  }, [fieldErrors, formRef]);
+}
+
+/**
+ * Warn before navigating away with unsaved form changes.
+ *
+ * Covers tab close, browser back/forward, and external navigation via the
+ * `beforeunload` event. In-app Next.js navigation is not reliably interceptable,
+ * so this only protects against hard navigation — which is where users
+ * actually lose unsaved long-form content.
+ */
+export function useUnsavedChangesWarning(isDirty: boolean): void {
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,4 +1,5 @@
 export const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const SLUG_MIN_LENGTH = 2;
 export const SLUG_MAX_LENGTH = 64;
 
 const COMBINING_MARKS = /[̀-ͯ]/g;
@@ -16,5 +17,5 @@ export function slugify(input: string): string {
 }
 
 export function isValidSlug(s: string): boolean {
-  return s.length >= 2 && s.length <= SLUG_MAX_LENGTH && SLUG_RE.test(s);
+  return s.length >= SLUG_MIN_LENGTH && s.length <= SLUG_MAX_LENGTH && SLUG_RE.test(s);
 }

--- a/src/lib/validation/groups.ts
+++ b/src/lib/validation/groups.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { SLUG_RE, SLUG_MAX_LENGTH } from "@/lib/slug";
+import { SLUG_RE, SLUG_MIN_LENGTH, SLUG_MAX_LENGTH } from "@/lib/slug";
 
 export const groupNameSchema = z
   .string()
@@ -14,7 +14,7 @@ export const groupDescriptionSchema = z
 
 export const groupSlugSchema = z
   .string()
-  .min(2, "Slug must be at least 2 characters.")
+  .min(SLUG_MIN_LENGTH, `Slug must be at least ${SLUG_MIN_LENGTH} characters.`)
   .max(SLUG_MAX_LENGTH, `Slug must be at most ${SLUG_MAX_LENGTH} characters.`)
   .regex(SLUG_RE, "Slug must be lowercase letters, numbers, and single dashes between segments.");
 


### PR DESCRIPTION
## Summary
- Knocks out the umbrella checklist in #53: loading states, a11y gaps, and form polish, all shippable as one bundle since they touch overlapping surfaces (layout, forms, dialogs).
- Replaces `window.confirm()` for destructive actions (archive group, remove member) with focus-trapped `Dialog`s so keyboard and screen-reader users get proper modal semantics.
- Adds debounced async slug availability checks on the new-group form so users see conflicts before submitting; backed by an authenticated, rate-limited API to discourage enumeration.

Closes #53

## Changes
- **Loading**: route-level `loading.tsx` skeletons for `/groups/:slug`, `/q/:id`, `/me`, `/u/:userId`.
- **A11y**: skip-to-content link in root layout, focusable `<main>`, `aria-current="page"` via new `NavLink`, focusable `<pre>` blocks in markdown rendering.
- **Forms**: shared `useFocusFirstError` and `useUnsavedChangesWarning` hooks in `src/lib/forms.ts`, wired into ask/answer/edit-question/edit-profile/new-group forms.
- **API**: new `GET /api/groups/check-slug` returning `{valid, available}`, with a 30-req/min per-user in-memory throttle and tests.
- **Misc**: `SLUG_MIN_LENGTH` exported from `src/lib/slug.ts` and reused in the schema and form input.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test -- --run src/app/api/groups/check-slug` (5 tests pass)
- [ ] Manual: visit `/groups/new`, type a name, confirm "Checking…/Available/Already taken/Invalid" status text and that submit disables on conflict.
- [ ] Manual: open archive and member-remove dialogs with keyboard only; verify focus trap and Escape closes.
- [ ] Manual: tab through a page and confirm the skip link appears on focus and jumps to `<main>`.

## Notes
- Rate limiter is in-memory per process; fine for the single-deployable v1, will need a shared store if we ever run multi-instance.
- `aria-pressed` on vote/favorite toggles from the issue checklist was left for a follow-up — those buttons live in components not touched here and warrant their own pass.