### PR TITLE
chore(make): add db-init and db-clean targets to refresh dev database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .DEFAULT_GOAL := help
 .PHONY: help setup install dev build start lint typecheck format format-check check clean reset \
-        db-migrate db-deploy db-reset db-seed db-studio
+        db-migrate db-deploy db-reset db-seed db-studio db-init db-clean
 
 NODE_MODULES := node_modules/.package-lock.json
 
@@ -70,3 +70,10 @@ db-seed: ## Seed the dev database (TODO: #17)
 
 db-studio: install ## Open Prisma Studio
 	npm run db:studio
+
+db-clean: ## Delete the dev SQLite file (DESTRUCTIVE — wipes data)
+	rm -f prisma/dev.db prisma/dev.db-journal
+
+db-init: install .env ## Refresh dev DB: apply migrations + run seed
+	npx prisma migrate deploy
+	npx prisma db seed


### PR DESCRIPTION
## Summary
- Bootstrapping a fresh clone required chaining raw `prisma` calls or remembering the npm script names; new developers (and AI agents) hit "DATABASE_URL not found" because `.env` wasn't created yet.
- Adds two opinionated entrypoints so `make db-clean db-init` reliably refreshes the dev SQLite from a clean slate.

## Changes
- `Makefile`: new `db-clean` (deletes `prisma/dev.db` + journal) and `db-init` (depends on `install` and the existing `.env` rule, then runs `prisma migrate deploy` + `prisma db seed`). Both added to `.PHONY`.

## Test plan
- [x] `make help` lists both new targets
- [x] `make db-clean && make db-init` against this workspace: migrations applied, seed produced 5 users / 5 groups / 50 questions / 140 notifications
- [x] `db-init`'s `.env` prereq creates `.env` from `.env.example` when missing (existing rule, exercised by the chain)

## Notes
- `db-init` is intentionally not wired as a dep of `db-clean` so destructive wipes stay explicit. `db-seed`'s "TODO #17" placeholder is left untouched — separate cleanup.