### PR TITLE
fix(make): regenerate Prisma client in db-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,6 @@ db-clean: ## Delete the dev SQLite file (DESTRUCTIVE — wipes data)
 	rm -f prisma/dev.db prisma/dev.db-journal
 
 db-init: install .env ## Refresh dev DB: apply migrations + run seed
+	npx prisma generate
 	npx prisma migrate deploy
 	npx prisma db seed


### PR DESCRIPTION
## Summary

- `make db-init` (added in #76) failed with `table main.User does not exist` when the cached Prisma client had been generated inside a paseo agent worktree.
- The runtime client embeds `sourceFilePath` and resolves `file:./dev.db` against it, so migrate writes to `prisma/dev.db` while seed reads an empty ghost DB under `.claude/worktrees/agent-…/prisma/dev.db`.
- Adding `npx prisma generate` as the first step of `db-init` rewrites `sourceFilePath` to the current clone, making the target self-healing on any machine where a stale client got cached.

## Test plan

- [x] In a clone with a stale `sourceFilePath`: ran `make db-clean && make db-init` — completes cleanly; seed reports `users: 5, groups: 5, …`; `sqlite3 prisma/dev.db "SELECT count(*) FROM User"` returns 5.
- [x] In a healthy clone: ran `make db-clean && make db-init` — happy path still passes; the extra `prisma generate` is a ~40ms no-op.
- [x] Verified `grep sourceFilePath node_modules/.prisma/client/index.js` resolves to the current clone's `prisma/schema.prisma` after `db-init`.