### PR TITLE
chore(db): make Prisma query logging opt-in via PRISMA_LOG_QUERIES

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,10 +2,13 @@ import { PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
+const isDev = process.env.NODE_ENV === "development";
+const logQueries = process.env.PRISMA_LOG_QUERIES === "1";
+
 export const db =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
+    log: isDev ? (logQueries ? ["query", "error", "warn"] : ["error", "warn"]) : ["error"],
   });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = db;


### PR DESCRIPTION
## Summary
- Dev server stdout was flooded with `prisma:query` lines for every request, drowning out warnings and app logs.
- Move query logging behind an opt-in env flag so the default dev experience is quiet but SQL inspection is still one variable away.

## Changes
- `src/lib/db.ts`: default dev `log` is now `["error", "warn"]`; setting `PRISMA_LOG_QUERIES=1` restores `["query", "error", "warn"]`. Production remains `["error"]`.

## Test plan
- [x] `npx tsc --noEmit` passes.
- [ ] Restart `npm run dev` and confirm no `prisma:query` lines appear during normal browsing.
- [ ] Run `PRISMA_LOG_QUERIES=1 npm run dev` and confirm query logs return.