### PR TITLE
test(ui): add React Testing Library component tests (closes #55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,52 @@ Specs live in [e2e/](e2e/) and run against an isolated SQLite database (`prisma/
 - **Adding a spec**: drop a `*.spec.ts` under `e2e/`. Prefer `getByRole` / `getByLabel` over CSS selectors. Drive flows through the UI rather than calling APIs directly so middleware, CSRF, and server actions all get exercised. Use timestamped emails / slugs (e.g. `owner-${Date.now()}@example.com`) so reruns don't collide with prior state when the DB isn't reset between runs.
 - **Two-user flows**: open a separate `browser.newContext()` per user so session cookies don't clash.
 - **Caveats**: tests run serially (`fullyParallel: false`, `workers: 1`) because the DB is shared. Reports land in `playwright-report/` and traces in `test-results/` — both gitignored.
+
+## Component tests (Vitest + React Testing Library)
+
+Component tests run in jsdom and live alongside their components. They are configured as a separate Vitest project so the existing node-environment route and lib tests stay in node — see [vitest.config.ts](vitest.config.ts).
+
+- **Run**: `npm run test` (runs both `node` and `dom` projects). `npm run test:watch` for watch mode.
+- **File suffix**: `*.dom.test.tsx`. Anything else stays in the node project.
+- **Location**: colocate with the component (e.g. `src/components/foo.tsx` → `src/components/foo.dom.test.tsx`).
+- **Setup**: jsdom + `@testing-library/jest-dom` matchers + RTL `cleanup` are registered by [test/setup-dom.ts](test/setup-dom.ts) — no per-file imports needed beyond `@testing-library/react` and `@testing-library/user-event`.
+
+### Mocking common dependencies
+
+- `next/navigation` — hoist a shared spy so the mock and assertions point at the same function:
+  ```ts
+  const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+  vi.mock("next/navigation", () => ({ useRouter: () => ({ replace }) }));
+  ```
+- `@/lib/csrf-client` — stub the token reader and fetch wrapper so tests don't need a `sme_csrf` cookie:
+  ```ts
+  vi.mock("@/lib/csrf-client", () => ({
+    readCsrfToken: vi.fn(() => "test-token"),
+    csrfFetch: vi.fn(() => Promise.resolve(new Response("{}", { status: 200 }))),
+  }));
+  ```
+- `@/lib/auth-client` (`useSession`) — `vi.mock` it and set the return value per test (`mockedUseSession.mockReturnValue(...)`).
+- Server actions (e.g. `voteAction`, `favoriteAction`) — mock the local module: `vi.mock("./vote-actions", () => ({ voteAction: vi.fn() }))`.
+- `global.fetch` — `vi.stubGlobal("fetch", vi.fn(...))`; reset in `afterEach` with `vi.unstubAllGlobals()`.
+
+### Timers and debounce
+
+Two strategies depending on what you're testing:
+
+- **Debounce / typeahead** (`SearchControls`, `AuthorPicker`): keep real timers and assert with `waitFor`. Combining `userEvent` with `vi.useFakeTimers()` is fragile (we hit hangs in jsdom).
+  ```ts
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText(/search/i), "hello");
+  await waitFor(() => expect(replace).toHaveBeenCalled());
+  ```
+- **Polling intervals** (`NotificationBell`): fake only the interval timers so we can advance through poll cycles deterministically.
+  ```ts
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  await act(async () => { vi.advanceTimersByTime(30_000); });
+  ```
+
+`NotificationBell` queues its initial fetch as a microtask (`Promise.resolve().then(...)`); flush with `await act(async () => { await Promise.resolve(); })` before asserting on rendered state.
+
+### What to test
+
+Behavior, not implementation. Good targets: optimistic UI updates, error rollback, ARIA roles/names (`aria-pressed`, `aria-label`, `role="alert"`), debounce-driven side effects (`router.replace` URL contents, fetch URLs). Avoid asserting on Tailwind class strings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,9 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -38,6 +41,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "eslint-config-prettier": "^10.1.8",
+        "jsdom": "^25.0.1",
         "prettier": "^3.8.3",
         "prisma": "^6.19.3",
         "tailwindcss": "^4",
@@ -45,6 +49,13 @@
         "typescript": "^5",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -56,6 +67,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -502,6 +534,121 @@
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2075,6 +2222,107 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -2149,6 +2397,14 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3012,6 +3268,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -3490,6 +3753,19 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3626,6 +3902,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3637,6 +3920,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3654,6 +3958,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3718,6 +4036,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3845,6 +4170,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3908,6 +4243,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4000,6 +4343,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -5030,6 +5386,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -5494,6 +5890,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
@@ -5527,6 +5936,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5594,6 +6017,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6016,6 +6449,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6289,6 +6729,80 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "license": "MIT",
@@ -6554,6 +7068,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7554,6 +8079,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "dev": true,
@@ -7864,6 +8399,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nypm": {
       "version": "0.6.6",
@@ -8236,6 +8778,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8447,6 +9002,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -8706,6 +9310,20 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8977,6 +9595,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -9064,6 +9689,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -9700,6 +10338,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "dev": true,
@@ -9771,6 +10422,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -9927,6 +10585,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -10632,6 +11303,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -10639,6 +11323,67 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -10822,6 +11567,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -10837,6 +11604,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -53,6 +56,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^25.0.1",
     "prettier": "^3.8.3",
     "prisma": "^6.19.3",
     "tailwindcss": "^4",

--- a/src/app/q/[id]/favorite-button.dom.test.tsx
+++ b/src/app/q/[id]/favorite-button.dom.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FavoriteButton } from "./favorite-button";
+import { favoriteAction } from "./favorite-actions";
+
+vi.mock("./favorite-actions", () => ({
+  favoriteAction: vi.fn(),
+}));
+
+vi.mock("@/lib/csrf-client", () => ({
+  readCsrfToken: vi.fn(() => "test-token"),
+}));
+
+const mockedFavoriteAction = vi.mocked(favoriteAction);
+
+const baseProps = {
+  targetType: "question" as const,
+  targetId: "q-1",
+  questionId: "q-1",
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("FavoriteButton", () => {
+  it("renders not favorited initially", () => {
+    render(<FavoriteButton {...baseProps} initialFavorited={false} />);
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("optimistically toggles and confirms with server", async () => {
+    let resolveFavorite: (
+      v: Awaited<ReturnType<typeof favoriteAction>>,
+    ) => void = () => {};
+    mockedFavoriteAction.mockImplementation(
+      () =>
+        new Promise<Awaited<ReturnType<typeof favoriteAction>>>((resolve) => {
+          resolveFavorite = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<FavoriteButton {...baseProps} initialFavorited={false} />);
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+
+    await user.click(button);
+
+    // Optimistic flip happens before the server resolves.
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("aria-label", "Remove from favorites");
+    expect(mockedFavoriteAction).toHaveBeenCalledWith(
+      "question",
+      "q-1",
+      "q-1",
+      "test-token",
+    );
+
+    resolveFavorite({ ok: true, favorited: true });
+
+    // Reconciliation preserves the optimistic state.
+    await screen.findByRole("button", { name: "Remove from favorites" });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("rolls back and surfaces the server error on failure", async () => {
+    mockedFavoriteAction.mockResolvedValue({
+      ok: false,
+      error: "You must be approved in this group to favorite.",
+    });
+
+    const user = userEvent.setup();
+    render(<FavoriteButton {...baseProps} initialFavorited={false} />);
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+
+    await user.click(button);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "You must be approved in this group to favorite.",
+    );
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("does not invoke the action when disabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <FavoriteButton
+        {...baseProps}
+        initialFavorited={false}
+        disabled
+        disabledReason="Sign in to favorite."
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "Sign in to favorite.");
+
+    await user.click(button);
+    expect(mockedFavoriteAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/q/[id]/vote-button.dom.test.tsx
+++ b/src/app/q/[id]/vote-button.dom.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VoteButton } from "./vote-button";
+import { voteAction } from "./vote-actions";
+
+vi.mock("./vote-actions", () => ({
+  voteAction: vi.fn(),
+}));
+
+vi.mock("@/lib/csrf-client", () => ({
+  readCsrfToken: vi.fn(() => "test-token"),
+}));
+
+const mockedVoteAction = vi.mocked(voteAction);
+
+const baseProps = {
+  targetType: "question" as const,
+  targetId: "q-1",
+  questionId: "q-1",
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("VoteButton", () => {
+  it("renders the initial score and is not pressed", () => {
+    render(
+      <VoteButton {...baseProps} initialScore={3} initialVoted={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Upvote" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveTextContent("3");
+  });
+
+  it("optimistically increments and reconciles with server result", async () => {
+    let resolveVote: (v: Awaited<ReturnType<typeof voteAction>>) => void = () => {};
+    mockedVoteAction.mockImplementation(
+      () =>
+        new Promise<Awaited<ReturnType<typeof voteAction>>>((resolve) => {
+          resolveVote = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <VoteButton {...baseProps} initialScore={3} initialVoted={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Upvote" });
+
+    await user.click(button);
+
+    // Optimistic state: voted=true, score=4
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveTextContent("4");
+    expect(mockedVoteAction).toHaveBeenCalledWith(
+      "question",
+      "q-1",
+      "q-1",
+      "test-token",
+    );
+
+    await Promise.resolve();
+    resolveVote({ ok: true, voted: true, voteScore: 5 });
+    await Promise.resolve();
+
+    // Wait for transition microtasks to settle.
+    await screen.findByText("5");
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("rolls back and surfaces the server error on failure", async () => {
+    mockedVoteAction.mockResolvedValue({
+      ok: false,
+      error: "You can't vote on your own question.",
+    });
+
+    const user = userEvent.setup();
+    render(
+      <VoteButton {...baseProps} initialScore={3} initialVoted={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Upvote" });
+
+    await user.click(button);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("You can't vote on your own question.");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveTextContent("3");
+  });
+
+  it("does not invoke the action when disabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <VoteButton
+        {...baseProps}
+        initialScore={3}
+        initialVoted={false}
+        disabled
+        disabledReason="You can't vote on your own question."
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Upvote" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      "title",
+      "You can't vote on your own question.",
+    );
+
+    await user.click(button);
+    expect(mockedVoteAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/search/search-controls.dom.test.tsx
+++ b/src/app/search/search-controls.dom.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SearchControls } from "./search-controls";
+
+const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+const baseProps = {
+  initialQ: "",
+  initialScope: "all" as const,
+  initialGroupIds: [],
+  myGroups: [
+    { id: "g1", slug: "alpha", name: "Alpha" },
+    { id: "g2", slug: "beta", name: "Beta" },
+  ],
+  initialStatus: "all" as const,
+  initialRange: "all" as const,
+  initialSort: "relevance" as const,
+  initialAuthor: null,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  replace.mockReset();
+});
+
+describe("SearchControls", () => {
+  it("disables the My groups scope when the user has no groups", () => {
+    render(<SearchControls {...baseProps} myGroups={[]} />);
+    const myGroupsButton = screen.getByRole("button", { name: /My groups/i });
+    expect(myGroupsButton).toBeDisabled();
+    expect(myGroupsButton).toHaveAttribute(
+      "title",
+      "Join a group to use this scope.",
+    );
+  });
+
+  it("reveals checkboxes for every group when Pick groups is selected", async () => {
+    const user = userEvent.setup();
+    render(<SearchControls {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Pick groups" }));
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(2);
+    checkboxes.forEach((cb) => expect(cb).not.toBeChecked());
+
+    await user.click(checkboxes[0]!);
+    expect(
+      screen.getByText(/Choose groups \(1 selected\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("debounces query input and pushes the URL", async () => {
+    const user = userEvent.setup();
+    render(<SearchControls {...baseProps} />);
+
+    await user.type(screen.getByLabelText("Search query"), "hello");
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+    const lastUrl = replace.mock.calls.at(-1)?.[0] as string;
+    expect(lastUrl).toMatch(/[?&]q=hello(&|$)/);
+    expect(lastUrl).toMatch(/[?&]scope=all(&|$)/);
+  });
+
+  it("emits a status filter when a status toggle is pressed", async () => {
+    const user = userEvent.setup();
+    render(<SearchControls {...baseProps} />);
+
+    const statusGroup = screen.getByRole("group", {
+      name: "Filter by question status",
+    });
+    await user.click(
+      within(statusGroup).getByRole("button", { name: "Answered" }),
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+    const lastUrl = replace.mock.calls.at(-1)?.[0] as string;
+    expect(lastUrl).toMatch(/[?&]status=answered(&|$)/);
+  });
+
+  it("debounces the author typeahead and queries the search API", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const user = userEvent.setup();
+    render(<SearchControls {...baseProps} />);
+
+    await user.type(screen.getByLabelText("Filter by author"), "jo");
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const [calledUrl, calledInit] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(calledUrl).toMatch(/^\/api\/users\/search\?q=jo&limit=8$/);
+    expect(calledInit).toEqual(
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+});

--- a/src/components/notification-bell.dom.test.tsx
+++ b/src/components/notification-bell.dom.test.tsx
@@ -1,0 +1,273 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationBell } from "./notification-bell";
+import { useSession } from "@/lib/auth-client";
+import { csrfFetch } from "@/lib/csrf-client";
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(),
+}));
+
+vi.mock("@/lib/csrf-client", () => ({
+  csrfFetch: vi.fn(() =>
+    Promise.resolve(new Response("{}", { status: 200 })),
+  ),
+}));
+
+const mockedUseSession = vi.mocked(useSession);
+const mockedCsrfFetch = vi.mocked(csrfFetch);
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function emptyNotificationList(unreadCount = 0) {
+  return {
+    items: [] as unknown[],
+    total: 0,
+    page: 1,
+    per: 20,
+    unreadCount,
+  };
+}
+
+function notification(
+  id: string,
+  unread: boolean,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    type: "question.created" as const,
+    payload: {
+      questionId: "q-1",
+      questionTitle: "How do I test polling?",
+      authorName: "Ada",
+      groupName: "Astronomers",
+    },
+    createdAt: new Date("2026-05-01T12:00:00Z").toISOString(),
+    readAt: unread ? null : new Date("2026-05-01T13:00:00Z").toISOString(),
+    ...overrides,
+  };
+}
+
+function authenticated() {
+  mockedUseSession.mockReturnValue({
+    status: "authenticated",
+    data: { user: { id: "u-1", email: "user@example.com", name: "User" } },
+  } as unknown as ReturnType<typeof useSession>);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("NotificationBell", () => {
+  beforeEach(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    // Drop the per-test instance descriptor so the prototype getter is
+    // visible again on the next test (which redefines it in beforeEach).
+    delete (document as unknown as { hidden?: boolean }).hidden;
+  });
+
+  it("renders nothing when unauthenticated", () => {
+    mockedUseSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    } as unknown as ReturnType<typeof useSession>);
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { container } = render(<NotificationBell />);
+    expect(container.firstChild).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches initial notifications and shows the unread badge", async () => {
+    authenticated();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        items: [notification("n-1", true), notification("n-2", true)],
+        total: 2,
+        page: 1,
+        per: 20,
+        unreadCount: 2,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    render(<NotificationBell />);
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith("/api/notifications", {
+      cache: "no-store",
+    });
+    expect(
+      screen.getByLabelText(/Notifications \(2 unread\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("polls every 30 seconds while the tab is visible", async () => {
+    authenticated();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(emptyNotificationList(0)));
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+
+    render(<NotificationBell />);
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("pauses polling when the tab is hidden and resumes on visible", async () => {
+    authenticated();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(emptyNotificationList(0)));
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+
+    render(<NotificationBell />);
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flush();
+    // Visibility handler refetches immediately and restarts the interval.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("optimistically marks all notifications read", async () => {
+    authenticated();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        items: [notification("n-1", true), notification("n-2", true)],
+        total: 2,
+        page: 1,
+        per: 20,
+        unreadCount: 2,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const user = userEvent.setup();
+    render(<NotificationBell />);
+    await flush();
+
+    await user.click(screen.getByLabelText(/Notifications \(2 unread\)/i));
+    await user.click(await screen.findByText("Mark all read"));
+
+    expect(mockedCsrfFetch).toHaveBeenCalledWith(
+      "/api/notifications/read-all",
+      { method: "POST" },
+    );
+    expect(
+      screen.queryByLabelText(/Notifications \(\d+ unread\)/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/^Notifications$/)).toBeInTheDocument();
+  });
+
+  it("optimistically marks a single notification read on click", async () => {
+    authenticated();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        items: [
+          notification("n-1", true, {
+            payload: {
+              questionId: "q-1",
+              questionTitle: "First notification title",
+              authorName: "Ada",
+              groupName: "Astronomers",
+            },
+          }),
+          notification("n-2", true, {
+            payload: {
+              questionId: "q-2",
+              questionTitle: "Second notification title",
+              authorName: "Grace",
+              groupName: "Astronomers",
+            },
+          }),
+        ],
+        total: 2,
+        page: 1,
+        per: 20,
+        unreadCount: 2,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const user = userEvent.setup();
+    render(<NotificationBell />);
+    await flush();
+
+    await user.click(screen.getByLabelText(/Notifications \(2 unread\)/i));
+    const firstItem = await screen.findByText("First notification title");
+    await user.click(firstItem);
+
+    expect(mockedCsrfFetch).toHaveBeenCalledWith(
+      "/api/notifications/n-1/read",
+      { method: "POST" },
+    );
+    expect(
+      screen.getByLabelText(/Notifications \(1 unread\)/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/test/setup-dom.ts
+++ b/test/setup-dom.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,23 +1,50 @@
 import { configDefaults, defineConfig } from "vitest/config";
 import path from "node:path";
 
+const sharedAlias = {
+  "@": path.resolve(__dirname, "src"),
+  // Next.js synthesises `server-only` at build time. Vitest doesn't, so
+  // alias it to a no-op module for tests that import server-side code.
+  "server-only": path.resolve(__dirname, "test/stubs/server-only.ts"),
+};
+
+const sharedServerDeps = {
+  inline: ["server-only"] as string[],
+};
+
 export default defineConfig({
-  test: {
-    environment: "node",
-    // Playwright specs live under e2e/ and use @playwright/test's own runner.
-    exclude: [...configDefaults.exclude, "e2e/**"],
-    server: {
-      deps: {
-        // Next.js synthesises `server-only` at build time. Vitest doesn't, so
-        // alias it to a no-op module for tests that import server-side code.
-        inline: ["server-only"],
-      },
-    },
-  },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
-      "server-only": path.resolve(__dirname, "test/stubs/server-only.ts"),
-    },
+    alias: sharedAlias,
+  },
+  test: {
+    projects: [
+      {
+        resolve: { alias: sharedAlias },
+        test: {
+          name: "node",
+          environment: "node",
+          server: { deps: sharedServerDeps },
+          include: ["src/**/*.test.{ts,tsx}"],
+          // The include glob `*.test.{ts,tsx}` also matches `*.dom.test.tsx`,
+          // so we must explicitly exclude dom tests here — they belong to the
+          // jsdom project below. Don't drop this exclude.
+          exclude: [
+            ...configDefaults.exclude,
+            "e2e/**",
+            "src/**/*.dom.test.tsx",
+          ],
+        },
+      },
+      {
+        resolve: { alias: sharedAlias },
+        test: {
+          name: "dom",
+          environment: "jsdom",
+          server: { deps: sharedServerDeps },
+          include: ["src/**/*.dom.test.tsx"],
+          setupFiles: ["./test/setup-dom.ts"],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Closes #55. The repo had no component tests, so optimistic UI, polling, and debounce-driven URL pushes were unverified.
- Splits Vitest into `node` (existing) and `dom` (jsdom) projects so node-environment route/lib tests stay in node and aren't slowed down by jsdom setup.
- Documents the patterns (mocks for `next/navigation` / `csrf-client` / `useSession` / server actions, real-vs-fake timer strategy) in CLAUDE.md so future component tests have a recipe.

## Changes
- **Config**: `vitest.config.ts` adds a `dom` project (jsdom + `@testing-library/jest-dom` matchers + RTL `cleanup` via `test/setup-dom.ts`); the `node` project keeps its scope by excluding `*.dom.test.tsx`.
- **Deps**: `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`, `jsdom`.
- **Tests**: `NotificationBell` (initial fetch, 30s poll cadence, visibilitychange pause/resume, mark-all-read, single mark-read), `VoteButton` and `FavoriteButton` (optimistic flip, server reconciliation, error rollback, disabled-state), `SearchControls` (scope toggle, Pick-groups picker, debounced `q`/`status` URL push, author typeahead fetch).
- **Docs**: new "Component tests" section in CLAUDE.md.

## Test plan
- [x] `npx vitest run --project node` — 513 passed (no regressions).
- [x] `npx vitest run --project dom` — 19 passed.
- [ ] `npm run test` end-to-end on a clean clone — not run here; CI will cover.

## Notes
- The dom suite logs a benign jsdom "Not implemented: navigation" warning when a `next/link` click fires; it's surfaced after assertions complete and doesn't affect results.