### PR TITLE
test(search): add Postgres-mode CI run for the search suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,51 @@ jobs:
 
       - name: Unit tests
         run: npm run test
+
+  ci-search-postgres:
+    name: ci-search-postgres
+    needs: ci
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_PROVIDER: postgres
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      AUTH_SECRET: ci-dummy-secret-not-used-at-runtime-xx
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # See ci job for the rationale on the lockfile workaround.
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install --no-audit --no-fund
+
+      - name: Generate Postgres-flavoured Prisma schema
+        run: npm run db:gen-postgres-schema
+
+      - name: Generate Prisma client (Postgres)
+        run: npx prisma generate --schema=prisma/schema.postgres.prisma
+
+      - name: Validate Postgres schema
+        run: npx prisma validate --schema=prisma/schema.postgres.prisma
+
+      - name: Search tests (Postgres tsvector)
+        run: npm run test -- --project node src/lib/search.test.ts src/app/api/search/route.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ yarn-error.log*
 /prisma/dev.db
 /prisma/dev.db-journal
 
+# Generated Postgres-flavoured schema (built from schema.prisma at test/CI time)
+/prisma/schema.postgres.prisma
+
 # Playwright e2e SQLite database, reports, and traces
 /prisma/e2e.db
 /prisma/e2e.db-journal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,33 @@ The plan in [PROJECT_PLAN.md](PROJECT_PLAN.md) is a proposal, not a decided cont
 - Issues use milestone labels (`M1-foundation`…`M6-polish`) plus surface labels (`frontend`, `backend`, `infra`). New issues should follow the same scheme.
 - Each milestone issue has explicit acceptance criteria — treat those as the definition of done; if a criterion is wrong, amend the issue rather than silently diverging.
 
+## Postgres-mode search tests
+
+Search has a dual-track abstraction (SQLite FTS5 in dev, Postgres `tsvector` in prod). The CI job `ci-search-postgres` boots a Postgres 16 service container and runs `src/lib/search.test.ts` + `src/app/api/search/route.test.ts` with `DATABASE_PROVIDER=postgres` to keep the two backends honest — same assertions, both providers. Divergence is a bug in the dual-track abstraction, not the test.
+
+- **Provider switch**: `setupTestDb()` in [test/db.ts](test/db.ts) branches on `DATABASE_PROVIDER`. SQLite path uses a per-worker `*.db` file + `prisma migrate deploy` (unchanged). Postgres path derives a per-worker schema name (`test_w<id>_..._<ts>`), runs `prisma db push --schema=prisma/schema.postgres.prisma --skip-generate` to sync it (no migrations — the FTS5 migration is SQLite-only), and drops the schema in `afterAll`.
+- **Generated schema**: `prisma/schema.postgres.prisma` is built from `prisma/schema.prisma` by [scripts/generate-postgres-schema.mjs](scripts/generate-postgres-schema.mjs) — single source of truth, only the datasource provider differs. The generated file is git-ignored; regenerate with `npm run db:gen-postgres-schema`.
+- **SQLite-only assertions**: the `toFtsMatchExpr` describe block in `search.test.ts` uses `describe.skipIf(isPostgres)` because the Postgres branch (`runTsvector`) bypasses that helper entirely.
+
+To reproduce locally:
+
+```sh
+# 1. Boot Postgres 16 (any reachable instance works)
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+
+# 2. Generate the Postgres schema and Prisma client
+npm run db:gen-postgres-schema
+npx prisma generate --schema=prisma/schema.postgres.prisma
+
+# 3. Run the search suite against Postgres
+DATABASE_PROVIDER=postgres \
+  DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+  npm run test -- --project node src/lib/search.test.ts src/app/api/search/route.test.ts
+
+# 4. Restore the SQLite Prisma client when done
+npx prisma generate
+```
+
 ## End-to-end tests (Playwright)
 
 Specs live in [e2e/](e2e/) and run against an isolated SQLite database (`prisma/e2e.db`) so they never touch `prisma/dev.db`. The harness boots its own dev server.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:reset": "prisma migrate reset",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
+    "db:gen-postgres-schema": "node scripts/generate-postgres-schema.mjs",
     "postinstall": "prisma generate"
   },
   "prisma": {

--- a/scripts/generate-postgres-schema.mjs
+++ b/scripts/generate-postgres-schema.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Derives prisma/schema.postgres.prisma from prisma/schema.prisma by swapping
+// the datasource provider to "postgresql". The generated file is git-ignored
+// and consumed by the Postgres-mode test path (test/db.ts) and the
+// ci-search-postgres CI job.
+//
+// Run via `npm run db:gen-postgres-schema`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "..");
+const source = path.join(root, "prisma", "schema.prisma");
+const target = path.join(root, "prisma", "schema.postgres.prisma");
+
+const original = readFileSync(source, "utf8");
+
+// Locate the `datasource db { ... }` block by name and walk braces so a future
+// nested `{ ... }` inside the block (e.g. options bearing JSON) wouldn't
+// confuse the rewrite. Then swap only the `provider = "sqlite"` line inside
+// that specific block.
+const blockHeaderRe = /datasource\s+db\s*\{/m;
+const headerMatch = blockHeaderRe.exec(original);
+if (!headerMatch) {
+  console.error(
+    "generate-postgres-schema: no `datasource db { ... }` block found in schema.prisma",
+  );
+  process.exit(1);
+}
+
+const blockStart = headerMatch.index + headerMatch[0].length;
+let depth = 1;
+let blockEnd = -1;
+for (let i = blockStart; i < original.length; i++) {
+  const ch = original[i];
+  if (ch === "{") depth++;
+  else if (ch === "}") {
+    depth--;
+    if (depth === 0) {
+      blockEnd = i;
+      break;
+    }
+  }
+}
+if (blockEnd === -1) {
+  console.error("generate-postgres-schema: unterminated `datasource db` block");
+  process.exit(1);
+}
+
+const block = original.slice(blockStart, blockEnd);
+const providerRe = /(provider\s*=\s*)"sqlite"/;
+if (!providerRe.test(block)) {
+  console.error(
+    'generate-postgres-schema: expected `provider = "sqlite"` inside `datasource db` block',
+  );
+  process.exit(1);
+}
+const rewrittenBlock = block.replace(providerRe, '$1"postgresql"');
+
+const rewritten =
+  original.slice(0, blockStart) +
+  rewrittenBlock +
+  original.slice(blockEnd);
+
+const banner =
+  "// AUTO-GENERATED from schema.prisma by scripts/generate-postgres-schema.mjs — do not edit.\n" +
+  "// Regenerate with `npm run db:gen-postgres-schema`.\n\n";
+
+writeFileSync(target, banner + rewritten);
+console.log(`generate-postgres-schema: wrote ${path.relative(root, target)}`);

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,16 +1,10 @@
 /**
- * GET /api/search route handler tests.
+ * GET /api/search route handler tests. Runs against the configured
+ * DATABASE_PROVIDER (sqlite/FTS5 by default, postgres/tsvector when set).
  */
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { execSync } from "node:child_process";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-
-const testDbPath = path.join(os.tmpdir(), `sme-api-search-test-${Date.now()}.db`);
-process.env.DATABASE_URL = `file:${testDbPath}`;
-process.env.AUTH_SECRET = "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+import { describe, expect, it, vi } from "vitest";
+import { setupTestDb } from "@test/db";
 
 vi.mock("next/headers", () => ({
   cookies: async () => ({
@@ -26,31 +20,12 @@ vi.mock("next/navigation", () => ({
   },
 }));
 
+setupTestDb("api-search");
+
 const { db } = await import("@/lib/db");
 const { createGroup } = await import("@/lib/groups");
 const { createQuestion } = await import("@/lib/questions");
 const { GET } = await import("./route");
-
-beforeAll(async () => {
-  const root = path.resolve(import.meta.dirname, "../../../..");
-  execSync("node_modules/.bin/prisma migrate deploy", {
-    cwd: root,
-    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
-    stdio: "pipe",
-  });
-  await db.$connect();
-});
-
-afterAll(async () => {
-  await db.$disconnect();
-  for (const ext of ["", "-wal", "-shm"]) {
-    try {
-      fs.unlinkSync(`${testDbPath}${ext}`);
-    } catch {
-      // ignore
-    }
-  }
-});
 
 let counter = 0;
 function uniq(label: string): string {

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,41 +1,20 @@
 /**
- * Search service tests — exercises FTS5 triggers, tokenizer, and scope filter.
+ * Search service tests — runs against SQLite/FTS5 by default and against
+ * Postgres/tsvector when DATABASE_PROVIDER=postgres. The integration assertions
+ * must pass on both backends; divergence is a bug in the dual-track abstraction.
  */
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { execSync } from "node:child_process";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { setupTestDb } from "@test/db";
 
-const testDbPath = path.join(os.tmpdir(), `sme-search-test-${Date.now()}.db`);
-process.env["DATABASE_URL"] = `file:${testDbPath}`;
+const handle = setupTestDb("search");
 
 const { db } = await import("./db");
 const { createGroup } = await import("./groups");
 const { createQuestion } = await import("./questions");
 const { searchContent, toFtsMatchExpr } = await import("./search");
 
-beforeAll(async () => {
-  const root = path.resolve(import.meta.dirname, "../..");
-  execSync("node_modules/.bin/prisma migrate deploy", {
-    cwd: root,
-    env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
-    stdio: "pipe",
-  });
-  await db.$connect();
-});
-
-afterAll(async () => {
-  await db.$disconnect();
-  for (const ext of ["", "-wal", "-shm"]) {
-    try {
-      fs.unlinkSync(`${testDbPath}${ext}`);
-    } catch {
-      // ignore
-    }
-  }
-});
+const isPostgres = handle.provider === "postgres";
 
 let counter = 0;
 function uniq(label: string): string {
@@ -47,7 +26,10 @@ async function makeUser(label: string) {
   return db.user.create({ data: { email: `${uniq(label)}@example.com`, name: label } });
 }
 
-describe("toFtsMatchExpr", () => {
+// toFtsMatchExpr generates SQLite FTS5 query syntax; the Postgres branch in
+// runTsvector ignores the parsed expression and feeds the raw query to
+// plainto_tsquery. Skip this block when running against Postgres.
+describe.skipIf(isPostgres)("toFtsMatchExpr", () => {
   it("returns null when the query reduces to nothing", () => {
     expect(toFtsMatchExpr("")).toBeNull();
     expect(toFtsMatchExpr("   ")).toBeNull();

--- a/test/db.ts
+++ b/test/db.ts
@@ -1,31 +1,45 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { afterAll, beforeAll } from "vitest";
 import type { PrismaClient } from "@prisma/client";
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
 const DEFAULT_AUTH_SECRET =
   "0".repeat(32) + "abcdef0123456789abcdef0123456789";
+const POSTGRES_SCHEMA_FILE = "prisma/schema.postgres.prisma";
+const PRISMA_BIN = path.join(PROJECT_ROOT, "node_modules", ".bin", "prisma");
+
+export type TestDbProvider = "sqlite" | "postgres";
 
 export type TestDbHandle = {
-  /** Absolute path to the SQLite file backing this test run. */
-  dbPath: string;
+  /** Which backend is in use; tests can branch on this without re-reading env. */
+  provider: TestDbProvider;
+  /** Connection target — sqlite file path or postgres schema name. */
+  dbId: string;
   /** Resolves the shared Prisma client (lazy, cached). */
   getDb: () => Promise<PrismaClient>;
 };
 
 export function setupTestDb(label: string): TestDbHandle {
+  if (!process.env.AUTH_SECRET) {
+    process.env.AUTH_SECRET = DEFAULT_AUTH_SECRET;
+  }
+  const provider = (process.env.DATABASE_PROVIDER ?? "sqlite").toLowerCase();
+  if (provider === "postgres" || provider === "postgresql") {
+    return setupPostgresTestDb(label);
+  }
+  return setupSqliteTestDb(label);
+}
+
+function setupSqliteTestDb(label: string): TestDbHandle {
   const workerId = process.env.VITEST_WORKER_ID ?? "0";
   const dbPath = path.join(
     os.tmpdir(),
     `sme-${label}-w${workerId}-${Date.now()}.db`,
   );
   process.env.DATABASE_URL = `file:${dbPath}`;
-  if (!process.env.AUTH_SECRET) {
-    process.env.AUTH_SECRET = DEFAULT_AUTH_SECRET;
-  }
 
   let cached: PrismaClient | null = null;
   const getDb = async (): Promise<PrismaClient> => {
@@ -58,5 +72,85 @@ export function setupTestDb(label: string): TestDbHandle {
     }
   });
 
-  return { dbPath, getDb };
+  return { provider: "sqlite", dbId: dbPath, getDb };
+}
+
+function setupPostgresTestDb(label: string): TestDbHandle {
+  const baseUrl = process.env.DATABASE_URL;
+  if (!baseUrl || !/^postgres(ql)?:\/\//.test(baseUrl)) {
+    throw new Error(
+      `setupTestDb: DATABASE_PROVIDER=postgres requires DATABASE_URL=postgresql://..., got ${baseUrl ?? "(unset)"}`,
+    );
+  }
+
+  const workerId = process.env.VITEST_WORKER_ID ?? "0";
+  const sanitized = label.replace(/[^a-z0-9_]/gi, "_").toLowerCase();
+  // Schema names must be valid PostgreSQL identifiers; quote for safety regardless.
+  const schemaName = `test_w${workerId}_${sanitized}_${Date.now()}`;
+
+  // The test client connects with ?schema=<name>. DDL for the schema itself
+  // must run against the base URL (no schema override), since the schema
+  // doesn't exist yet at bootstrap time.
+  const testUrl = new URL(baseUrl);
+  testUrl.searchParams.set("schema", schemaName);
+  const bootUrl = new URL(baseUrl);
+  bootUrl.searchParams.delete("schema");
+
+  process.env.DATABASE_URL = testUrl.toString();
+
+  let cached: PrismaClient | null = null;
+  const getDb = async (): Promise<PrismaClient> => {
+    if (cached) return cached;
+    const mod = await import("@/lib/db");
+    cached = mod.db as unknown as PrismaClient;
+    return cached;
+  };
+
+  beforeAll(async () => {
+    runDdl(bootUrl.toString(), `CREATE SCHEMA IF NOT EXISTS "${schemaName}";`);
+    execFileSync(
+      PRISMA_BIN,
+      [
+        "db",
+        "push",
+        `--schema=${POSTGRES_SCHEMA_FILE}`,
+        "--skip-generate",
+      ],
+      {
+        cwd: PROJECT_ROOT,
+        env: { ...process.env, DATABASE_URL: testUrl.toString() },
+        stdio: "pipe",
+      },
+    );
+    const db = await getDb();
+    await db.$connect();
+  });
+
+  afterAll(async () => {
+    if (cached) {
+      await cached.$disconnect();
+    }
+    try {
+      runDdl(
+        bootUrl.toString(),
+        `DROP SCHEMA IF EXISTS "${schemaName}" CASCADE;`,
+      );
+    } catch (err) {
+      // Surface but don't fail the run — the next CI job starts fresh.
+      console.warn(`setupTestDb: failed to drop schema ${schemaName}:`, err);
+    }
+  });
+
+  return { provider: "postgres", dbId: schemaName, getDb };
+}
+
+function runDdl(url: string, sql: string): void {
+  // `prisma db execute` rejects --url + --schema together; --url alone is enough
+  // for raw DDL since we're not introspecting models here. Use execFileSync so
+  // the URL is passed as an argv element and never goes through shell parsing.
+  execFileSync(PRISMA_BIN, ["db", "execute", `--url=${url}`, "--stdin"], {
+    cwd: PROJECT_ROOT,
+    input: sql,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
 }


### PR DESCRIPTION
## Summary
- Keeps the SQLite/FTS5 and Postgres/tsvector search backends honest by running the same assertions against both in CI — any divergence is a bug in the dual-track abstraction, not the test.
- Closes #57.

## Changes
- **CI**: new `ci-search-postgres` job (gated on `ci`) boots Postgres 16 as a service container and runs `src/lib/search.test.ts` + `src/app/api/search/route.test.ts` with `DATABASE_PROVIDER=postgres`.
- **Test infra**: `setupTestDb` branches on `DATABASE_PROVIDER`; the Postgres path creates a per-worker schema, applies the model with `prisma db push` against a generated `schema.postgres.prisma`, and drops the schema in `afterAll`. Returns a `provider` field so tests can branch without re-reading env. Prisma CLI calls now use `execFileSync` argv arrays instead of shell strings.
- **Schema generator**: `scripts/generate-postgres-schema.mjs` derives `schema.postgres.prisma` from `schema.prisma` by scoping the `provider` swap to the `datasource db { ... }` block (located by name with brace tracking). Generated file is git-ignored.
- **Tests**: `search.test.ts` skips `toFtsMatchExpr` on Postgres (the tsvector branch bypasses it); both files now go through the shared `setupTestDb` helper.
- **Docs**: CLAUDE.md gains a "Postgres-mode search tests" section with the local reproduction recipe.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --project node src/lib/search.test.ts src/app/api/search/route.test.ts` (SQLite, 27/27 pass)
- [x] `npm run db:gen-postgres-schema` + `npx prisma validate --schema=prisma/schema.postgres.prisma` (with a placeholder `DATABASE_URL`)
- [ ] Postgres CI job — verified by the new GitHub Actions run on this PR (not reproduced locally against a real Postgres in this session)