### PR TITLE
feat(dashboard): add home widgets and group favorites

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -14,5 +14,7 @@ test("sign in then sign out", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Sign out" }).click();
 
   await expect(page).toHaveURL("/");
-  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+  await expect(
+    page.getByRole("navigation").getByRole("link", { name: "Sign in" }),
+  ).toBeVisible();
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,105 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./setup";
+
+async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(email);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page).toHaveURL("/account");
+}
+
+test("home dashboard surfaces favorited groups and recent open questions", async ({
+  page,
+}) => {
+  test.slow();
+
+  const ts = Date.now();
+  const email = `dash-${ts}@example.com`;
+  const groupName = `Dash Group ${ts}`;
+  const expectedSlug = `dash-group-${ts}`;
+  const questionTitle = `Dashboard open question ${ts}`;
+
+  await signIn(page, email);
+
+  // Seed: create a group and ask one open question in it so the home page has
+  // something to render for "Recent open questions".
+  await page.goto("/groups/new");
+  await page.getByLabel("Name").fill(groupName);
+  await expect(page.locator("#slug-status")).toHaveText("Available");
+  await page.getByRole("button", { name: "Create group" }).click();
+  await expect(page).toHaveURL(`/groups/${expectedSlug}`);
+
+  await page.getByRole("link", { name: "Ask a question" }).click();
+  await expect(page).toHaveURL(`/groups/${expectedSlug}/ask`);
+  await page.getByLabel("Title").fill(questionTitle);
+  await page.getByLabel(/^Body/).fill("Open question body for dashboard test.");
+  await page.getByRole("button", { name: "Post question" }).click();
+  await expect(page).toHaveURL(/\/q\/[a-z0-9-]+$/i);
+
+  // Dashboard blocks render and the question shows under "Recent open questions".
+  await page.goto("/");
+  // CardTitle renders as a div, so probe via the per-block toggle button.
+  await expect(page.getByRole("button", { name: /Top groups$/ })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Your favorite groups$/ }),
+  ).toBeVisible();
+  const openQuestions = page.locator("#dashboard-block-body-open-questions");
+  await expect(
+    openQuestions.getByRole("link", { name: questionTitle }),
+  ).toBeVisible();
+
+  // Empty favorites preview before we star anything.
+  const favorites = page.locator("#dashboard-block-body-favorite-groups");
+  await expect(favorites.getByText(/No favorites yet/i)).toBeVisible();
+
+  // Favorite the group from its detail page. The button optimistically flips
+  // before the server action commits — wait for the transition to settle
+  // (button re-enabled) so the favorite is persisted before we navigate away.
+  await page.goto(`/groups/${expectedSlug}`);
+  await page.getByRole("button", { name: "Add to favorites" }).click();
+  const unfavoriteButton = page.getByRole("button", { name: "Remove from favorites" });
+  await expect(unfavoriteButton).toBeVisible();
+  await expect(unfavoriteButton).toBeEnabled();
+
+  // Group now appears in the dashboard favorites preview.
+  await page.goto("/");
+  await expect(favorites.getByRole("link", { name: groupName })).toBeVisible();
+
+  // …and on /me/favorites under the Groups section.
+  await page.goto("/me/favorites");
+  await expect(page.getByRole("heading", { name: /^Groups \(\d+\)$/ })).toBeVisible();
+  await expect(page.getByRole("link", { name: groupName })).toBeVisible();
+
+  // Unfavorite — the preview returns to the empty state.
+  await page.goto(`/groups/${expectedSlug}`);
+  await page.getByRole("button", { name: "Remove from favorites" }).click();
+  const favoriteButton = page.getByRole("button", { name: "Add to favorites" });
+  await expect(favoriteButton).toBeVisible();
+  await expect(favoriteButton).toBeEnabled();
+
+  await page.goto("/");
+  await expect(favorites.getByText(/No favorites yet/i)).toBeVisible();
+  await expect(favorites.getByRole("link", { name: groupName })).toHaveCount(0);
+});
+
+test("dashboard block collapse state persists across reloads", async ({ page }) => {
+  const email = `dash-collapse-${Date.now()}@example.com`;
+  await signIn(page, email);
+
+  await page.goto("/");
+  const hide = page.getByRole("button", { name: "Hide Top groups" });
+  await expect(hide).toBeVisible();
+  await hide.click();
+
+  // After collapse, the toggle flips and the body is hidden.
+  await expect(page.getByRole("button", { name: "Show Top groups" })).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Show Top groups" })).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 3000;
+const PORT = Number(process.env["E2E_PORT"] ?? 3000);
 const BASE_URL = `http://localhost:${PORT}`;
 
 const E2E_DATABASE_URL = "file:./e2e.db";
@@ -27,8 +27,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev",
-    url: BASE_URL,
+    command: `npm run dev -- --port ${PORT}`,
+    // Use port-based readiness instead of URL-based: polling `/` would render
+    // the home page, which opens a Prisma connection to the SQLite db — and
+    // globalSetup unlinks + recreates that file, leaving the warm connection
+    // pointed at a moved inode (SQLITE_READONLY_DBMOVED) for the rest of the
+    // run.
+    port: PORT,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {

--- a/prisma/migrations/20260511000000_add_group_target_type/migration.sql
+++ b/prisma/migrations/20260511000000_add_group_target_type/migration.sql
@@ -1,0 +1,16 @@
+-- Add "group" as a valid TargetType for Vote and Favorite.
+--
+-- SQLite stores Prisma enums as plain TEXT with no CHECK constraint on the
+-- existing Vote/Favorite tables (see 20260430172732_init/migration.sql), so
+-- widening the Prisma enum requires no schema change here — this migration
+-- exists purely to record the schema version. On Postgres, the test path uses
+-- `prisma db push` against the generated postgres schema and never replays
+-- this file.
+--
+-- PROD POSTGRES BOOTSTRAP RISK: when production switches to Postgres and is
+-- bootstrapped with `prisma migrate deploy` (not `db push`), this empty file
+-- will NOT widen the Postgres `TargetType` enum, and `Favorite` inserts with
+-- `targetType = 'group'` will fail. Before that switch lands, add a real
+-- Postgres-only step (`ALTER TYPE "TargetType" ADD VALUE 'group'`) to a
+-- Postgres-specific migration path, or fold this into the first Postgres
+-- baseline migration.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ enum QuestionStatus {
 enum TargetType {
   question
   answer
+  group
 }
 
 model User {

--- a/src/app/groups/[slug]/favorite-actions.ts
+++ b/src/app/groups/[slug]/favorite-actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth";
+import { assertCsrfToken, CsrfError } from "@/lib/csrf-server";
+import { NotFoundError } from "@/lib/memberships";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
+import { toggleFavorite } from "@/lib/favorites";
+
+export type GroupFavoriteActionResult =
+  | { ok: true; favorited: boolean }
+  | { ok: false; error: string };
+
+export async function favoriteGroupAction(
+  groupId: string,
+  slug: string,
+  csrfToken: string,
+): Promise<GroupFavoriteActionResult> {
+  try {
+    await assertCsrfToken(csrfToken);
+  } catch (err) {
+    if (err instanceof CsrfError) return { ok: false, error: err.message };
+    throw err;
+  }
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: "You must be signed in to favorite." };
+  }
+
+  try {
+    await assertRateLimitForAction("favorites");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return {
+        ok: false,
+        error: `Too many favorites. Try again in ${seconds} seconds.`,
+      };
+    }
+    throw err;
+  }
+
+  try {
+    const result = await toggleFavorite(
+      { targetType: "group", targetId: groupId },
+      session.user.id,
+    );
+    revalidatePath(`/groups/${slug}`);
+    revalidatePath("/");
+    revalidatePath("/me/favorites");
+    return { ok: true, favorited: result.favorited };
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return { ok: false, error: err.message };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not update favorite.",
+    };
+  }
+}

--- a/src/app/groups/[slug]/group-action-bar.tsx
+++ b/src/app/groups/[slug]/group-action-bar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { MaterialIcon } from "@/components/ui/material-icon";
 import { NotificationPreferencesControl } from "@/components/notification-preferences-control";
+import { GroupFavoriteButton } from "@/components/groups/group-favorite-button";
 import { csrfFetch } from "@/lib/csrf-client";
 import type { NotificationCategory } from "@/lib/notification-categories";
 
@@ -32,6 +33,7 @@ type Props = {
   membership: MembershipShape | null;
   isArchived: boolean;
   initialMutedTypes: NotificationCategory[];
+  initialFavorited: boolean;
 };
 
 async function readError(res: Response): Promise<string> {
@@ -52,6 +54,7 @@ export function GroupActionBar({
   membership,
   isArchived,
   initialMutedTypes,
+  initialFavorited,
 }: Props) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -148,6 +151,14 @@ export function GroupActionBar({
 
   return (
     <div className="flex items-center gap-1">
+      {isAuthenticated ? (
+        <GroupFavoriteButton
+          groupId={groupId}
+          slug={slug}
+          initialFavorited={initialFavorited}
+        />
+      ) : null}
+
       <Button
         variant="ghost"
         size="icon-sm"

--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { GroupAvatar } from "@/components/ui/group-avatar";
 import { Pagination } from "@/components/ui/pagination";
 import { getSession } from "@/lib/auth";
+import { viewerFavoritesFor } from "@/lib/favorites";
 import { getGroupBySlug } from "@/lib/groups";
 import { countApprovedMembers, getMembership } from "@/lib/memberships";
 import { getPreferenceForGroup } from "@/lib/notification-preferences";
@@ -36,12 +37,16 @@ export default async function GroupDetailPage({ params, searchParams }: Props) {
   const page = Math.max(Number(sp.page) || 1, 1);
 
   const session = await getSession();
-  const [memberCount, membership, questions, sessionMutedTypes] = await Promise.all([
-    countApprovedMembers(group.id),
-    session ? getMembership(group.id, session.user.id) : Promise.resolve(null),
-    listQuestionsForGroup(group.id, { page, per: QUESTIONS_PER_PAGE }),
-    session ? getPreferenceForGroup(session.user.id, group.id) : Promise.resolve([]),
-  ]);
+  const [memberCount, membership, questions, sessionMutedTypes, viewerFavoritedGroups] =
+    await Promise.all([
+      countApprovedMembers(group.id),
+      session ? getMembership(group.id, session.user.id) : Promise.resolve(null),
+      listQuestionsForGroup(group.id, { page, per: QUESTIONS_PER_PAGE }),
+      session ? getPreferenceForGroup(session.user.id, group.id) : Promise.resolve([]),
+      session
+        ? viewerFavoritesFor("group", [group.id], session.user.id)
+        : Promise.resolve(new Set<string>()),
+    ]);
 
   const questionsTotalPages = Math.max(
     Math.ceil(questions.total / QUESTIONS_PER_PAGE),
@@ -110,6 +115,7 @@ export default async function GroupDetailPage({ params, searchParams }: Props) {
                 }
                 isArchived={isArchived}
                 initialMutedTypes={mutedTypes}
+                initialFavorited={viewerFavoritedGroups.has(group.id)}
               />
               {isOwner ? (
                 <Button

--- a/src/app/me/favorites/page.tsx
+++ b/src/app/me/favorites/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GroupCard } from "@/components/groups/group-card";
 import { requireAuth } from "@/lib/auth";
-import { listFavoritesForUser } from "@/lib/favorites";
+import { listFavoriteGroupsForUser, listFavoritesForUser } from "@/lib/favorites";
 
 function authorLabel(a: { name: string | null; email: string | null }): string {
   return a.name ?? a.email ?? "unknown";
@@ -15,9 +16,12 @@ function excerpt(body: string, max = 200): string {
 
 export default async function MyFavoritesPage() {
   const session = await requireAuth();
-  const { questions, answers } = await listFavoritesForUser(session.user.id);
+  const [{ questions, answers }, groups] = await Promise.all([
+    listFavoritesForUser(session.user.id),
+    listFavoriteGroupsForUser(session.user.id),
+  ]);
 
-  const empty = questions.length === 0 && answers.length === 0;
+  const empty = questions.length === 0 && answers.length === 0 && groups.length === 0;
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 py-8">
@@ -30,9 +34,20 @@ export default async function MyFavoritesPage() {
 
       {empty ? (
         <p className="text-sm text-muted-foreground">
-          You haven&rsquo;t favorited anything yet. Open a question and tap the star
-          to save it here.
+          You haven&rsquo;t favorited anything yet. Open a question or group and
+          tap the star to save it here.
         </p>
+      ) : null}
+
+      {groups.length > 0 ? (
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">Groups ({groups.length})</h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {groups.map((g) => (
+              <GroupCard key={g.id} group={g} />
+            ))}
+          </div>
+        </section>
       ) : null}
 
       {questions.length > 0 ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,99 @@
-export default function Home() {
+import Link from "next/link";
+import { DashboardBlock } from "@/components/dashboard/dashboard-block";
+import { OpenQuestionList } from "@/components/dashboard/open-question-list";
+import { GroupCard } from "@/components/groups/group-card";
+import { getSession } from "@/lib/auth";
+import { listFavoriteGroupsForUser } from "@/lib/favorites";
+import { listGroupsByActivity, type GroupListItem } from "@/lib/groups";
+import { listRecentOpenQuestionsAcrossGroups } from "@/lib/questions";
+
+const TOP_GROUPS_LIMIT = 5;
+const FAVORITES_PREVIEW_LIMIT = 5;
+const OPEN_QUESTIONS_LIMIT = 5;
+
+export default async function Home() {
+  const session = await getSession();
+
+  // Fetch one extra favorite so we know whether to render the "See all favorites" link.
+  const [topGroups, favoriteGroups, openQuestions] = await Promise.all([
+    listGroupsByActivity(TOP_GROUPS_LIMIT),
+    session
+      ? listFavoriteGroupsForUser(session.user.id, FAVORITES_PREVIEW_LIMIT + 1)
+      : Promise.resolve([]),
+    listRecentOpenQuestionsAcrossGroups(OPEN_QUESTIONS_LIMIT),
+  ]);
+
+  const favoritesPreview = favoriteGroups.slice(0, FAVORITES_PREVIEW_LIMIT);
+  const showAllFavoritesLink = favoriteGroups.length > FAVORITES_PREVIEW_LIMIT;
+
   return (
     <div className="space-y-4">
-      <h1 className="text-3xl font-semibold tracking-tight">SME Directory</h1>
-      <p className="text-zinc-600 dark:text-zinc-400">
-        A directory of subject matter expert groups. Browse groups, apply for membership, and ask
-        questions to people who know the answer.
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">SME Directory</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse groups, follow the ones you care about, and find unanswered questions.
+        </p>
+      </div>
+
+      <DashboardBlock
+        id="top-groups"
+        title="Top groups"
+        link={{ href: "/groups", label: "See more →" }}
+      >
+        <TopGroupsGrid items={topGroups} />
+      </DashboardBlock>
+
+      <DashboardBlock
+        id="favorite-groups"
+        title="Your favorite groups"
+        link={
+          showAllFavoritesLink
+            ? { href: "/me/favorites", label: "See all favorites →" }
+            : undefined
+        }
+      >
+        {!session ? (
+          <p className="text-sm text-muted-foreground">
+            <Link href="/login" className="font-medium hover:underline">
+              Sign in
+            </Link>{" "}
+            to track your favorite groups.
+          </p>
+        ) : favoritesPreview.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No favorites yet. Star a group from its page to add it here.
+          </p>
+        ) : (
+          <TopGroupsGrid items={favoritesPreview} />
+        )}
+      </DashboardBlock>
+
+      <DashboardBlock id="open-questions" title="Recent open questions">
+        <OpenQuestionList
+          items={openQuestions}
+          emptyState="No open questions right now."
+        />
+      </DashboardBlock>
+    </div>
+  );
+}
+
+function TopGroupsGrid({ items }: { items: GroupListItem[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No groups yet.{" "}
+        <Link href="/groups/new" className="font-medium hover:underline">
+          Create the first one.
+        </Link>
       </p>
-      <p className="text-sm text-zinc-500">
-        Foundation scaffold — feature work tracked in GitHub milestones M2–M6.
-      </p>
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((g) => (
+        <GroupCard key={g.id} group={g} />
+      ))}
     </div>
   );
 }

--- a/src/components/dashboard/dashboard-block.dom.test.tsx
+++ b/src/components/dashboard/dashboard-block.dom.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DashboardBlock } from "./dashboard-block";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+function renderBlock(id = "test-block") {
+  return render(
+    <DashboardBlock id={id} title="Top groups" link={{ href: "/groups", label: "See more" }}>
+      <p data-testid="body">block contents</p>
+    </DashboardBlock>,
+  );
+}
+
+describe("DashboardBlock", () => {
+  it("renders expanded by default and toggles to collapsed on click", async () => {
+    const user = userEvent.setup();
+    renderBlock();
+
+    const toggle = screen.getByRole("button", { name: "Hide Top groups" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("body")).toBeVisible();
+
+    await user.click(toggle);
+
+    const reToggle = screen.getByRole("button", { name: "Show Top groups" });
+    expect(reToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("body")).not.toBeVisible();
+  });
+
+  it("persists collapsed state to localStorage and rehydrates on re-render", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderBlock("persist-id");
+
+    await user.click(screen.getByRole("button", { name: "Hide Top groups" }));
+
+    const stored = window.localStorage.getItem("sme:dashboard:collapsed");
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({ "persist-id": true });
+
+    unmount();
+    renderBlock("persist-id");
+
+    expect(screen.getByRole("button", { name: "Show Top groups" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("reacts to localStorage changes from another tab via the storage event", async () => {
+    renderBlock("cross-tab");
+    expect(screen.getByRole("button", { name: "Hide Top groups" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    await act(async () => {
+      window.localStorage.setItem(
+        "sme:dashboard:collapsed",
+        JSON.stringify({ "cross-tab": true }),
+      );
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "sme:dashboard:collapsed",
+          newValue: JSON.stringify({ "cross-tab": true }),
+        }),
+      );
+    });
+
+    expect(screen.getByRole("button", { name: "Show Top groups" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("renders the right-side link", () => {
+    renderBlock();
+    const link = screen.getByRole("link", { name: "See more" });
+    expect(link).toHaveAttribute("href", "/groups");
+  });
+});

--- a/src/components/dashboard/dashboard-block.tsx
+++ b/src/components/dashboard/dashboard-block.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePersistedCollapse } from "./use-persisted-collapse";
+
+type Props = {
+  id: string;
+  title: string;
+  link?: { href: string; label: string };
+  children: ReactNode;
+};
+
+export function DashboardBlock({ id, title, link, children }: Props) {
+  const { collapsed, toggle } = usePersistedCollapse(id);
+  const bodyId = `dashboard-block-body-${id}`;
+  const toggleLabel = collapsed ? `Show ${title}` : `Hide ${title}`;
+
+  return (
+    <Card>
+      <CardHeader className="border-b">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <div className="flex items-center gap-3">
+            {link ? (
+              <Link
+                href={link.href}
+                className="text-xs font-medium text-muted-foreground hover:text-foreground hover:underline"
+              >
+                {link.label}
+              </Link>
+            ) : null}
+            <button
+              type="button"
+              onClick={toggle}
+              aria-expanded={!collapsed}
+              aria-controls={bodyId}
+              aria-label={toggleLabel}
+              title={toggleLabel}
+              className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              {collapsed ? (
+                <ChevronDownIcon className="h-4 w-4" />
+              ) : (
+                <ChevronUpIcon className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent id={bodyId} hidden={collapsed} className="pt-4">
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/open-question-list.tsx
+++ b/src/components/dashboard/open-question-list.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { OpenQuestionListItem } from "@/lib/questions";
+
+type Props = {
+  items: OpenQuestionListItem[];
+  emptyState: React.ReactNode;
+};
+
+function authorLabel(a: { name: string | null; email: string | null }): string {
+  return a.name ?? a.email ?? "unknown";
+}
+
+export function OpenQuestionList({ items, emptyState }: Props) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyState}</p>;
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {items.map((q) => (
+        <li key={q.id} className="py-3 first:pt-0 last:pb-0">
+          <Link href={`/q/${q.id}`} className="text-sm font-medium hover:underline">
+            {q.title}
+          </Link>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <Link href={`/groups/${q.group.slug}`} className="hover:underline">
+              {q.group.name}
+            </Link>
+            {" · "}
+            {authorLabel(q.author)}
+            {" · "}
+            {q.answerCount} {q.answerCount === 1 ? "answer" : "answers"}
+            {" · Score "}
+            {q.voteScore}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/dashboard/use-persisted-collapse.ts
+++ b/src/components/dashboard/use-persisted-collapse.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "sme:dashboard:collapsed";
+
+type CollapsedMap = Record<string, true>;
+
+function read(): CollapsedMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as CollapsedMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function write(map: CollapsedMap): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable (private mode, quota) — collapse state is best-effort.
+  }
+}
+
+const listeners = new Set<() => void>();
+
+// Single module-level storage listener — fanned out to all subscribers — so
+// mounting many DashboardBlocks doesn't duplicate window event listeners.
+let storageListenerAttached = false;
+function ensureStorageListener(): void {
+  if (storageListenerAttached || typeof window === "undefined") return;
+  window.addEventListener("storage", (e: StorageEvent) => {
+    if (e.key !== STORAGE_KEY) return;
+    for (const l of listeners) l();
+  });
+  storageListenerAttached = true;
+}
+
+function subscribe(cb: () => void): () => void {
+  ensureStorageListener();
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+// Stable empty-map snapshot for SSR / first server render so the snapshot
+// reference is identical across calls (useSyncExternalStore requires this).
+const SERVER_SNAPSHOT: CollapsedMap = {};
+
+// Cache the last-read client snapshot and only return a new object when the
+// underlying string changes, so useSyncExternalStore sees a stable reference.
+let cachedRaw: string | null = null;
+let cachedSnapshot: CollapsedMap = {};
+function getClientSnapshot(): CollapsedMap {
+  const raw = typeof window === "undefined" ? null : window.localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedRaw) return cachedSnapshot;
+  cachedRaw = raw;
+  cachedSnapshot = read();
+  return cachedSnapshot;
+}
+
+export function usePersistedCollapse(id: string): {
+  collapsed: boolean;
+  toggle: () => void;
+} {
+  const map = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    () => SERVER_SNAPSHOT,
+  );
+
+  const collapsed = map[id] === true;
+
+  const toggle = useCallback(() => {
+    const next = { ...read() };
+    if (next[id]) delete next[id];
+    else next[id] = true;
+    write(next);
+    notify();
+  }, [id]);
+
+  return { collapsed, toggle };
+}

--- a/src/components/groups/group-favorite-button.dom.test.tsx
+++ b/src/components/groups/group-favorite-button.dom.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GroupFavoriteButton } from "./group-favorite-button";
+import { favoriteGroupAction } from "@/app/groups/[slug]/favorite-actions";
+
+vi.mock("@/app/groups/[slug]/favorite-actions", () => ({
+  favoriteGroupAction: vi.fn(),
+}));
+
+vi.mock("@/lib/csrf-client", () => ({
+  readCsrfToken: vi.fn(() => "test-token"),
+}));
+
+const mocked = vi.mocked(favoriteGroupAction);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GroupFavoriteButton", () => {
+  it("renders not favorited initially", () => {
+    render(
+      <GroupFavoriteButton groupId="g-1" slug="g" initialFavorited={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("optimistically toggles on click and confirms with server", async () => {
+    let resolveFn: (v: Awaited<ReturnType<typeof favoriteGroupAction>>) => void =
+      () => {};
+    mocked.mockImplementation(
+      () =>
+        new Promise<Awaited<ReturnType<typeof favoriteGroupAction>>>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <GroupFavoriteButton groupId="g-1" slug="g" initialFavorited={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+
+    await user.click(button);
+
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(mocked).toHaveBeenCalledWith("g-1", "g", "test-token");
+
+    resolveFn({ ok: true, favorited: true });
+
+    await screen.findByRole("button", { name: "Remove from favorites" });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("rolls back and surfaces the server error", async () => {
+    mocked.mockResolvedValue({ ok: false, error: "Could not update favorite." });
+
+    const user = userEvent.setup();
+    render(
+      <GroupFavoriteButton groupId="g-1" slug="g" initialFavorited={false} />,
+    );
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+
+    await user.click(button);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not update favorite.");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/src/components/groups/group-favorite-button.tsx
+++ b/src/components/groups/group-favorite-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { StarIcon } from "lucide-react";
+import { useState, useTransition } from "react";
+import { readCsrfToken } from "@/lib/csrf-client";
+import { favoriteGroupAction } from "@/app/groups/[slug]/favorite-actions";
+
+type Props = {
+  groupId: string;
+  slug: string;
+  initialFavorited: boolean;
+};
+
+export function GroupFavoriteButton({ groupId, slug, initialFavorited }: Props) {
+  const [favorited, setFavorited] = useState(initialFavorited);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    if (pending) return;
+    setError(null);
+    const prevFavorited = favorited;
+    setFavorited(!prevFavorited);
+
+    startTransition(async () => {
+      const result = await favoriteGroupAction(groupId, slug, readCsrfToken());
+      if (result.ok) {
+        setFavorited(result.favorited);
+      } else {
+        setFavorited(prevFavorited);
+        setError(result.error);
+      }
+    });
+  };
+
+  const label = favorited ? "Remove from favorites" : "Add to favorites";
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        aria-pressed={favorited}
+        aria-label={label}
+        title={label}
+        className={
+          "inline-flex items-center justify-center rounded-md p-1.5 text-sm transition-colors " +
+          (favorited
+            ? "text-amber-600 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-950/40"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground") +
+          " disabled:cursor-not-allowed disabled:opacity-60"
+        }
+      >
+        <StarIcon className="h-4 w-4" fill={favorited ? "currentColor" : "none"} />
+      </button>
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/favorites.test.ts
+++ b/src/lib/favorites.test.ts
@@ -20,6 +20,7 @@ const {
   toggleFavorite,
   viewerFavoritesFor,
   listFavoritesForUser,
+  listFavoriteGroupsForUser,
 } = await import("./favorites");
 
 beforeAll(async () => {
@@ -275,5 +276,123 @@ describe("listFavoritesForUser", () => {
     const result = await listFavoritesForUser(user.id);
     expect(result.questions).toHaveLength(0);
     expect(result.answers).toHaveLength(0);
+  });
+
+  it("does not surface group favorites in the questions/answers lists", async () => {
+    const owner = await makeUser("g-owner-skip");
+    const group = await createGroup(
+      { name: "G", slug: uniq("g-skip"), autoApprove: true },
+      owner.id,
+    );
+    const user = await makeUser("g-fav-skip");
+    await toggleFavorite({ targetType: "group", targetId: group.id }, user.id);
+
+    const result = await listFavoritesForUser(user.id);
+    expect(result.questions).toHaveLength(0);
+    expect(result.answers).toHaveLength(0);
+  });
+});
+
+describe("toggleFavorite on groups", () => {
+  it("creates a favorite on a group", async () => {
+    const owner = await makeUser("g-owner");
+    const group = await createGroup(
+      { name: "G", slug: uniq("g"), autoApprove: true },
+      owner.id,
+    );
+    const user = await makeUser("g-fav");
+
+    const result = await toggleFavorite(
+      { targetType: "group", targetId: group.id },
+      user.id,
+    );
+
+    expect(result.favorited).toBe(true);
+    expect(result.targetType).toBe("group");
+    expect(result.targetId).toBe(group.id);
+
+    const stored = await db.favorite.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: user.id,
+          targetType: "group",
+          targetId: group.id,
+        },
+      },
+    });
+    expect(stored).not.toBeNull();
+  });
+
+  it("toggles off on second call", async () => {
+    const owner = await makeUser("g-owner-2");
+    const group = await createGroup(
+      { name: "G2", slug: uniq("g2"), autoApprove: true },
+      owner.id,
+    );
+    const user = await makeUser("g-fav-2");
+    await toggleFavorite({ targetType: "group", targetId: group.id }, user.id);
+    const second = await toggleFavorite(
+      { targetType: "group", targetId: group.id },
+      user.id,
+    );
+    expect(second.favorited).toBe(false);
+  });
+
+  it("throws NotFoundError for unknown group id", async () => {
+    const user = await makeUser("g-nf");
+    await expect(
+      toggleFavorite({ targetType: "group", targetId: "does-not-exist" }, user.id),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("listFavoriteGroupsForUser", () => {
+  it("returns favorited groups newest-first with hydrated member counts", async () => {
+    const owner = await makeUser("lfg-owner");
+    const g1 = await createGroup(
+      { name: "First", slug: uniq("g-first"), autoApprove: true },
+      owner.id,
+    );
+    const g2 = await createGroup(
+      { name: "Second", slug: uniq("g-second"), autoApprove: true },
+      owner.id,
+    );
+    // Add an extra approved member to g1 so memberCount > 1.
+    const extra = await makeUser("lfg-extra");
+    await db.membership.create({
+      data: { groupId: g1.id, userId: extra.id, status: "approved" },
+    });
+
+    const user = await makeUser("lfg-user");
+    await toggleFavorite({ targetType: "group", targetId: g1.id }, user.id);
+    await new Promise((r) => setTimeout(r, 5));
+    await toggleFavorite({ targetType: "group", targetId: g2.id }, user.id);
+
+    const result = await listFavoriteGroupsForUser(user.id);
+    expect(result.map((r) => r.id)).toEqual([g2.id, g1.id]);
+    const first = result.find((r) => r.id === g1.id);
+    expect(first?.memberCount).toBe(2); // owner + extra
+    const second = result.find((r) => r.id === g2.id);
+    expect(second?.memberCount).toBe(1);
+  });
+
+  it("respects limit", async () => {
+    const owner = await makeUser("lfg-lim-owner");
+    const user = await makeUser("lfg-lim-user");
+    for (let i = 0; i < 3; i++) {
+      const g = await createGroup(
+        { name: `Lim${i}`, slug: uniq("g-lim"), autoApprove: true },
+        owner.id,
+      );
+      await toggleFavorite({ targetType: "group", targetId: g.id }, user.id);
+    }
+    const result = await listFavoriteGroupsForUser(user.id, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty when user has no group favorites", async () => {
+    const user = await makeUser("lfg-empty");
+    const result = await listFavoriteGroupsForUser(user.id);
+    expect(result).toEqual([]);
   });
 });

--- a/src/lib/favorites.ts
+++ b/src/lib/favorites.ts
@@ -30,6 +30,18 @@ export type FavoritedAnswer = {
   question: { id: string; title: string };
 };
 
+export type FavoritedGroup = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  image: string | null;
+  memberCount: number;
+  archivedAt: Date | null;
+  createdAt: Date;
+  favoritedAt: Date;
+};
+
 export type FavoritesForUser = {
   questions: FavoritedQuestion[];
   answers: FavoritedAnswer[];
@@ -60,11 +72,20 @@ async function assertTargetExists(
     if (!q || q.deletedAt) throw new NotFoundError("Question not found.");
     return;
   }
-  const a = await db.answer.findUnique({
+  if (targetType === "answer") {
+    const a = await db.answer.findUnique({
+      where: { id: targetId },
+      select: { id: true, question: { select: { deletedAt: true } } },
+    });
+    if (!a || a.question.deletedAt) throw new NotFoundError("Answer not found.");
+    return;
+  }
+  // targetType === "group"
+  const g = await db.group.findUnique({
     where: { id: targetId },
-    select: { id: true, question: { select: { deletedAt: true } } },
+    select: { id: true },
   });
-  if (!a || a.question.deletedAt) throw new NotFoundError("Answer not found.");
+  if (!g) throw new NotFoundError("Group not found.");
 }
 
 export async function toggleFavorite(
@@ -139,7 +160,7 @@ export async function listFavoritesForUser(
   for (const r of rows) {
     favoritedAt.set(`${r.targetType}:${r.targetId}`, r.createdAt);
     if (r.targetType === "question") questionIds.push(r.targetId);
-    else answerIds.push(r.targetId);
+    else if (r.targetType === "answer") answerIds.push(r.targetId);
   }
 
   const [questionRows, answerRows] = await Promise.all([
@@ -184,7 +205,7 @@ export async function listFavoritesForUser(
         author: q.author,
         group: q.group,
       });
-    } else {
+    } else if (r.targetType === "answer") {
       const a = answersById.get(r.targetId);
       if (!a) continue;
       answers.push({
@@ -199,4 +220,62 @@ export async function listFavoritesForUser(
   }
 
   return { questions, answers };
+}
+
+// Archived groups are intentionally returned: the user starred them, so we keep
+// them visible (with the archived badge from GroupCard) so they can find and
+// unfavorite them.
+export async function listFavoriteGroupsForUser(
+  userId: string,
+  limit?: number,
+): Promise<FavoritedGroup[]> {
+  const favRows = await db.favorite.findMany({
+    where: { userId, targetType: "group" },
+    orderBy: { createdAt: "desc" },
+    select: { targetId: true, createdAt: true },
+    ...(limit ? { take: limit } : {}),
+  });
+  if (favRows.length === 0) return [];
+
+  const groupIds = favRows.map((r) => r.targetId);
+  const [groupRows, memberCounts] = await Promise.all([
+    db.group.findMany({
+      where: { id: { in: groupIds } },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        description: true,
+        image: true,
+        archivedAt: true,
+        createdAt: true,
+      },
+    }),
+    db.membership.groupBy({
+      by: ["groupId"],
+      where: { groupId: { in: groupIds }, status: "approved" },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const countById = new Map(memberCounts.map((c) => [c.groupId, c._count._all]));
+  const groupById = new Map(groupRows.map((g) => [g.id, g]));
+
+  const out: FavoritedGroup[] = [];
+  for (const r of favRows) {
+    const g = groupById.get(r.targetId);
+    if (!g) continue;
+    out.push({
+      id: g.id,
+      slug: g.slug,
+      name: g.name,
+      description: g.description,
+      image: g.image,
+      archivedAt: g.archivedAt,
+      createdAt: g.createdAt,
+      memberCount: countById.get(g.id) ?? 0,
+      favoritedAt: r.createdAt,
+    });
+  }
+  return out;
 }

--- a/src/lib/groups.test.ts
+++ b/src/lib/groups.test.ts
@@ -22,6 +22,7 @@ const {
   getGroupBySlug,
   getGroupBySlugOrThrow,
   listGroups,
+  listGroupsByActivity,
   unarchiveGroup,
   updateGroup,
   SlugConflictError,
@@ -304,5 +305,64 @@ describe("archiveGroup / unarchiveGroup", () => {
     await expect(assertGroupNotArchived(group.id)).resolves.toBeUndefined();
     await archiveGroup(slug, owner.id);
     await expect(assertGroupNotArchived(group.id)).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe("listGroupsByActivity", () => {
+  it("ranks groups by recent question+answer count", async () => {
+    const owner = await makeUser("act-owner");
+    const slugA = `act-a-${Date.now()}`;
+    const slugB = `act-b-${Date.now()}`;
+    const slugC = `act-c-${Date.now()}`;
+    const ga = await createGroup({ name: "A", slug: slugA, autoApprove: true }, owner.id);
+    const gb = await createGroup({ name: "B", slug: slugB, autoApprove: true }, owner.id);
+    const gc = await createGroup({ name: "C", slug: slugC, autoApprove: true }, owner.id);
+
+    // A: 1 question. B: 2 questions + 1 answer (3 events). C: 0 events.
+    await db.question.create({
+      data: { groupId: ga.id, authorId: owner.id, title: "A1", body: "x" },
+    });
+    const qb1 = await db.question.create({
+      data: { groupId: gb.id, authorId: owner.id, title: "B1", body: "x" },
+    });
+    await db.question.create({
+      data: { groupId: gb.id, authorId: owner.id, title: "B2", body: "x" },
+    });
+    await db.answer.create({
+      data: { questionId: qb1.id, authorId: owner.id, body: "ans" },
+    });
+
+    const ranked = await listGroupsByActivity(5);
+    const ids = ranked.map((g) => g.id);
+    // B should rank above A; C has no activity, so it shouldn't appear.
+    expect(ids).toContain(gb.id);
+    expect(ids).toContain(ga.id);
+    expect(ids.indexOf(gb.id)).toBeLessThan(ids.indexOf(ga.id));
+    expect(ids).not.toContain(gc.id);
+  });
+
+  it("excludes archived groups even if they have activity", async () => {
+    const owner = await makeUser("act-arch-owner");
+    const slug = `act-arch-${Date.now()}`;
+    const group = await createGroup({ name: "Arch", slug, autoApprove: true }, owner.id);
+    await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "Q", body: "x" },
+    });
+    await archiveGroup(slug, owner.id);
+
+    const ranked = await listGroupsByActivity(5);
+    expect(ranked.find((g) => g.id === group.id)).toBeUndefined();
+  });
+
+  it("falls back to member-count sort when no group has activity in the window", async () => {
+    const owner = await makeUser("act-fallback");
+    const slug = `act-fb-${Date.now()}`;
+    const group = await createGroup({ name: "FB", slug, autoApprove: true }, owner.id);
+    // Force the fallback path by setting `since` to the future — no activity
+    // anywhere in the DB can satisfy `createdAt >= since`.
+    const ranked = await listGroupsByActivity(50, { since: new Date(Date.now() + 60_000) });
+    const ids = ranked.map((g) => g.id);
+    expect(ids).toContain(group.id);
+    expect(ranked.every((g) => typeof g.memberCount === "number")).toBe(true);
   });
 });

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -129,6 +129,119 @@ export async function listGroups(opts: {
   return { items: items.slice(start, start + per), total, page, per };
 }
 
+// Window (in days) over which `listGroupsByActivity` measures question/answer activity.
+const ACTIVITY_WINDOW_DAYS = 30;
+
+export async function listGroupsByActivity(
+  limit: number,
+  opts: { since?: Date } = {},
+): Promise<GroupListItem[]> {
+  const since =
+    opts.since ?? new Date(Date.now() - ACTIVITY_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const [questionAgg, answerAgg] = await Promise.all([
+    db.question.groupBy({
+      by: ["groupId"],
+      where: { deletedAt: null, createdAt: { gte: since }, group: { archivedAt: null } },
+      _count: { _all: true },
+      _max: { createdAt: true },
+    }),
+    db.answer.groupBy({
+      by: ["questionId"],
+      where: {
+        createdAt: { gte: since },
+        question: { deletedAt: null, group: { archivedAt: null } },
+      },
+      _count: { _all: true },
+      _max: { createdAt: true },
+    }),
+  ]);
+
+  // Map answer counts (keyed by questionId) up to groupId.
+  const answeredQuestionIds = answerAgg.map((a) => a.questionId);
+  const questionToGroup =
+    answeredQuestionIds.length === 0
+      ? new Map<string, string>()
+      : new Map(
+          (
+            await db.question.findMany({
+              where: { id: { in: answeredQuestionIds } },
+              select: { id: true, groupId: true },
+            })
+          ).map((q) => [q.id, q.groupId]),
+        );
+
+  type Activity = { count: number; latest: Date };
+  const byGroup = new Map<string, Activity>();
+  for (const row of questionAgg) {
+    const cur = byGroup.get(row.groupId) ?? { count: 0, latest: new Date(0) };
+    cur.count += row._count._all;
+    if (row._max.createdAt && row._max.createdAt > cur.latest) cur.latest = row._max.createdAt;
+    byGroup.set(row.groupId, cur);
+  }
+  for (const row of answerAgg) {
+    const groupId = questionToGroup.get(row.questionId);
+    if (!groupId) continue;
+    const cur = byGroup.get(groupId) ?? { count: 0, latest: new Date(0) };
+    cur.count += row._count._all;
+    if (row._max.createdAt && row._max.createdAt > cur.latest) cur.latest = row._max.createdAt;
+    byGroup.set(groupId, cur);
+  }
+
+  if (byGroup.size === 0) {
+    const page = await listGroups({ sort: "members", per: limit });
+    return page.items;
+  }
+
+  const rankedIds = [...byGroup.entries()]
+    .sort(([, a], [, b]) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return b.latest.getTime() - a.latest.getTime();
+    })
+    .slice(0, limit)
+    .map(([id]) => id);
+
+  const [groupRows, memberCounts] = await Promise.all([
+    db.group.findMany({
+      where: { id: { in: rankedIds }, archivedAt: null },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        description: true,
+        image: true,
+        archivedAt: true,
+        createdAt: true,
+      },
+    }),
+    db.membership.groupBy({
+      by: ["groupId"],
+      where: { groupId: { in: rankedIds }, status: "approved" },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const countByGroupId = new Map(memberCounts.map((c) => [c.groupId, c._count._all]));
+  const groupById = new Map(groupRows.map((g) => [g.id, g]));
+
+  const items: GroupListItem[] = [];
+  for (const id of rankedIds) {
+    const g = groupById.get(id);
+    if (!g) continue;
+    items.push({
+      id: g.id,
+      slug: g.slug,
+      name: g.name,
+      description: g.description,
+      image: g.image,
+      archivedAt: g.archivedAt,
+      createdAt: g.createdAt,
+      memberCount: countByGroupId.get(g.id) ?? 0,
+    });
+  }
+  return items;
+}
+
 export async function getGroupBySlug(slug: string): Promise<GroupWithOwner | null> {
   return db.group.findUnique({
     where: { slug },

--- a/src/lib/questions.test.ts
+++ b/src/lib/questions.test.ts
@@ -15,12 +15,13 @@ const testDbPath = path.join(os.tmpdir(), `sme-questions-test-${Date.now()}.db`)
 process.env["DATABASE_URL"] = `file:${testDbPath}`;
 
 const { db } = await import("./db");
-const { createGroup } = await import("./groups");
+const { archiveGroup, createGroup } = await import("./groups");
 const { NotFoundError } = await import("./memberships");
 const {
   createQuestion,
   getQuestionById,
   listQuestionsForGroup,
+  listRecentOpenQuestionsAcrossGroups,
   softDeleteQuestion,
   acceptAnswer,
   reopenQuestion,
@@ -436,5 +437,94 @@ describe("acceptAnswer / reopenQuestion on deleted questions", () => {
     await expect(reopenQuestion(q.id, owner.id)).rejects.toBeInstanceOf(
       NotFoundError,
     );
+  });
+});
+
+describe("listRecentOpenQuestionsAcrossGroups", () => {
+  it("returns only open, non-deleted questions whose group is not archived, newest first", async () => {
+    const owner = await makeUser("lroq-owner");
+    const groupA = await createGroup(
+      { name: "A", slug: uniq("lroq-a"), autoApprove: true },
+      owner.id,
+    );
+    const groupB = await createGroup(
+      { name: "B", slug: uniq("lroq-b"), autoApprove: true },
+      owner.id,
+    );
+
+    // Open question in A (oldest)
+    const qOpenA = await createQuestion(
+      { title: "Open A", body: "body" },
+      groupA.id,
+      owner.id,
+    );
+    // Open question in B (newer)
+    await new Promise((r) => setTimeout(r, 10));
+    const qOpenB = await createQuestion(
+      { title: "Open B", body: "body" },
+      groupB.id,
+      owner.id,
+    );
+    // Answered question in A
+    await new Promise((r) => setTimeout(r, 10));
+    const qAnsweredA = await createQuestion(
+      { title: "Answered A", body: "body" },
+      groupA.id,
+      owner.id,
+    );
+    const ans = await db.answer.create({
+      data: { questionId: qAnsweredA.id, authorId: owner.id, body: "ans" },
+    });
+    await acceptAnswer(qAnsweredA.id, ans.id, owner.id);
+    // Deleted open question
+    const qDeletedA = await createQuestion(
+      { title: "Deleted A", body: "body" },
+      groupA.id,
+      owner.id,
+    );
+    await softDeleteQuestion(qDeletedA.id, owner.id);
+
+    const list = await listRecentOpenQuestionsAcrossGroups(10);
+    const ids = list.map((q) => q.id);
+    expect(ids).toContain(qOpenA.id);
+    expect(ids).toContain(qOpenB.id);
+    expect(ids).not.toContain(qAnsweredA.id);
+    expect(ids).not.toContain(qDeletedA.id);
+    // Newest first: qOpenB before qOpenA.
+    expect(ids.indexOf(qOpenB.id)).toBeLessThan(ids.indexOf(qOpenA.id));
+    // Group info hydrated.
+    const found = list.find((q) => q.id === qOpenA.id);
+    expect(found?.group.slug).toBe(groupA.slug);
+  });
+
+  it("excludes questions from archived groups", async () => {
+    const owner = await makeUser("lroq-arch");
+    const slug = uniq("lroq-arch-g");
+    const group = await createGroup({ name: "Arch", slug, autoApprove: true }, owner.id);
+    const q = await createQuestion(
+      { title: "Pre-archive", body: "x" },
+      group.id,
+      owner.id,
+    );
+    await archiveGroup(slug, owner.id);
+    const list = await listRecentOpenQuestionsAcrossGroups(50);
+    expect(list.find((it) => it.id === q.id)).toBeUndefined();
+  });
+
+  it("respects limit", async () => {
+    const owner = await makeUser("lroq-lim");
+    const group = await createGroup(
+      { name: "Lim", slug: uniq("lroq-lim-g"), autoApprove: true },
+      owner.id,
+    );
+    for (let i = 0; i < 3; i++) {
+      await createQuestion(
+        { title: `Limited ${i}`, body: "x" },
+        group.id,
+        owner.id,
+      );
+    }
+    const list = await listRecentOpenQuestionsAcrossGroups(2);
+    expect(list.length).toBeLessThanOrEqual(2);
   });
 });

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -90,6 +90,46 @@ export async function updateQuestion(
   });
 }
 
+export type OpenQuestionListItem = QuestionListItem & {
+  group: { id: string; slug: string; name: string };
+};
+
+export async function listRecentOpenQuestionsAcrossGroups(
+  limit: number,
+): Promise<OpenQuestionListItem[]> {
+  const rows = await db.question.findMany({
+    where: {
+      status: "open",
+      deletedAt: null,
+      group: { archivedAt: null },
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    include: {
+      author: { select: { id: true, email: true, name: true, image: true } },
+      group: { select: { id: true, slug: true, name: true } },
+      _count: { select: { answers: true } },
+    },
+  });
+
+  const scores = await voteScoresFor(
+    "question",
+    rows.map((r) => r.id),
+  );
+
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    status: r.status,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+    author: r.author,
+    answerCount: r._count.answers,
+    voteScore: scores.get(r.id) ?? 0,
+    group: r.group,
+  }));
+}
+
 export async function listQuestionsForGroup(
   groupId: string,
   opts: { page: number; per: number },

--- a/src/lib/validation/favorites.ts
+++ b/src/lib/validation/favorites.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const favoriteTargetTypeSchema = z.enum(["question", "answer"]);
+export const favoriteTargetTypeSchema = z.enum(["question", "answer", "group"]);
 
 export const favoriteInputSchema = z.object({
   targetType: favoriteTargetTypeSchema,


### PR DESCRIPTION
## Summary
- Turns the home page from a scaffold into a useful landing: three collapsible blocks (top groups by activity, your favorite groups, recent open questions) so signed-in users see something actionable without navigating.
- Adds group-level favoriting (previously only questions/answers were favoritable) and surfaces those favorites on both the home dashboard and `/me/favorites`, so users can curate and re-find groups they care about.
- Keeps the change consistent with the existing dual-track storage model: widens the Prisma `TargetType` enum to include `group`, with a Postgres-bootstrap note on the no-op SQLite migration.

## Changes
- **Home / dashboard UI**: new `DashboardBlock` (with `usePersistedCollapse` backed by a single module-level `storage` listener), `OpenQuestionList`, and a rewritten `src/app/page.tsx` that parallelizes the three queries.
- **Favorites**: `GroupFavoriteButton` + `favoriteGroupAction` (CSRF + rate-limited, revalidates `/`, `/groups/[slug]`, `/me/favorites`); `listFavoriteGroupsForUser`; group-aware branch in `assertTargetExists` and `listFavoritesForUser`; `/me/favorites` now renders a Groups section.
- **Data layer**: `listGroupsByActivity(limit, { since? })` ranks by question+answer count in the last 30 days with a member-count fallback; `listRecentOpenQuestionsAcrossGroups(limit)` for the home open-questions list.
- **Schema**: `TargetType` enum gains `group`; Zod favorites validator updated; no-op SQLite migration with prod-Postgres bootstrap warning.
- **Tests**: lib coverage for the three new lib functions (incl. archived/deleted exclusion, fallback path, limits); dom tests for `DashboardBlock` (toggle, persistence, cross-tab) and `GroupFavoriteButton` (optimistic UI + rollback); new `e2e/dashboard.spec.ts` covers favorite/unfavorite end-to-end and collapse persistence.
- **E2E infra**: `playwright.config.ts` parameterizes the dev port via `E2E_PORT` and uses port-based readiness instead of URL-based (a URL ping was warming a Prisma connection that `globalSetup`'s DB recreate then invalidated with SQLITE_READONLY_DBMOVED). `e2e/auth.spec.ts` scopes the post-signout "Sign in" assertion to the nav to avoid collision with the new in-block sign-in link.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test` — full vitest suite (node + dom) passes
- [x] `E2E_PORT=3100 npm run test:e2e` — 4 specs pass (auth, core-journey, dashboard ×2)
- [ ] Manual: sign in, favorite a group from `/groups/[slug]`, verify it appears under "Your favorite groups" on `/` and under Groups on `/me/favorites`; toggle collapse and reload to confirm persistence.

## Notes
- The `prisma/migrations/.../migration.sql` is intentionally empty for SQLite (TEXT columns accept the new enum value with no DDL). When prod switches to Postgres-backed `prisma migrate deploy`, a real `ALTER TYPE "TargetType" ADD VALUE 'group'` will be required — flagged inline in the migration file.
- `listFavoriteGroupsForUser` intentionally returns archived groups so users can find and unfavorite them; `GroupCard` already renders an archived badge.