### PR TITLE
refactor(profile): remove Favorites section from /me sidebar

### DIFF
--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -16,15 +16,6 @@ const items: Item[] = [
   { href: "/me", label: "Overview", exact: true },
   { href: "/me/questions", label: "Questions" },
   { href: "/me/answers", label: "Answers" },
-  {
-    label: "Favorites",
-    matchPrefix: "/me/favorites",
-    children: [
-      { href: "/me/favorites/questions", label: "Questions" },
-      { href: "/me/favorites/answers", label: "Answers" },
-      { href: "/me/favorites/groups", label: "Groups" },
-    ],
-  },
   { href: "/me/groups", label: "Groups" },
   { href: "/me/settings", label: "Settings" },
   { href: "/me/notification-settings", label: "Notification settings" },


### PR DESCRIPTION
## Summary
- The Favorites parent + three nested links (Questions, Answers, Groups) in the profile sidebar duplicated entry points that already exist on the home dashboard widgets, `/me`, and `/account`. Removing them trims the sidebar without losing access.

## Changes
- `src/components/profile/profile-sidebar.tsx`: drop the `Favorites` `ParentItem` from the `items` array. The `ParentItem` branch in the render is left in place for future use. Routes under `src/app/me/favorites/*` are unchanged.

## Test plan
- [x] `npm run lint`
- [ ] Manual: visit `/me`, `/me/settings`, `/me/questions` — sidebar should show Overview, Questions, Answers, Groups, Settings, Notification settings (no Favorites parent or indented children).
- [ ] Manual: confirm `/me/favorites`, `/me/favorites/questions`, `/me/favorites/answers`, `/me/favorites/groups` still load directly via links from home, `/me`, and `/account`.

## Notes
No tests reference the Favorites sidebar entry; the sidebar component has no dedicated test file.