### PR TITLE
feat(groups): show 24h new-question count on group cards

### DIFF
--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -38,6 +38,8 @@ export function GroupCard({ group }: { group: GroupListItem }) {
                 <span>
                   {group.memberCount} {memberLabel}
                 </span>
+                {" · "}
+                <span>{group.recentQuestionCount} new in 24h</span>
               </CardDescription>
             </div>
           </div>

--- a/src/lib/favorites.ts
+++ b/src/lib/favorites.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { Prisma, type TargetType } from "@prisma/client";
 import { db } from "@/lib/db";
+import { countRecentQuestionsByGroup } from "@/lib/groups";
 import { NotFoundError } from "@/lib/memberships";
 
 export type FavoriteTargetType = TargetType;
@@ -37,6 +38,7 @@ export type FavoritedGroup = {
   description: string | null;
   image: string | null;
   memberCount: number;
+  recentQuestionCount: number;
   archivedAt: Date | null;
   createdAt: Date;
   favoritedAt: Date;
@@ -238,7 +240,7 @@ export async function listFavoriteGroupsForUser(
   if (favRows.length === 0) return [];
 
   const groupIds = favRows.map((r) => r.targetId);
-  const [groupRows, memberCounts] = await Promise.all([
+  const [groupRows, memberCounts, recentByGroupId] = await Promise.all([
     db.group.findMany({
       where: { id: { in: groupIds } },
       select: {
@@ -256,6 +258,7 @@ export async function listFavoriteGroupsForUser(
       where: { groupId: { in: groupIds }, status: "approved" },
       _count: { _all: true },
     }),
+    countRecentQuestionsByGroup(groupIds),
   ]);
 
   const countById = new Map(memberCounts.map((c) => [c.groupId, c._count._all]));
@@ -274,6 +277,7 @@ export async function listFavoriteGroupsForUser(
       archivedAt: g.archivedAt,
       createdAt: g.createdAt,
       memberCount: countById.get(g.id) ?? 0,
+      recentQuestionCount: recentByGroupId.get(g.id) ?? 0,
       favoritedAt: r.createdAt,
     });
   }

--- a/src/lib/groups.test.ts
+++ b/src/lib/groups.test.ts
@@ -224,6 +224,44 @@ describe("listGroups", () => {
     expect(found!.archivedAt).not.toBeNull();
   });
 
+  it("counts recentQuestionCount only for questions created in the last 24h", async () => {
+    const owner = await makeUser("ls-recent");
+    const slug = `ls-recent-${Date.now()}`;
+    const group = await createGroup({ name: "R", slug, autoApprove: true }, owner.id);
+
+    // Fresh question (within 24h) — counts.
+    await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "fresh", body: "x" },
+    });
+    // Stale question (>24h ago) — must not count.
+    const stale = await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "stale", body: "x" },
+    });
+    await db.question.update({
+      where: { id: stale.id },
+      data: { createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000) },
+    });
+    // Soft-deleted recent question — must not count.
+    const del = await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "deleted", body: "x" },
+    });
+    await db.question.update({ where: { id: del.id }, data: { deletedAt: new Date() } });
+
+    const list = (await listGroups({ sort: "newest" })).items;
+    const found = list.find((g) => g.id === group.id);
+    expect(found).toBeDefined();
+    expect(found!.recentQuestionCount).toBe(1);
+  });
+
+  it("returns recentQuestionCount=0 when no recent questions", async () => {
+    const owner = await makeUser("ls-zero");
+    const slug = `ls-zero-${Date.now()}`;
+    const group = await createGroup({ name: "Z", slug }, owner.id);
+    const list = (await listGroups({ sort: "newest" })).items;
+    const found = list.find((g) => g.id === group.id);
+    expect(found?.recentQuestionCount).toBe(0);
+  });
+
   it("respects page boundaries (page 2 returns expected slice)", async () => {
     const owner = await makeUser("ls-page");
     const tag = `ls-page-${Date.now()}`;
@@ -352,6 +390,30 @@ describe("listGroupsByActivity", () => {
 
     const ranked = await listGroupsByActivity(5);
     expect(ranked.find((g) => g.id === group.id)).toBeUndefined();
+  });
+
+  it("populates recentQuestionCount on returned items", async () => {
+    const owner = await makeUser("act-recent-owner");
+    const slug = `act-recent-${Date.now()}`;
+    const group = await createGroup({ name: "AR", slug, autoApprove: true }, owner.id);
+    await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "fresh1", body: "x" },
+    });
+    await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "fresh2", body: "x" },
+    });
+    const stale = await db.question.create({
+      data: { groupId: group.id, authorId: owner.id, title: "old", body: "x" },
+    });
+    await db.question.update({
+      where: { id: stale.id },
+      data: { createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000) },
+    });
+
+    const ranked = await listGroupsByActivity(5);
+    const found = ranked.find((g) => g.id === group.id);
+    expect(found).toBeDefined();
+    expect(found!.recentQuestionCount).toBe(2);
   });
 
   it("falls back to member-count sort when no group has activity in the window", async () => {

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -60,9 +60,29 @@ export type GroupListItem = {
   description: string | null;
   image: string | null;
   memberCount: number;
+  recentQuestionCount: number;
   createdAt: Date;
   archivedAt: Date | null;
 };
+
+const RECENT_QUESTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export async function countRecentQuestionsByGroup(
+  groupIds?: string[],
+): Promise<Map<string, number>> {
+  if (groupIds && groupIds.length === 0) return new Map();
+  const since = new Date(Date.now() - RECENT_QUESTION_WINDOW_MS);
+  const rows = await db.question.groupBy({
+    by: ["groupId"],
+    where: {
+      deletedAt: null,
+      createdAt: { gte: since },
+      ...(groupIds ? { groupId: { in: groupIds } } : {}),
+    },
+    _count: { _all: true },
+  });
+  return new Map(rows.map((r) => [r.groupId, r._count._all]));
+}
 
 export type ListGroupsSort = "newest" | "members";
 
@@ -82,7 +102,7 @@ export async function listGroups(opts: {
   const page = Math.max(opts.page ?? 1, 1);
   const per = Math.min(Math.max(opts.per ?? 20, 1), 50);
   const where = opts.includeArchived ? {} : { archivedAt: null };
-  const [groups, counts] = await Promise.all([
+  const [groups, counts, recentByGroupId] = await Promise.all([
     db.group.findMany({
       where,
       select: {
@@ -100,6 +120,7 @@ export async function listGroups(opts: {
       where: { status: "approved" },
       _count: { _all: true },
     }),
+    countRecentQuestionsByGroup(),
   ]);
 
   const countByGroupId = new Map(counts.map((c) => [c.groupId, c._count._all]));
@@ -113,6 +134,7 @@ export async function listGroups(opts: {
     createdAt: g.createdAt,
     archivedAt: g.archivedAt,
     memberCount: countByGroupId.get(g.id) ?? 0,
+    recentQuestionCount: recentByGroupId.get(g.id) ?? 0,
   }));
 
   if (opts.sort === "members") {
@@ -201,7 +223,7 @@ export async function listGroupsByActivity(
     .slice(0, limit)
     .map(([id]) => id);
 
-  const [groupRows, memberCounts] = await Promise.all([
+  const [groupRows, memberCounts, recentByGroupId] = await Promise.all([
     db.group.findMany({
       where: { id: { in: rankedIds }, archivedAt: null },
       select: {
@@ -219,6 +241,7 @@ export async function listGroupsByActivity(
       where: { groupId: { in: rankedIds }, status: "approved" },
       _count: { _all: true },
     }),
+    countRecentQuestionsByGroup(rankedIds),
   ]);
 
   const countByGroupId = new Map(memberCounts.map((c) => [c.groupId, c._count._all]));
@@ -237,6 +260,7 @@ export async function listGroupsByActivity(
       archivedAt: g.archivedAt,
       createdAt: g.createdAt,
       memberCount: countByGroupId.get(g.id) ?? 0,
+      recentQuestionCount: recentByGroupId.get(g.id) ?? 0,
     });
   }
   return items;


### PR DESCRIPTION
## Summary
- Group cards (both `/groups` and the dashboard's Top Groups / Favorites widgets) now surface a fresh-activity signal — "N new in 24h" — alongside member count, giving browsers a tighter "what's hot right now" indicator than the existing 30-day activity sort.
- The 24h count is wired into every loader that feeds `GroupCard` (`listGroups`, `listGroupsByActivity`, `listFavoriteGroupsForUser`) so the dashboard never renders some cards with the badge and others without.

## Changes
- **lib**: add `recentQuestionCount` to `GroupListItem` and `FavoritedGroup`; introduce a shared `countRecentQuestionsByGroup` helper (24h window, `deletedAt: null`) backed by a single `question.groupBy` query parallelised with the existing member-count query.
- **ui**: `GroupCard` renders `· {recentQuestionCount} new in 24h` after the member-count segment, unconditionally so layout stays consistent.
- **tests**: new cases in `groups.test.ts` covering fresh vs. >24h-old vs. soft-deleted questions for both `listGroups` and `listGroupsByActivity`.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test` — 555 tests pass (52 files)
- [ ] Manual: visit `/` and `/groups` against seeded data and confirm the new segment renders on every card; post a new question and reload to see the count increment. Not exercised in this session — no browser run.

## Notes
- No schema change — relies on the existing `Question.@@index([groupId])`.
- The label is intentionally always rendered (including `0 new in 24h`) for layout uniformity; easy to switch to conditional rendering later if the noise outweighs the signal.