### PR TITLE
refactor(search): replace filter toggle rows with compact dropdowns

### DIFF
--- a/e2e/search-filters.spec.ts
+++ b/e2e/search-filters.spec.ts
@@ -1,0 +1,122 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./setup";
+
+async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(email);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page).toHaveURL("/account");
+}
+
+// Base UI's Menu radio item doesn't auto-close the menu on select, and its
+// presentation backdrop intercepts pointer events on the next trigger.
+// Explicitly dismiss the menu with Escape after each selection.
+async function pickFilter(
+  page: Page,
+  triggerName: RegExp,
+  optionName: string,
+): Promise<void> {
+  const trigger = page.getByRole("button", { name: triggerName });
+  await trigger.click();
+  await page
+    .getByRole("menuitemradio", { name: optionName, exact: true })
+    .click();
+  await page.keyboard.press("Escape");
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+}
+
+test("search filter dropdowns drive the URL and active chips", async ({ page }) => {
+  test.slow();
+
+  const ts = Date.now();
+  const email = `search-filter-${ts}@example.com`;
+  const groupName = `Search Filter Group ${ts}`;
+  const expectedSlug = `search-filter-group-${ts}`;
+  const marker = `searchfilter${ts}`;
+  const openTitle = `Open ${marker} question`;
+  const answeredTitle = `Answered ${marker} question`;
+
+  await signIn(page, email);
+
+  // Seed: a group with two questions sharing the marker — one stays open, one
+  // gets an accepted answer so the "answered" filter has something to bite on.
+  await page.goto("/groups/new");
+  await page.getByLabel("Name").fill(groupName);
+  await expect(page.locator("#slug-status")).toHaveText("Available");
+  await page.getByRole("button", { name: "Create group" }).click();
+  await expect(page).toHaveURL(`/groups/${expectedSlug}`);
+
+  await page.getByRole("link", { name: "Ask a question" }).click();
+  await page.getByLabel("Title").fill(openTitle);
+  await page.getByLabel(/^Body/).fill(`Body for ${marker} open.`);
+  await page.getByRole("button", { name: "Post question" }).click();
+  await expect(page).toHaveURL(/\/q\/[a-z0-9-]+$/i);
+
+  await page.goto(`/groups/${expectedSlug}/ask`);
+  await page.getByLabel("Title").fill(answeredTitle);
+  await page.getByLabel(/^Body/).fill(`Body for ${marker} answered.`);
+  await page.getByRole("button", { name: "Post question" }).click();
+  await expect(page).toHaveURL(/\/q\/[a-z0-9-]+$/i);
+
+  await page.getByLabel(/^Your answer/).fill(`Resolved ${marker}.`);
+  await page.getByRole("button", { name: "Post answer" }).click();
+  await page.getByRole("button", { name: "Accept this answer" }).click();
+  await expect(page.getByText("✓ Accepted answer")).toBeVisible();
+
+  await page.goto(`/search?q=${encodeURIComponent(marker)}`);
+
+  const openLinks = page.getByRole("link", { name: new RegExp(openTitle, "i") });
+  const answeredLinks = page.getByRole("link", {
+    name: new RegExp(answeredTitle, "i"),
+  });
+
+  // Both questions surface before any filter is applied. The answered one also
+  // produces an answer-card hit, so we assert >=1 link rather than ==1.
+  await expect(openLinks.first()).toBeVisible();
+  await expect(answeredLinks.first()).toBeVisible();
+
+  // Status trigger advertises its current value to assistive tech without
+  // requiring the menu to be opened.
+  const statusTrigger = page.getByRole("button", {
+    name: /Filter by question status, currently All/i,
+  });
+  await expect(statusTrigger).toBeVisible();
+
+  // Pick "Answered" via the dropdown — URL syncs and the open question drops out.
+  await pickFilter(page, /Filter by question status/i, "Answered");
+  await expect(page).toHaveURL(/[?&]status=answered(&|$)/);
+  await expect(answeredLinks.first()).toBeVisible();
+  await expect(openLinks).toHaveCount(0);
+
+  // The active-filters chip reflects the selection and the trigger now
+  // announces "Answered" as the current value.
+  const filtersRegion = page.getByRole("region", { name: "Active filters" });
+  await expect(filtersRegion.getByText("Status: Answered")).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: /Filter by question status, currently Answered/i,
+    }),
+  ).toBeVisible();
+
+  // Sort dropdown writes sort=newest to the URL.
+  await pickFilter(page, /Sort results/i, "Newest");
+  await expect(page).toHaveURL(/[?&]sort=newest(&|$)/);
+  await expect(filtersRegion.getByText("Sort: Newest")).toBeVisible();
+
+  // Date dropdown writes range=year to the URL.
+  await pickFilter(page, /Filter by date range/i, "Past year");
+  await expect(page).toHaveURL(/[?&]range=year(&|$)/);
+  await expect(filtersRegion.getByText("Date: Past year")).toBeVisible();
+
+  // Clearing a chip removes it from the URL and brings the matching content back
+  // when relevant. Clear status → both questions are visible again.
+  await filtersRegion.getByRole("link", { name: /Clear Status: Answered/i }).click();
+  await expect(page).not.toHaveURL(/[?&]status=answered(&|$)/);
+  await expect(openLinks.first()).toBeVisible();
+  await expect(answeredLinks.first()).toBeVisible();
+
+  // "Clear all" wipes the remaining filters and the chips region disappears.
+  await filtersRegion.getByRole("link", { name: "Clear all" }).click();
+  await expect(page).toHaveURL(/^[^?]*\/search\?q=/);
+  await expect(page.getByRole("region", { name: "Active filters" })).toHaveCount(0);
+});

--- a/src/app/search/labels.ts
+++ b/src/app/search/labels.ts
@@ -1,0 +1,19 @@
+import type { SearchRange, SearchSort, SearchStatus } from "@/lib/search";
+
+export const STATUS_LABEL: Record<SearchStatus, string> = {
+  all: "All",
+  answered: "Answered",
+  unanswered: "Unanswered",
+};
+
+export const RANGE_LABEL: Record<SearchRange, string> = {
+  all: "Any time",
+  week: "Past week",
+  month: "Past month",
+  year: "Past year",
+};
+
+export const SORT_LABEL: Record<SearchSort, string> = {
+  relevance: "Relevance",
+  newest: "Newest",
+};

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -15,6 +15,7 @@ import {
 import { getUserSummaryById } from "@/lib/users";
 import { searchQuerySchema } from "@/lib/validation/search";
 
+import { RANGE_LABEL, SORT_LABEL, STATUS_LABEL } from "./labels";
 import { applyGroupSlugDefault } from "./normalize";
 import { SearchControls, type AuthorOption, type MyGroup } from "./search-controls";
 
@@ -133,24 +134,6 @@ function HitCard({
   );
 }
 
-const STATUS_LABEL: Record<SearchStatus, string> = {
-  all: "All",
-  answered: "Answered",
-  unanswered: "Unanswered",
-};
-
-const RANGE_LABEL: Record<SearchRange, string> = {
-  all: "Any time",
-  week: "Past week",
-  month: "Past month",
-  year: "Past year",
-};
-
-const SORT_LABEL: Record<SearchSort, string> = {
-  relevance: "Relevance",
-  newest: "Newest",
-};
-
 function ActiveFilters({
   state,
   authorLabelText,
@@ -173,18 +156,18 @@ function ActiveFilters({
       clearUrl: buildSearchUrl(state, { range: "all", page: 1 }),
     });
   }
-  if (state.authorId && authorLabelText) {
-    chips.push({
-      key: "author",
-      label: `Author: ${authorLabelText}`,
-      clearUrl: buildSearchUrl(state, { authorId: undefined, page: 1 }),
-    });
-  }
   if (state.sort !== "relevance") {
     chips.push({
       key: "sort",
       label: `Sort: ${SORT_LABEL[state.sort]}`,
       clearUrl: buildSearchUrl(state, { sort: "relevance", page: 1 }),
+    });
+  }
+  if (state.authorId && authorLabelText) {
+    chips.push({
+      key: "author",
+      label: `Author: ${authorLabelText}`,
+      clearUrl: buildSearchUrl(state, { authorId: undefined, page: 1 }),
     });
   }
 

--- a/src/app/search/search-controls.dom.test.tsx
+++ b/src/app/search/search-controls.dom.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -70,15 +70,20 @@ describe("SearchControls", () => {
     expect(lastUrl).toMatch(/[?&]scope=all(&|$)/);
   });
 
-  it("emits a status filter when a status toggle is pressed", async () => {
+  it("emits a status filter when a status option is picked from the dropdown", async () => {
     const user = userEvent.setup();
     render(<SearchControls {...baseProps} />);
 
-    const statusGroup = screen.getByRole("group", {
-      name: "Filter by question status",
+    const trigger = screen.getByRole("button", {
+      name: /Filter by question status/i,
     });
+    // Accessible name must include the current value so screen readers can
+    // announce it without opening the menu.
+    expect(trigger).toHaveAccessibleName(/currently All/i);
+
+    await user.click(trigger);
     await user.click(
-      within(statusGroup).getByRole("button", { name: "Answered" }),
+      await screen.findByRole("menuitemradio", { name: "Answered" }),
     );
 
     await waitFor(() => {
@@ -86,6 +91,31 @@ describe("SearchControls", () => {
     });
     const lastUrl = replace.mock.calls.at(-1)?.[0] as string;
     expect(lastUrl).toMatch(/[?&]status=answered(&|$)/);
+  });
+
+  it("emits range and sort filters when their dropdowns are used", async () => {
+    const user = userEvent.setup();
+    render(<SearchControls {...baseProps} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Filter by date range/i }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "Past week" }),
+    );
+    await waitFor(() => {
+      const last = replace.mock.calls.at(-1)?.[0] as string | undefined;
+      expect(last).toMatch(/[?&]range=week(&|$)/);
+    });
+
+    await user.click(screen.getByRole("button", { name: /Sort results/i }));
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "Newest" }),
+    );
+    await waitFor(() => {
+      const last = replace.mock.calls.at(-1)?.[0] as string | undefined;
+      expect(last).toMatch(/[?&]sort=newest(&|$)/);
+    });
   });
 
   it("debounces the author typeahead and queries the search API", async () => {

--- a/src/app/search/search-controls.tsx
+++ b/src/app/search/search-controls.tsx
@@ -1,11 +1,21 @@
 "use client";
 
+import { ChevronDownIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import type { SearchRange, SearchSort, SearchStatus } from "@/lib/search";
+
+import { RANGE_LABEL, SORT_LABEL, STATUS_LABEL } from "./labels";
 
 const DEBOUNCE_MS = 250;
 const AUTHOR_DEBOUNCE_MS = 200;
@@ -68,7 +78,16 @@ export function SearchControls({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
-  const myGroupIds = useMemo(() => myGroups.map((g) => g.id), [myGroups]);
+  // Value-stable key so reference churn of `myGroups` from RSC re-renders
+  // doesn't refire the URL-sync effect on every server response.
+  const myGroupIdsKey = useMemo(
+    () => myGroups.map((g) => g.id).join(","),
+    [myGroups],
+  );
+  const myGroupIds = useMemo(
+    () => (myGroupIdsKey ? myGroupIdsKey.split(",") : []),
+    [myGroupIdsKey],
+  );
 
   const [q, setQ] = useState(initialQ);
   const [surfaceScope, setSurfaceScope] = useState<ScopeOption>(() =>
@@ -243,54 +262,41 @@ export function SearchControls({
       ) : null}
 
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs font-medium text-muted-foreground">Status</span>
-        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by question status">
-          <ToggleButton pressed={status === "all"} onClick={() => setStatus("all")}>
-            All
-          </ToggleButton>
-          <ToggleButton pressed={status === "answered"} onClick={() => setStatus("answered")}>
-            Answered
-          </ToggleButton>
-          <ToggleButton pressed={status === "unanswered"} onClick={() => setStatus("unanswered")}>
-            Unanswered
-          </ToggleButton>
-        </div>
+        <FilterDropdown
+          label="Status"
+          ariaLabel="Filter by question status"
+          value={status}
+          onValueChange={(v) => setStatus(v as SearchStatus)}
+          options={[
+            { value: "all", label: STATUS_LABEL.all },
+            { value: "answered", label: STATUS_LABEL.answered },
+            { value: "unanswered", label: STATUS_LABEL.unanswered },
+          ]}
+        />
+        <FilterDropdown
+          label="Date"
+          ariaLabel="Filter by date range"
+          value={range}
+          onValueChange={(v) => setRange(v as SearchRange)}
+          options={[
+            { value: "all", label: RANGE_LABEL.all },
+            { value: "week", label: RANGE_LABEL.week },
+            { value: "month", label: RANGE_LABEL.month },
+            { value: "year", label: RANGE_LABEL.year },
+          ]}
+        />
+        <FilterDropdown
+          label="Sort"
+          ariaLabel="Sort results"
+          value={sort}
+          onValueChange={(v) => setSort(v as SearchSort)}
+          options={[
+            { value: "relevance", label: SORT_LABEL.relevance },
+            { value: "newest", label: SORT_LABEL.newest },
+          ]}
+        />
+        <AuthorPicker author={author} onChange={setAuthor} />
       </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs font-medium text-muted-foreground">Date</span>
-        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by date range">
-          <ToggleButton pressed={range === "all"} onClick={() => setRange("all")}>
-            Any time
-          </ToggleButton>
-          <ToggleButton pressed={range === "week"} onClick={() => setRange("week")}>
-            Past week
-          </ToggleButton>
-          <ToggleButton pressed={range === "month"} onClick={() => setRange("month")}>
-            Past month
-          </ToggleButton>
-          <ToggleButton pressed={range === "year"} onClick={() => setRange("year")}>
-            Past year
-          </ToggleButton>
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs font-medium text-muted-foreground">Sort</span>
-        <div className="flex flex-wrap gap-1" role="group" aria-label="Sort results">
-          <ToggleButton pressed={sort === "relevance"} onClick={() => setSort("relevance")}>
-            Relevance
-          </ToggleButton>
-          <ToggleButton pressed={sort === "newest"} onClick={() => setSort("newest")}>
-            Newest
-          </ToggleButton>
-        </div>
-      </div>
-
-      <AuthorPicker
-        author={author}
-        onChange={setAuthor}
-      />
     </div>
   );
 }
@@ -414,6 +420,43 @@ function AuthorPicker({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function FilterDropdown({
+  label,
+  ariaLabel,
+  value,
+  onValueChange,
+  options,
+}: {
+  label: string;
+  ariaLabel: string;
+  value: string;
+  onValueChange: (next: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  const current = options.find((o) => o.value === value)?.label ?? options[0]?.label ?? "";
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={<Button variant="outline" size="sm" />}
+        aria-label={`${ariaLabel}, currently ${current}`}
+      >
+        <span className="text-muted-foreground">{label}:</span>
+        <span className="ml-1 font-medium">{current}</span>
+        <ChevronDownIcon className="ml-1 size-3.5 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
+          {options.map((o) => (
+            <DropdownMenuRadioItem key={o.value} value={o.value}>
+              {o.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -40,9 +40,14 @@ describe.skipIf(isPostgres)("toFtsMatchExpr", () => {
   it("strips FTS syntax characters and prefix-matches the trailing token", () => {
     expect(toFtsMatchExpr("rust")).toBe('"rust"*');
     expect(toFtsMatchExpr("how to rust")).toBe('"how" AND "to" AND "rust"*');
-    // Special chars are stripped per token.
     expect(toFtsMatchExpr('rust*())"')).toBe('"rust"*');
-    expect(toFtsMatchExpr("foo:bar baz-qux")).toBe('"foobar" AND "bazqux"*');
+    // Non-alphanumeric runs split a "word" into separate tokens rather than
+    // smushing the surrounding characters together, so queries like
+    // "net/http" find docs containing both words.
+    expect(toFtsMatchExpr("foo:bar baz-qux")).toBe(
+      '"foo" AND "bar" AND "baz" AND "qux"*',
+    );
+    expect(toFtsMatchExpr("net/http")).toBe('"net" AND "http"*');
   });
 });
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -74,8 +74,10 @@ function resolveOptions(opts: SearchOptions): ResolvedOptions {
 
 /**
  * Convert a free-form user query into a safe FTS5 MATCH expression.
- * - Lowercases, splits on whitespace.
- * - Strips characters FTS5 treats as syntax (`"`, `*`, `:`, parens, `-`, etc.).
+ * - Lowercases, splits on any run of non-letter/non-digit characters.
+ *   This treats `/`, `:`, `-`, `"`, `*`, parens etc. as separators rather than
+ *   smushing the surrounding text together (so `net/http` tokenizes as
+ *   `net` + `http`, not `nethttp`).
  * - Wraps each remaining token in double quotes and ANDs them together.
  * - Appends `*` to the final token for prefix matching.
  *
@@ -85,8 +87,7 @@ function resolveOptions(opts: SearchOptions): ResolvedOptions {
 export function toFtsMatchExpr(q: string): string | null {
   const tokens = q
     .toLowerCase()
-    .split(/\s+/)
-    .map((t) => t.replace(/[^\p{L}\p{N}]+/gu, ""))
+    .split(/[^\p{L}\p{N}]+/u)
     .filter((t) => t.length > 0);
   if (tokens.length === 0) return null;
   const quoted = tokens.map((t) => `"${t}"`);


### PR DESCRIPTION
## Summary

- The Status/Date/Sort toggle rows wrap onto multiple lines as filters proliferate. Swapping them for `DropdownMenuRadioGroup` triggers keeps the filter bar compact and aligns the UI with how filters are typically presented elsewhere in the app.
- Triggers expose their current value as part of the accessible name (`"Filter by date range, currently Past week"`) so screen readers announce state without opening the menu — the prior `aria-pressed` toggles had this; the dropdown swap would have regressed it.
- `toFtsMatchExpr` stripped non-alphanumerics per token, so queries like `net/http` collapsed to `nethttp` and matched nothing. It now splits on those runs so `net/http` searches as `net AND http`.
- `myGroupIds` was re-derived from a fresh `.map(...)` on every RSC re-render, refiring the URL-sync effect. A string-keyed memo keeps the array reference stable across renders that produce the same group set.

## Changes

- **UI**: New `FilterDropdown` component in `search-controls.tsx`; chip and dropdown ordering aligned to Status → Date → Sort → Author.
- **Shared**: `src/app/search/labels.ts` extracts `STATUS_LABEL` / `RANGE_LABEL` / `SORT_LABEL` so chips and dropdowns share one source of truth.
- **Search lib**: `toFtsMatchExpr` regex change + matching unit tests covering `net/http` and `foo:bar baz-qux`.
- **Tests**: dom test updated for the dropdown UI, added Date/Sort coverage and an `toHaveAccessibleName` assertion. New `e2e/search-filters.spec.ts` drives Status/Date/Sort selections, asserts URL and chip sync, and exercises single-chip and Clear-all flows.

## Test plan

- [x] \`npm run test\` — 553 passed
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:e2e -- search-filters.spec.ts\` — passed
- [ ] Manual: open \`/search?q=...\`, confirm dropdowns open, selection updates the URL, chips appear, and a screen reader announces the current value on focus.

## Notes

- Base UI's \`MenuRadioItem\` doesn't auto-close the menu on select, and its presentation backdrop intercepts pointer events on the next trigger; the e2e helper presses Escape and waits on \`aria-expanded="false"\` between selections.
- Postgres search path (\`runTsvector\`) is unchanged — the tokenizer fix is SQLite/FTS5 specific; Postgres feeds the raw query through \`plainto_tsquery\` and was never affected.