### PR TITLE
feat(groups): editable name and description on group settings

### DIFF
--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { GroupAvatar } from "@/components/ui/group-avatar";
+import { MaterialIcon } from "@/components/ui/material-icon";
 import { Pagination } from "@/components/ui/pagination";
 import { getSession } from "@/lib/auth";
 import { viewerFavoritesFor } from "@/lib/favorites";
@@ -56,9 +57,10 @@ export default async function GroupDetailPage({ params, searchParams }: Props) {
   const buildQuestionsHref = (p: number): string =>
     p > 1 ? `/groups/${group.slug}?page=${p}` : `/groups/${group.slug}`;
 
-  const isOwner = membership?.role === "owner" && membership.status === "approved";
   const isApproved = membership?.status === "approved";
   const isPending = membership?.status === "pending";
+  const canManageGroup =
+    isApproved && (membership?.role === "owner" || membership?.role === "moderator");
   const mutedTypes = isApproved ? sessionMutedTypes : [];
   const isArchived = group.archivedAt != null;
   const memberLabel = memberCount === 1 ? "1 member" : `${memberCount} members`;
@@ -117,13 +119,15 @@ export default async function GroupDetailPage({ params, searchParams }: Props) {
                 initialMutedTypes={mutedTypes}
                 initialFavorited={viewerFavoritedGroups.has(group.id)}
               />
-              {isOwner ? (
+              {canManageGroup ? (
                 <Button
-                  variant="outline"
-                  size="sm"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Group settings"
+                  title="Group settings"
                   render={<Link href={`/groups/${group.slug}/settings`} />}
                 >
-                  Settings
+                  <MaterialIcon name="settings" />
                 </Button>
               ) : null}
             </div>

--- a/src/app/groups/[slug]/settings/actions.test.ts
+++ b/src/app/groups/[slug]/settings/actions.test.ts
@@ -1,0 +1,151 @@
+import type { User } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDb } from "@test/db";
+import { clearSession, cookieStore, setSessionUser } from "@test/auth-mock";
+import { makeGroup, makeUser } from "@test/factories";
+
+async function signInAs(u: User): Promise<void> {
+  // Factory-created users always have an email; assert for the type system.
+  await setSessionUser({ id: u.id, email: u.email!, name: u.name });
+}
+
+vi.mock("next/headers", async () => (await import("@test/auth-mock")).nextHeadersMock());
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+setupTestDb("settings-actions");
+
+const { db } = await import("@/lib/db");
+const { CSRF_COOKIE, CSRF_FIELD } = await import("@/lib/csrf");
+const { updateGroupDetailsAction } = await import("./actions");
+
+const VALID_TOKEN = "a".repeat(64);
+
+function makeFormData(fields: Record<string, string>, withCsrf = true): FormData {
+  const fd = new FormData();
+  if (withCsrf) fd.set(CSRF_FIELD, VALID_TOKEN);
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+function setCsrfCookie(value = VALID_TOKEN): void {
+  cookieStore.set(CSRF_COOKIE, { name: CSRF_COOKIE, value });
+}
+
+beforeEach(() => {
+  clearSession();
+});
+
+describe("updateGroupDetailsAction", () => {
+  it("returns CSRF error when token is missing", async () => {
+    const { owner, group } = await makeGroup(db);
+    await signInAs(owner);
+    // No CSRF cookie set, no field either.
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "New name", description: "" }, false),
+    );
+    expect(result.error).toMatch(/csrf/i);
+  });
+
+  it("returns sign-in error when unauthenticated", async () => {
+    const { group } = await makeGroup(db);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "New name", description: "" }),
+    );
+    expect(result.error).toMatch(/signed in/i);
+  });
+
+  it("returns field errors when name is too short", async () => {
+    const { owner, group } = await makeGroup(db);
+    await signInAs(owner);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "x", description: "" }),
+    );
+    expect(result.fieldErrors?.[0]?.path).toBe("name");
+    expect(result.values?.name).toBe("x");
+  });
+
+  it("rejects a whitespace-only name (trimmed to empty)", async () => {
+    const { owner, group } = await makeGroup(db);
+    await signInAs(owner);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "   ", description: "" }),
+    );
+    expect(result.fieldErrors?.[0]?.path).toBe("name");
+    const fresh = await db.group.findUnique({ where: { id: group.id } });
+    expect(fresh?.name).toBe(group.name);
+  });
+
+  it("forbids non-owner moderator from editing details", async () => {
+    const { group } = await makeGroup(db);
+    const mod = await makeUser(db);
+    await db.membership.create({
+      data: { groupId: group.id, userId: mod.id, role: "moderator", status: "approved" },
+    });
+    await signInAs(mod);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "Hijack", description: "" }),
+    );
+    expect(result.error).toMatch(/owner/i);
+    const fresh = await db.group.findUnique({ where: { id: group.id } });
+    expect(fresh?.name).toBe(group.name);
+  });
+
+  it("returns conflict when group is archived", async () => {
+    const { owner, group } = await makeGroup(db);
+    await db.group.update({
+      where: { id: group.id },
+      data: { archivedAt: new Date() },
+    });
+    await signInAs(owner);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: "Renamed", description: "" }),
+    );
+    expect(result.error).toMatch(/archived/i);
+  });
+
+  it("updates name and description on the happy path", async () => {
+    const { owner, group } = await makeGroup(db, { name: "Old name" });
+    await signInAs(owner);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({
+        slug: group.slug,
+        name: "New name",
+        description: "Now with a description.",
+      }),
+    );
+    expect(result.ok).toBe(true);
+    const fresh = await db.group.findUnique({ where: { id: group.id } });
+    expect(fresh?.name).toBe("New name");
+    expect(fresh?.description).toBe("Now with a description.");
+  });
+
+  it("clears description when submitted empty", async () => {
+    const { owner, group } = await makeGroup(db);
+    await db.group.update({
+      where: { id: group.id },
+      data: { description: "Existing." },
+    });
+    await signInAs(owner);
+    setCsrfCookie();
+    const result = await updateGroupDetailsAction(
+      {},
+      makeFormData({ slug: group.slug, name: group.name, description: "" }),
+    );
+    expect(result.ok).toBe(true);
+    const fresh = await db.group.findUnique({ where: { id: group.id } });
+    expect(fresh?.description).toBeNull();
+  });
+});

--- a/src/app/groups/[slug]/settings/actions.ts
+++ b/src/app/groups/[slug]/settings/actions.ts
@@ -5,11 +5,81 @@ import { getSession } from "@/lib/auth";
 import { assertCsrf, assertCsrfToken, CsrfError } from "@/lib/csrf-server";
 import { archiveGroup, unarchiveGroup, updateGroup } from "@/lib/groups";
 import { AuthorizationError, ConflictError, NotFoundError } from "@/lib/memberships";
+import { updateGroupSchema } from "@/lib/validation/groups";
 
 export type ToggleAutoApproveState = {
   error?: string;
   autoApprove?: boolean;
 };
+
+export type FieldError = { path: string; message: string };
+
+export type UpdateGroupDetailsState = {
+  error?: string;
+  fieldErrors?: FieldError[];
+  values?: { name?: string; description?: string };
+  ok?: true;
+};
+
+export async function updateGroupDetailsAction(
+  _prev: UpdateGroupDetailsState,
+  formData: FormData,
+): Promise<UpdateGroupDetailsState> {
+  try {
+    await assertCsrf(formData);
+  } catch (err) {
+    if (err instanceof CsrfError) return { error: err.message };
+    throw err;
+  }
+  const session = await getSession();
+  if (!session) return { error: "You must be signed in." };
+
+  const slug = String(formData.get("slug") ?? "");
+  const raw = {
+    name: String(formData.get("name") ?? ""),
+    description: String(formData.get("description") ?? ""),
+  };
+
+  const parsed = updateGroupSchema.safeParse({
+    name: raw.name,
+    description: raw.description.length > 0 ? raw.description : null,
+  });
+
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+      values: raw,
+    };
+  }
+
+  try {
+    await updateGroup(slug, parsed.data, session.user.id);
+    revalidatePath("/");
+    revalidatePath("/groups");
+    revalidatePath(`/groups/${slug}`);
+    revalidatePath(`/groups/${slug}/settings`);
+    revalidatePath("/me/groups");
+    revalidatePath("/me/favorites/groups");
+    return { ok: true, values: raw };
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      return { error: "Only the owner can change settings.", values: raw };
+    }
+    if (err instanceof NotFoundError) {
+      return { error: "Group not found.", values: raw };
+    }
+    if (err instanceof ConflictError) {
+      return { error: err.message, values: raw };
+    }
+    return {
+      error: err instanceof Error ? err.message : "Could not update settings.",
+      values: raw,
+    };
+  }
+}
 
 export async function toggleAutoApproveAction(
   _prev: ToggleAutoApproveState,

--- a/src/app/groups/[slug]/settings/group-details-form.dom.test.tsx
+++ b/src/app/groups/[slug]/settings/group-details-form.dom.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GroupDetailsForm } from "./group-details-form";
+import { updateGroupDetailsAction } from "./actions";
+
+vi.mock("./actions", () => ({
+  updateGroupDetailsAction: vi.fn(),
+}));
+
+vi.mock("@/components/csrf-field", () => ({
+  CsrfField: () => <input type="hidden" name="_csrf" value="test-token" />,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockedAction = vi.mocked(updateGroupDetailsAction);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GroupDetailsForm", () => {
+  it("renders inputs prefilled with the current values", () => {
+    render(
+      <GroupDetailsForm
+        slug="my-group"
+        initialName="My group"
+        initialDescription="An existing description."
+      />,
+    );
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue("My group");
+    expect(screen.getByLabelText(/description/i)).toHaveValue(
+      "An existing description.",
+    );
+  });
+
+  it("renders an empty description textarea when none is set", () => {
+    render(
+      <GroupDetailsForm slug="my-group" initialName="My group" initialDescription={null} />,
+    );
+    expect(screen.getByLabelText(/description/i)).toHaveValue("");
+  });
+
+  it("submits the form data to the server action", async () => {
+    mockedAction.mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+    render(
+      <GroupDetailsForm slug="my-group" initialName="Old" initialDescription={null} />,
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "New name");
+    await user.type(screen.getByLabelText(/description/i), "Fresh description");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(mockedAction).toHaveBeenCalledTimes(1));
+    const fd = mockedAction.mock.calls[0]?.[1] as FormData;
+    expect(fd.get("slug")).toBe("my-group");
+    expect(fd.get("name")).toBe("New name");
+    expect(fd.get("description")).toBe("Fresh description");
+    expect(fd.get("_csrf")).toBe("test-token");
+  });
+
+  it("renders field errors returned by the action", async () => {
+    mockedAction.mockResolvedValue({
+      fieldErrors: [{ path: "name", message: "Name must be at least 2 characters." }],
+      values: { name: "x", description: "" },
+    });
+    const user = userEvent.setup();
+    render(
+      <GroupDetailsForm slug="my-group" initialName="Valid" initialDescription={null} />,
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "x");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    const alerts = await screen.findAllByRole("alert");
+    expect(alerts.some((el) => /at least 2 characters/i.test(el.textContent ?? ""))).toBe(
+      true,
+    );
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("renders a top-level error returned by the action", async () => {
+    mockedAction.mockResolvedValue({
+      error: "Only the owner can change settings.",
+      values: { name: "Hijack", description: "" },
+    });
+    const user = userEvent.setup();
+    render(
+      <GroupDetailsForm slug="my-group" initialName="Valid" initialDescription={null} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    const alerts = await screen.findAllByRole("alert");
+    expect(alerts.some((el) => /only the owner/i.test(el.textContent ?? ""))).toBe(true);
+  });
+});

--- a/src/app/groups/[slug]/settings/group-details-form.tsx
+++ b/src/app/groups/[slug]/settings/group-details-form.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { CsrfField } from "@/components/csrf-field";
+import { useFocusFirstError, useUnsavedChangesWarning } from "@/lib/forms";
+import { updateGroupDetailsAction, type UpdateGroupDetailsState } from "./actions";
+
+const initialState: UpdateGroupDetailsState = {};
+
+type Props = {
+  slug: string;
+  initialName: string;
+  initialDescription: string | null;
+};
+
+function fieldError(state: UpdateGroupDetailsState, path: string): string | undefined {
+  return state.fieldErrors?.find((e) => e.path === path)?.message;
+}
+
+export function GroupDetailsForm({ slug, initialName, initialDescription }: Props) {
+  const [state, formAction, isPending] = useActionState(
+    updateGroupDetailsAction,
+    initialState,
+  );
+  const [name, setName] = useState(state.values?.name ?? initialName);
+  const [description, setDescription] = useState(
+    state.values?.description ?? initialDescription ?? "",
+  );
+  const [isDirty, setIsDirty] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useFocusFirstError(formRef, state.fieldErrors);
+  useUnsavedChangesWarning(isDirty && !isPending);
+
+  useEffect(() => {
+    if (state.ok) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsDirty(false);
+      toast.success("Group details updated.");
+    }
+  }, [state.ok]);
+
+  const nameError = fieldError(state, "name");
+  const descriptionError = fieldError(state, "description");
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      onChange={() => setIsDirty(true)}
+      className="space-y-4"
+    >
+      <CsrfField />
+      <input type="hidden" name="slug" value={slug} />
+
+      <div className="space-y-1">
+        <label htmlFor="name" className="block text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          minLength={2}
+          maxLength={80}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-invalid={Boolean(nameError)}
+          className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+        />
+        {nameError ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {nameError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="description" className="block text-sm font-medium">
+          Description <span className="text-zinc-500">(optional)</span>
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          rows={3}
+          maxLength={2000}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          aria-invalid={Boolean(descriptionError)}
+          className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:ring-zinc-100"
+        />
+        {descriptionError ? (
+          <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+            {descriptionError}
+          </p>
+        ) : null}
+      </div>
+
+      {state.error ? (
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+          {state.error}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded bg-zinc-900 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {isPending ? "Saving…" : "Save changes"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/groups/[slug]/settings/page.tsx
+++ b/src/app/groups/[slug]/settings/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/memberships";
 import { ArchiveControls } from "./archive-controls";
 import { AutoApproveToggle } from "./auto-approve-toggle";
+import { GroupDetailsForm } from "./group-details-form";
 import { MembersList, type MembersListItem } from "./members-list";
 import { PendingApplicationsList, type PendingApplicationView } from "./pending-applications-list";
 
@@ -68,6 +69,47 @@ export default async function GroupSettingsPage({ params }: Props) {
           Back to group
         </Button>
       </div>
+
+      {viewerIsOwner ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Group details</CardTitle>
+            <CardDescription>
+              {isArchived
+                ? "Archived groups are read-only. Restore the group to edit its details."
+                : "Update the group name and description. The slug is permanent."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isArchived ? (
+              <dl className="space-y-2 text-sm">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Name
+                  </dt>
+                  <dd>{group.name}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Description
+                  </dt>
+                  <dd className="whitespace-pre-line">
+                    {group.description ?? (
+                      <span className="text-muted-foreground">No description.</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <GroupDetailsForm
+                slug={group.slug}
+                initialName={group.name}
+                initialDescription={group.description}
+              />
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
 
       {viewerIsOwner ? (
         <Card>


### PR DESCRIPTION
## Summary
- Owners can now rename a group and edit its description from the settings page instead of needing DB access.
- Settings entry point on the group page opens to moderators+owners (route already gated to both; only the gear was owner-only), so moderators can reach the Members card without the route 404ing on them.

## Changes
- **UI**: new `GroupDetailsForm` (client) with prefilled values, inline field errors, `aria-invalid`, focus-first-error, unsaved-changes warning, and an archived read-only view rendered in a `<dl>` with `whitespace-pre-line`. Group page swaps the text Settings button for an icon-only gear (`aria-label`/`title="Group settings"`) gated by a new `canManageGroup` (owner OR moderator, status approved).
- **Server action**: `updateGroupDetailsAction` validates with `updateGroupSchema`, delegates auth to `updateGroup`/`assertOwner` (owner-only enforced server-side even though moderators see the route), maps `AuthorizationError`/`NotFoundError`/`ConflictError` to user-readable errors, and revalidates `/`, `/groups`, `/groups/[slug]`, `/groups/[slug]/settings`, `/me/groups`, `/me/favorites/groups` so cached lists/cards refresh.
- **Tests**: node-project action tests (CSRF, unauth, validation incl. whitespace-only name, moderator forbidden with DB read-back, archived conflict, happy path, empty description clears to null) and dom-project form tests (prefill, submit payload, field error rendering, top-level error rendering).

## Test plan
- [x] \`npm run test -- src/app/groups/[slug]/settings/actions.test.ts src/app/groups/[slug]/settings/group-details-form.dom.test.tsx\` — 13/13 pass
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [ ] Manual: open \`/groups/<slug>/settings\` as owner, edit name + description, confirm toast, refresh, confirm home/cards/favorites reflect the change. Not exercised in this branch.
- [ ] Manual: as a moderator, confirm the gear appears on the group page and the settings route renders Members (no Group details card). Not exercised in this branch.

## Notes
- Description field accepts up to 2000 chars; whitespace is trimmed by \`groupNameSchema\`/\`groupDescriptionSchema\` (Zod \`.trim()\`).
- Archived groups render a read-only view rather than a disabled form — restore the group to edit.