### PR TITLE
refactor(groups): remove slug id from group cards

### DIFF
--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -27,8 +27,6 @@ export function GroupCard({ group }: { group: GroupListItem }) {
                 ) : null}
               </div>
               <CardDescription>
-                <span className="font-mono text-xs">{group.slug}</span>
-                {" · "}
                 <span>
                   {group.memberCount} {memberLabel}
                 </span>


### PR DESCRIPTION
## Summary
- The slug was visible noise in the card description line — it's an internal URL identifier, not something members reference in conversation.
- The slug remains the link target (`/groups/<slug>`), so navigation is unchanged.

## Test plan
- [ ] Visit `/groups` and confirm cards now show only "N members · M new in 24h" — no monospace slug.
- [ ] Click a card and confirm it still routes to `/groups/<slug>`.
- [ ] Not run locally: `npm run test` (no component test covers `GroupCard`).