### PR TITLE
refactor(groups): hide slug from group, settings, and profile pages

### DIFF
--- a/src/app/groups/[slug]/page.tsx
+++ b/src/app/groups/[slug]/page.tsx
@@ -81,8 +81,6 @@ export default async function GroupDetailPage({ params, searchParams }: Props) {
                   ) : null}
                 </CardTitle>
                 <CardDescription>
-                  <span className="font-mono text-xs">{group.slug}</span>
-                  {" · "}
                   <span>{memberLabel}</span>
                   {" · "}
                   <span>

--- a/src/app/groups/[slug]/settings/page.tsx
+++ b/src/app/groups/[slug]/settings/page.tsx
@@ -53,8 +53,6 @@ export default async function GroupSettingsPage({ params }: Props) {
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
           <p className="text-sm text-muted-foreground">
-            <span className="font-mono text-xs">{group.slug}</span>
-            {" · "}
             {group.name}
             {isArchived ? (
               <span className="ml-2 rounded-md border border-border px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/src/app/me/notification-settings/page.tsx
+++ b/src/app/me/notification-settings/page.tsx
@@ -42,7 +42,6 @@ export default async function NotificationSettingsPage() {
                     <Link href={`/groups/${g.slug}`} className="font-medium hover:underline">
                       {g.name}
                     </Link>
-                    <span className="font-mono text-xs text-muted-foreground">{g.slug}</span>
                   </div>
                   <NotificationPreferencesControl
                     groupId={g.id}

--- a/src/components/profile/profile-group-list.tsx
+++ b/src/components/profile/profile-group-list.tsx
@@ -26,7 +26,6 @@ export function ProfileGroupList({ items, viewer, emptyState, mutedTypesByGroupI
               <Link href={`/groups/${g.slug}`} className="font-medium hover:underline">
                 {g.name}
               </Link>
-              <span className="font-mono text-xs text-muted-foreground">{g.slug}</span>
               {g.role !== "member" ? (
                 <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   {g.role}


### PR DESCRIPTION
## Summary
- Slugs are routing identifiers, not user-facing content — surfacing them as monospace meta text added noise without informing users.
- Continues the cleanup started in #93, which removed the slug from the groups index card.

## Changes
- **UI**: removed the `<span className="font-mono text-xs">{slug}</span>` render (and adjacent `·` separators) from:
  - `src/app/groups/[slug]/page.tsx` — group detail header
  - `src/app/groups/[slug]/settings/page.tsx` — settings header
  - `src/components/profile/profile-group-list.tsx` — profile groups list
  - `src/app/me/notification-settings/page.tsx` — notification-settings groups list
- Slug is still used everywhere it's needed for routing (`<Link href="/groups/${slug}">`, server actions, etc.).

## Test plan
- [x] `npm run test` — 569 tests pass across 54 files
- [ ] Manual: visit `/groups/<slug>`, `/groups/<slug>/settings`, `/me/notification-settings`, and a public profile with group memberships — verify no slug text appears in headers/lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)