### PR TITLE
feat(votes): allow non-members to vote on questions and answers

### DIFF
--- a/src/app/api/votes/route.test.ts
+++ b/src/app/api/votes/route.test.ts
@@ -141,14 +141,17 @@ describe("POST /api/votes", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when caller is not an approved member", async () => {
+  it("returns 200 when caller is a signed-in non-member", async () => {
     const { question } = await setupGroupWithQuestion();
     cookieStore.clear();
     await auth.signIn(`${uniq("stranger")}@example.com`);
     const res = await POST(
       jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.voted).toBe(true);
+    expect(json.voteScore).toBe(1);
   });
 
   it("returns 200 with voted=true for an approved member voting on a question", async () => {

--- a/src/app/q/[id]/page.tsx
+++ b/src/app/q/[id]/page.tsx
@@ -81,13 +81,8 @@ export default async function QuestionDetailPage({ params }: Props) {
   const canDeleteQuestion = currentUserId !== null && (isAuthor || isModOrOwner);
   const isEdited = question.updatedAt.getTime() > question.createdAt.getTime();
 
-  const voteDisabledReason = !currentUserId
-    ? "Sign in to vote."
-    : !isApprovedViewer
-      ? "You must be an approved member of this group to vote."
-      : undefined;
-  const questionVoteDisabled =
-    !currentUserId || !isApprovedViewer || question.author.id === currentUserId;
+  const voteDisabledReason = !currentUserId ? "Sign in to vote." : undefined;
+  const questionVoteDisabled = !currentUserId || question.author.id === currentUserId;
   const questionVoteDisabledReason =
     currentUserId && question.author.id === currentUserId
       ? "You cannot vote on your own question."
@@ -165,7 +160,7 @@ export default async function QuestionDetailPage({ params }: Props) {
             {question.answers.map((a) => {
               const isOwnAnswer = currentUserId !== null && a.author.id === currentUserId;
               const canEdit = isOwnAnswer;
-              const answerVoteDisabled = !currentUserId || !isApprovedViewer || isOwnAnswer;
+              const answerVoteDisabled = !currentUserId || isOwnAnswer;
               const answerVoteDisabledReason = isOwnAnswer
                 ? "You cannot vote on your own answer."
                 : voteDisabledReason;

--- a/src/lib/votes.test.ts
+++ b/src/lib/votes.test.ts
@@ -123,10 +123,7 @@ describe("castVote on questions", () => {
     const { question } = await setupGroupWithQuestion();
     const stranger = await makeUser("stranger");
 
-    const result = await castVote(
-      { targetType: "question", targetId: question.id },
-      stranger.id,
-    );
+    const result = await castVote({ targetType: "question", targetId: question.id }, stranger.id);
 
     expect(result.voted).toBe(true);
     expect(result.voteScore).toBe(1);
@@ -148,10 +145,7 @@ describe("castVote on questions", () => {
     const pending = await makeUser("pending");
     await applyToGroup(group.id, pending.id);
 
-    const result = await castVote(
-      { targetType: "question", targetId: question.id },
-      pending.id,
-    );
+    const result = await castVote({ targetType: "question", targetId: question.id }, pending.id);
 
     expect(result.voted).toBe(true);
     expect(result.voteScore).toBe(1);
@@ -165,10 +159,7 @@ describe("castVote on questions", () => {
     });
     const voter = await makeUser("archived-voter");
 
-    const result = await castVote(
-      { targetType: "question", targetId: question.id },
-      voter.id,
-    );
+    const result = await castVote({ targetType: "question", targetId: question.id }, voter.id);
 
     expect(result.voted).toBe(true);
     expect(result.voteScore).toBe(1);

--- a/src/lib/votes.test.ts
+++ b/src/lib/votes.test.ts
@@ -119,21 +119,59 @@ describe("castVote on questions", () => {
     ).rejects.toBeInstanceOf(AuthorizationError);
   });
 
-  it("rejects votes from non-members", async () => {
+  it("allows a signed-in non-member to vote", async () => {
     const { question } = await setupGroupWithQuestion();
     const stranger = await makeUser("stranger");
-    await expect(
-      castVote({ targetType: "question", targetId: question.id }, stranger.id),
-    ).rejects.toBeInstanceOf(AuthorizationError);
+
+    const result = await castVote(
+      { targetType: "question", targetId: question.id },
+      stranger.id,
+    );
+
+    expect(result.voted).toBe(true);
+    expect(result.voteScore).toBe(1);
+
+    const stored = await db.vote.findUnique({
+      where: {
+        userId_targetType_targetId: {
+          userId: stranger.id,
+          targetType: "question",
+          targetId: question.id,
+        },
+      },
+    });
+    expect(stored).not.toBeNull();
   });
 
-  it("rejects votes from pending applicants", async () => {
+  it("allows a pending applicant to vote", async () => {
     const { group, question } = await setupGroupWithQuestion(false);
     const pending = await makeUser("pending");
     await applyToGroup(group.id, pending.id);
-    await expect(
-      castVote({ targetType: "question", targetId: question.id }, pending.id),
-    ).rejects.toBeInstanceOf(AuthorizationError);
+
+    const result = await castVote(
+      { targetType: "question", targetId: question.id },
+      pending.id,
+    );
+
+    expect(result.voted).toBe(true);
+    expect(result.voteScore).toBe(1);
+  });
+
+  it("allows voting on a question in an archived group", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    await db.group.update({
+      where: { id: group.id },
+      data: { archivedAt: new Date() },
+    });
+    const voter = await makeUser("archived-voter");
+
+    const result = await castVote(
+      { targetType: "question", targetId: question.id },
+      voter.id,
+    );
+
+    expect(result.voted).toBe(true);
+    expect(result.voteScore).toBe(1);
   });
 
   it("throws NotFoundError for unknown question id", async () => {

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -1,8 +1,7 @@
 import "server-only";
 import { Prisma, type TargetType } from "@prisma/client";
 import { db } from "@/lib/db";
-import { assertGroupNotArchived } from "@/lib/groups";
-import { AuthorizationError, NotFoundError, assertApprovedMember } from "@/lib/memberships";
+import { AuthorizationError, NotFoundError } from "@/lib/memberships";
 
 export type VoteTargetType = TargetType;
 
@@ -46,36 +45,34 @@ export async function viewerVotesFor(
 async function resolveTarget(
   targetType: VoteTargetType,
   targetId: string,
-): Promise<{ groupId: string; authorId: string }> {
+): Promise<{ authorId: string }> {
   if (targetType === "question") {
     const q = await db.question.findUnique({
       where: { id: targetId },
-      select: { groupId: true, authorId: true, deletedAt: true },
+      select: { authorId: true, deletedAt: true },
     });
     if (!q || q.deletedAt) throw new NotFoundError("Question not found.");
-    return { groupId: q.groupId, authorId: q.authorId };
+    return { authorId: q.authorId };
   }
   const a = await db.answer.findUnique({
     where: { id: targetId },
     select: {
       authorId: true,
-      question: { select: { groupId: true, deletedAt: true } },
+      question: { select: { deletedAt: true } },
     },
   });
   if (!a || a.question.deletedAt) throw new NotFoundError("Answer not found.");
-  return { groupId: a.question.groupId, authorId: a.authorId };
+  return { authorId: a.authorId };
 }
 
 export async function castVote(
   input: { targetType: VoteTargetType; targetId: string },
   userId: string,
 ): Promise<CastVoteResult> {
-  const { groupId, authorId } = await resolveTarget(input.targetType, input.targetId);
+  const { authorId } = await resolveTarget(input.targetType, input.targetId);
   if (authorId === userId) {
     throw new AuthorizationError("You cannot vote on your own content.");
   }
-  await assertApprovedMember(groupId, userId);
-  await assertGroupNotArchived(groupId);
 
   const existing = await db.vote.findUnique({
     where: {


### PR DESCRIPTION
## Summary
- Voting was previously gated to approved members of the question's group, which was too restrictive for a directory whose discovery and engagement loop benefits from outsiders being able to surface useful Q&A.
- Any signed-in user can now upvote questions and answers regardless of membership status, including in archived groups. Self-vote and sign-in requirements stay.
- The policy change lives in one chokepoint (`castVote`) so the server action and the JSON API route inherit it without further edits.

## Changes
- **lib**: `castVote()` no longer calls `assertApprovedMember` / `assertGroupNotArchived`; `resolveTarget()` trimmed to return only `authorId` (the `groupId` it previously selected is no longer consumed by any caller).
- **UI**: question detail page (`src/app/q/[id]/page.tsx`) no longer disables the vote button for non-approved viewers — only the unauthenticated and self-author cases stay disabled. `isApprovedViewer` is retained for unaffected gates (answer form, mod actions).
- **Tests**: replaced the two negative gating tests (non-member, pending applicant) with three positives (non-member, pending applicant, archived group) in `src/lib/votes.test.ts`. The 403-not-member case in the API route test is flipped to a 200 positive.

## Test plan
- [x] `npm run test -- --project node src/lib/votes.test.ts src/app/api/votes/route.test.ts` — 23/23 pass
- [x] `npm run test` (full suite, node + dom) — 570/570 pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual browser smoke (signed-in non-member voting on a question, archived-group voting, self-vote still blocked) — not exercised in this PR; reviewer welcome to verify against dev server

## Notes
Related: #95 tracks adding the same rate-limit guard to `/api/votes` that the server action already enforces. That asymmetry predates this change but the larger pool of legitimate callers makes it more worth fixing.