### PR TITLE
feat(votes): rate-limit /api/votes route for parity with server action

### DIFF
--- a/src/app/api/votes/route.test.ts
+++ b/src/app/api/votes/route.test.ts
@@ -33,10 +33,20 @@ vi.mock("next/navigation", () => ({
   },
 }));
 
+const { rateLimitMock } = vi.hoisted(() => ({ rateLimitMock: vi.fn() }));
+vi.mock("@/lib/rate-limit", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/rate-limit")>("@/lib/rate-limit");
+  return {
+    ...actual,
+    assertRateLimitForAction: rateLimitMock,
+  };
+});
+
 const auth = await import("@/lib/auth");
 const { db } = await import("@/lib/db");
 const { createGroup } = await import("@/lib/groups");
 const { applyToGroup } = await import("@/lib/memberships");
+const { RateLimitError } = await import("@/lib/rate-limit");
 const { POST } = await import("./route");
 
 beforeAll(async () => {
@@ -62,6 +72,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   cookieStore.clear();
+  rateLimitMock.mockReset();
 });
 
 function jsonReq(method: string, body?: unknown, raw?: string): Request {
@@ -195,6 +206,26 @@ describe("POST /api/votes", () => {
     expect(json.voted).toBe(true);
     expect(json.voteScore).toBe(1);
     expect(json.targetType).toBe("answer");
+  });
+
+  it("returns 429 with Retry-After header when rate-limited", async () => {
+    const { group, question } = await setupGroupWithQuestion();
+    cookieStore.clear();
+    await auth.signIn(`${uniq("rl")}@example.com`);
+    const sess = (await auth.getSession())!;
+    await applyToGroup(group.id, sess.user.id);
+
+    rateLimitMock.mockRejectedValueOnce(new RateLimitError(2500));
+
+    const res = await POST(
+      jsonReq("POST", { targetType: "question", targetId: question.id, value: 1 }),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("3");
+    const json = await res.json();
+    expect(json.error).toBe("RateLimited");
+    expect(json.message).toMatch(/Too many votes/);
+    expect(json.message).toMatch(/3 seconds/);
   });
 
   it("toggles off on second call and returns voted=false", async () => {

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -30,10 +30,7 @@ export async function POST(req: Request): Promise<Response> {
   } catch (err) {
     if (err instanceof RateLimitError) {
       const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
-      return rateLimited(
-        err.retryAfterMs,
-        `Too many votes. Try again in ${seconds} seconds.`,
-      );
+      return rateLimited(err.retryAfterMs, `Too many votes. Try again in ${seconds} seconds.`);
     }
     throw err;
   }

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,5 +1,6 @@
 import { getSession } from "@/lib/auth";
-import { errorToResponse, unauthorized, validationFailed } from "@/lib/api/errors";
+import { errorToResponse, rateLimited, unauthorized, validationFailed } from "@/lib/api/errors";
+import { RateLimitError, assertRateLimitForAction } from "@/lib/rate-limit";
 import { castVote } from "@/lib/votes";
 import { voteInputSchema } from "@/lib/validation/votes";
 
@@ -19,6 +20,23 @@ export async function POST(req: Request): Promise<Response> {
 
   const parsed = voteInputSchema.safeParse(raw);
   if (!parsed.success) return validationFailed(parsed.error);
+
+  // Mirror the server-action rate-limit (see `voteAction` in
+  // `src/app/q/[id]/vote-actions.ts`) so direct-API callers can't bypass the
+  // per-user budget if the proxy is ever skipped (internal callers, tests, or
+  // a future routing change). Entrypoints own rate-limiting — not `castVote`.
+  try {
+    await assertRateLimitForAction("votes");
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const seconds = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+      return rateLimited(
+        err.retryAfterMs,
+        `Too many votes. Try again in ${seconds} seconds.`,
+      );
+    }
+    throw err;
+  }
 
   try {
     const result = await castVote(

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -25,6 +25,28 @@ export function validationFailed(err: z.ZodError): Response {
   );
 }
 
+/**
+ * Canonical 429 response shape for rate-limited API routes.
+ *
+ * `retryAfterMs` is rounded up to the next whole second (floor of 1s) and
+ * surfaced in both the `Retry-After` header and — implicitly — in the
+ * caller-supplied `message`, which should mention the same delay.
+ *
+ * Keep this aligned with the proxy's 429 in `@/lib/rate-limit`; they share the
+ * same `{ error: "RateLimited", message }` body and `Retry-After` header so
+ * clients can branch on a single shape regardless of which layer rejected them.
+ */
+export function rateLimited(
+  retryAfterMs: number,
+  message = "Too many requests. Try again shortly.",
+): Response {
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  return Response.json(
+    { error: "RateLimited", message },
+    { status: 429, headers: { "Retry-After": String(seconds) } },
+  );
+}
+
 export function errorToResponse(err: unknown): Response {
   if (err instanceof SlugConflictError) {
     return Response.json(


### PR DESCRIPTION
## Summary

- `/api/votes` now calls `assertRateLimitForAction("votes")` so direct JSON POSTs hit the same per-user budget as the `voteAction` server action — closing a CSRF-valid bypass that widened after #96 opened voting to non-members.
- Extracts a shared `rateLimited(retryAfterMs, message?)` helper in `src/lib/api/errors.ts` so the route and the proxy emit the same canonical 429 shape (`{ error: "RateLimited", message }` + `Retry-After`).
- New unit test mocks `assertRateLimitForAction` with `vi.importActual` (so `RateLimitError` stays real) and asserts status, header, and message format.

## Why

The proxy already enforces rate-limit on mutating `/api/*` requests, but route-level parity matters because (a) the action and the route should share one contract — entrypoints own rate-limiting, not `castVote` — and (b) the proxy is bypassed in route unit tests and could be bypassed in future routing changes. A short comment in the route documents this so it doesn't get "simplified" away.

Closes #95.

## Test plan

- [x] `npm test -- --project node src/app/api/votes/route.test.ts` — 11/11 pass, including the new 429 case
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] CI green

## Notes for reviewer

- Server-action path (`voteAction`) is unchanged — still returns 200 with a friendly `error` string for the UI, as the issue requires.
- `castVote` chokepoint is untouched; the limit lives in the entrypoints.
- `src/app/api/groups/check-slug/route.ts` still has its own local bucket implementation. Migrating it to the shared helper would be a behavior change (would add `Retry-After`, drop its private bucket) and is out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)